### PR TITLE
trim and stop commands

### DIFF
--- a/inx/inkstitch_commands.inx
+++ b/inx/inkstitch_commands.inx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <_name>Attach Commands</_name>
+    <id>org.inkstitch.commands</id>
+    <dependency type="executable" location="extensions">inkstitch.py</dependency>
+    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <param name="fill_start" type="boolean" _gui-text="Fill starting position">false</param>
+    <param name="fill_end" type="boolean" _gui-text="Fill ending position">false</param>
+    <param name="stop" type="boolean" _gui-text="Stop after sewing this object">false</param>
+    <param name="trim" type="boolean" _gui-text="Trim thread after sewing this object">false</param>
+    <param name="extension" type="string" gui-hidden="true">commands</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu _name="Embroidery" />
+        </effects-menu>
+    </effect>
+    <script>
+        <command reldir="extensions" interpreter="python">inkstitch.py</command>
+    </script>
+</inkscape-extension>

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -77,9 +77,6 @@ def find_commands(node):
         try:
             commands.append(Command(connector))
         except ValueError:
-            import sys
-            import traceback
-            print >> sys.stderr, "not a Command:", connector.get('id'), traceback.format_exc()
             # Parsing the connector failed, meaning it's not actually an Ink/Stitch command.
             pass
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -242,22 +242,10 @@ class EmbroideryElement(object):
         return [self.strip_control_points(subpath) for subpath in path]
 
     @property
-    @param('trim_after',
-           _('TRIM after'),
-           tooltip=_('Trim thread after this object (for supported machines and file formats)'),
-           type='boolean',
-           default=False,
-           sort_index=1000)
     def trim_after(self):
         return self.get_boolean_param('trim_after', False)
 
     @property
-    @param('stop_after',
-           _('STOP after'),
-           tooltip=_('Add STOP instruction after this object (for supported machines and file formats)'),
-           type='boolean',
-           default=False,
-           sort_index=1000)
     def stop_after(self):
         return self.get_boolean_param('stop_after', False)
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -268,8 +268,8 @@ class EmbroideryElement(object):
         patches = self.to_patches(last_patch)
 
         if patches:
-            patches[-1].trim_after = self.trim_after
-            patches[-1].stop_after = self.stop_after
+            patches[-1].trim_after = self.has_command("trim") or self.trim_after
+            patches[-1].stop_after = self.has_command("stop") or self.stop_after
 
         return patches
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -206,6 +206,10 @@ class EmbroideryElement(object):
         return apply_transforms(self.path, self.node)
 
     @property
+    def shape(self):
+        raise NotImplementedError("INTERNAL ERROR: %s must implement shape()", self.__class__)
+
+    @property
     @cache
     def commands(self):
         return find_commands(self.node)

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -215,6 +215,10 @@ class EmbroideryElement(object):
         return [c for c in self.commands if c.command == command]
 
     @cache
+    def has_command(self, command):
+        return len(self.get_commands(command)) > 0
+
+    @cache
     def get_command(self, command):
         commands = self.get_commands(command)
 

--- a/lib/elements/polyline.py
+++ b/lib/elements/polyline.py
@@ -1,3 +1,5 @@
+from shapely import geometry as shgeo
+
 from .element import param, EmbroideryElement, Patch
 from ..i18n import _
 from ..utils.geometry import Point
@@ -26,6 +28,11 @@ class Polyline(EmbroideryElement):
        points = [[float(coord) for coord in point.split(",")] for point in points]
 
        return points
+
+    @property
+    @cache
+    def shape(self):
+        return shgeo.LineString(self.points)
 
     @property
     def path(self):

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -89,6 +89,17 @@ class SatinColumn(EmbroideryElement):
 
     @property
     @cache
+    def shape(self):
+        # This isn't used for satins at all, but other parts of the code
+        # may need to know the general shape of a satin column.
+
+        flattened = self.flatten(self.parse_path())
+        line_strings = [shgeo.LineString(path) for path in flattened]
+
+        return shgeo.MultiLineString(line_strings)
+
+    @property
+    @cache
     def csp(self):
         return self.parse_path()
 

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -1,4 +1,5 @@
 import sys
+import shapely.geometry
 
 from .element import param, EmbroideryElement, Patch
 from ..i18n import _
@@ -49,6 +50,12 @@ class Stroke(EmbroideryElement):
             return [self.strip_control_points(subpath) for subpath in path]
         else:
             return self.flatten(path)
+
+    @property
+    @cache
+    def shape(self):
+        line_strings = [shapely.geometry.LineString(path) for path in self.paths]
+        return shapely.geometry.MultiLineString(line_strings)
 
     @property
     @param('manual_stitch', _('Manual stitch placement'), tooltip=_("Stitch every node in the path.  Stitch length and zig-zag spacing are ignored."), type='boolean', default=False)

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -7,3 +7,4 @@ from input import Input
 from output import Output
 from zip import Zip
 from flip import Flip
+from commands import *

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -7,4 +7,4 @@ from input import Input
 from output import Output
 from zip import Zip
 from flip import Flip
-from commands import *
+from commands import Commands

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -142,5 +142,11 @@ class Commands(InkstitchExtension):
         for command in commands:
             self.ensure_symbol(command)
 
+        # Each object (node) in the SVG may correspond to multiple Elements of different
+        # types (e.g. stroke + fill).  We only want to process each one once.
+        seen_nodes = set()
+
         for element in self.elements:
-            self.add_command(element, commands)
+            if element.node not in seen_nodes:
+                self.add_command(element, commands)
+                seen_nodes.add(element.node)

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import inkex
+import simpletransform
+import cubicsuperpath
+from copy import deepcopy
+from shapely import geometry as shgeo
+
+from .base import InkstitchExtension
+from ..i18n import _
+from ..elements import SatinColumn
+from ..utils import get_bundled_dir, cache
+from ..svg.tags import SVG_DEFS_TAG, SVG_GROUP_TAG, SVG_USE_TAG, SVG_PATH_TAG, INKSCAPE_GROUPMODE, XLINK_HREF, CONNECTION_START, CONNECTION_END, CONNECTOR_TYPE
+from ..svg import get_node_transform
+
+
+class Commands(InkstitchExtension):
+    COMMANDS = ["fill_start", "fill_end", "stop", "trim"]
+
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        for command in self.COMMANDS:
+            self.OptionParser.add_option("--%s" % command, type="inkbool")
+
+    @property
+    def symbols_path(self):
+        return os.path.join(get_bundled_dir("symbols"), "inkstitch.svg")
+
+    @property
+    @cache
+    def symbols_svg(self):
+        with open(self.symbols_path) as symbols_file:
+            return inkex.etree.parse(symbols_file)
+
+    @property
+    @cache
+    def symbol_defs(self):
+        return self.symbols_svg.find(SVG_DEFS_TAG)
+
+    @property
+    @cache
+    def defs(self):
+        return self.document.find(SVG_DEFS_TAG)
+
+    def ensure_symbol(self, command):
+        path = "./*[@id='inkstitch_%s']" % command
+        if self.defs.find(path) is None:
+            self.defs.append(deepcopy(self.symbol_defs.find(path)))
+
+    def get_correction_transform(self, node):
+        # if we want to place our new nodes in the same group as this node,
+        # then we'll need to factor in the effects of any transforms set on
+        # the parents of this node.
+
+        # we can ignore the transform on the node itself since it won't apply
+        # to the objects we add
+        transform = get_node_transform(node.getparent())
+
+        # now invert it, so that we can position our objects in absolute
+        # coordinates
+        transform = simpletransform.invertTransform(transform)
+
+        return simpletransform.formatTransform(transform)
+
+    def add_connector(self, symbol, element):
+        # I'd like it if I could position the connector endpoint nicely but inkscape just
+        # moves it to the element's center immediately after the extension runs.
+        start_pos = (symbol.get('x'), symbol.get('y'))
+        end_pos = element.shape.centroid
+
+        path = inkex.etree.Element(SVG_PATH_TAG,
+            {
+                "id": self.uniqueId("connector"),
+                "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
+                "style": "stroke:#000000;stroke-width:1px;",
+                "transform": self.get_correction_transform(symbol),
+                CONNECTION_START: "#%s" % symbol.get('id'),
+                CONNECTION_END: "#%s" % element.node.get('id'),
+                CONNECTOR_TYPE: "polyline",
+            }
+        )
+
+        symbol.getparent().insert(symbol.getparent().index(symbol), path)
+
+    def get_command_pos(self, element, index, total):
+        # Put command symbols 30 pixels out from the shape, spaced evenly around it.
+        outline = element.shape.buffer(30).exterior
+        return outline.interpolate(index / float(total), normalized=True)
+
+    def add_command(self, element, commands):
+        for i, command in enumerate(commands):
+            pos = self.get_command_pos(element, i, len(commands))
+
+            symbol = inkex.etree.SubElement(element.node.getparent(), SVG_USE_TAG,
+                {
+                    "id": self.uniqueId("use"),
+                    XLINK_HREF: "#inkstitch_%s" % command,
+                    "height": "100%",
+                    "width": "100%",
+                    "x": str(pos.x),
+                    "y": str(pos.y),
+                    "transform": self.get_correction_transform(element.node)
+                }
+            )
+
+            self.add_connector(symbol, element)
+
+    def effect(self):
+        if not self.get_elements():
+            return
+
+        if not self.selected:
+            inkex.errormsg(_("Please select one or more objects to which to attach commands."))
+            return
+
+        self.svg = self.document.getroot()
+
+        commands = [command for command in self.COMMANDS if getattr(self.options, command)]
+
+        if not commands:
+            inkex.errormsg(_("Please choose one or more commands to attach."))
+            return
+
+        for command in commands:
+            self.ensure_symbol(command)
+
+        for element in self.elements:
+                self.add_command(element, commands)

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -73,7 +73,7 @@ class Commands(InkstitchExtension):
             {
                 "id": self.uniqueId("connector"),
                 "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
-                "style": "stroke:#000000;stroke-width:1px;fill:none;",
+                "style": "stroke:#000000;stroke-width:1px;stroke-opacity:0.5;fill:none;",
                 "transform": self.get_correction_transform(symbol),
                 CONNECTION_START: "#%s" % symbol.get('id'),
                 CONNECTION_END: "#%s" % element.node.get('id'),

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -72,7 +72,7 @@ class Commands(InkstitchExtension):
             {
                 "id": self.uniqueId("connector"),
                 "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
-                "style": "stroke:#000000;stroke-width:1px;",
+                "style": "stroke:#000000;stroke-width:1px;fill:none;",
                 "transform": self.get_correction_transform(symbol),
                 CONNECTION_START: "#%s" % symbol.get('id'),
                 CONNECTION_END: "#%s" % element.node.get('id'),

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -4,6 +4,7 @@ import inkex
 import simpletransform
 import cubicsuperpath
 from copy import deepcopy
+from random import random
 from shapely import geometry as shgeo
 
 from .base import InkstitchExtension
@@ -84,8 +85,16 @@ class Commands(InkstitchExtension):
 
     def get_command_pos(self, element, index, total):
         # Put command symbols 30 pixels out from the shape, spaced evenly around it.
+
+        # get a line running 30 pixels out from the shape
         outline = element.shape.buffer(30).exterior
-        return outline.interpolate(index / float(total), normalized=True)
+
+        # pick this item's spot arond the outline and perturb it a bit to avoid
+        # stacking up commands if they run the extension multiple times
+        position = index / float(total)
+        position += random() * 0.1
+
+        return outline.interpolate(position, normalized=True)
 
     def remove_legacy_param(self, element, command):
         if command == "trim" or command == "stop":

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -13,7 +13,7 @@ import logging
 import wx
 import inkex
 
-from ..utils import guess_inkscape_config_path
+from ..utils import guess_inkscape_config_path, get_bundled_dir
 
 
 class InstallerFrame(wx.Frame):
@@ -78,14 +78,8 @@ class InstallerFrame(wx.Frame):
 
     def install_addons(self, type):
         path = os.path.join(self.path, type)
-        src_dir = self.get_bundled_dir(type)
+        src_dir = get_bundled_dir(type)
         self.copy_files(glob(os.path.join(src_dir, "*")), path)
-
-    def get_bundled_dir(self, name):
-        if getattr(sys, 'frozen', None) is not None:
-            return realpath(os.path.join(sys._MEIPASS, '..', name))
-        else:
-            return realpath(os.path.join(dirname(realpath(__file__)), '..', '..', name))
 
     if (sys.platform == "win32"):
         # If we try to just use shutil.copy it says the operation requires elevation.

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -183,10 +183,7 @@ class ColorBlock(object):
     def num_stops(self):
         """Number of pauses in this color block."""
 
-        # Stops are encoded using two STOP stitches each.  See the comment in
-        # stop.py for an explanation.
-
-        return sum(1 for stitch in self if stitch.stop) / 2
+        return sum(1 for stitch in self if stitch.stop)
 
     @property
     def num_trims(self):

--- a/lib/svg/__init__.py
+++ b/lib/svg/__init__.py
@@ -1,3 +1,3 @@
 from .svg import color_block_to_point_lists, render_stitch_plan
 from .units import *
-from .path import apply_transforms
+from .path import apply_transforms, get_node_transform

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -4,6 +4,14 @@ import cubicsuperpath
 from .units import get_viewbox_transform
 
 def apply_transforms(path, node):
+    transform = get_node_transform(node)
+
+    # apply the combined transform to this node's path
+    simpletransform.applyTransformToPath(transform, path)
+
+    return path
+
+def get_node_transform(node):
     # start with the identity transform
     transform = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 
@@ -14,7 +22,4 @@ def apply_transforms(path, node):
     viewbox_transform = get_viewbox_transform(node.getroottree().getroot())
     transform = simpletransform.composeTransform(viewbox_transform, transform)
 
-    # apply the combined transform to this node's path
-    simpletransform.applyTransformToPath(transform, path)
-
-    return path
+    return transform

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -12,6 +12,7 @@ INKSCAPE_LABEL = inkex.addNS('label', 'inkscape')
 INKSCAPE_GROUPMODE = inkex.addNS('groupmode', 'inkscape')
 CONNECTION_START = inkex.addNS('connection-start', 'inkscape')
 CONNECTION_END = inkex.addNS('connection-end', 'inkscape')
+CONNECTOR_TYPE = inkex.addNS('connector-type', 'inkscape')
 XLINK_HREF = inkex.addNS('href', 'xlink')
 
 EMBROIDERABLE_TAGS = (SVG_PATH_TAG, SVG_POLYLINE_TAG)

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -2,3 +2,4 @@ from geometry import *
 from cache import cache
 from io import *
 from inkscape import *
+from paths import *

--- a/lib/utils/paths.py
+++ b/lib/utils/paths.py
@@ -1,0 +1,10 @@
+import sys
+import os
+from os.path import dirname, realpath
+
+
+def get_bundled_dir(name):
+    if getattr(sys, 'frozen', None) is not None:
+        return realpath(os.path.join(sys._MEIPASS, "..", name))
+    else:
+        return realpath(os.path.join(dirname(realpath(__file__)), '..', '..', name))

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-12 20:04-0400\n"
+"POT-Creation-Date: 2018-07-12 20:13-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,20 +49,6 @@ msgstr ""
 
 #, python-format
 msgid "%(id)s has more than one command of type '%(command)s' linked to it"
-msgstr ""
-
-msgid "TRIM after"
-msgstr ""
-
-msgid "Trim thread after this object (for supported machines and file formats)"
-msgstr ""
-
-msgid "STOP after"
-msgstr ""
-
-msgid ""
-"Add STOP instruction after this object (for supported machines and file "
-"formats)"
 msgstr ""
 
 msgid "Fill"

--- a/messages.po
+++ b/messages.po
@@ -178,6 +178,12 @@ msgstr ""
 msgid "Tip: use Path -> Object to Path to convert non-paths."
 msgstr ""
 
+msgid "Please select one or more objects to which to attach commands."
+msgstr ""
+
+msgid "Please choose one or more commands to attach."
+msgstr ""
+
 msgid ""
 "\n"
 "\n"

--- a/symbols/inkstitch.svg
+++ b/symbols/inkstitch.svg
@@ -61,64 +61,64 @@
     <symbol
        id="inkstitch_fill_end">
       <title
-         id="title9427">Fill stitch ending point</title>
+         id="inkstitch_title9427">Fill stitch ending point</title>
       <path
-         id="circle13166"
+         id="inkstitch_circle13166"
          d="m 9.220113,0.0792309 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 1e-7,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.27154255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
          d="m -4.570439,-4.5704391 c 0,0 9.140878,0 9.140878,0 0,0 0,9.14087 0,9.14087 0,0 -9.140878,0 -9.140878,0 0,0 0,-9.14087 0,-9.14087"
-         id="rect5371-2"
+         id="inkstitch_rect5371-2"
          inkscape:connector-curvature="0" />
     </symbol>
     <symbol
        id="inkstitch_trim">
       <title
-         id="title9282">Trim the thread after sewing this object.</title>
+         id="inkstitch_title9282">Trim the thread after sewing this object.</title>
       <path
-         id="circle13405"
+         id="inkstitch_circle13405"
          d="m 9.2465284,-8.6e-6 c 1.8e-6,2.452339 -0.9741847,4.804237 -2.7082493,6.538304 C 4.8042146,8.2723614 2.4523174,9.2465504 -2.1625959e-5,9.2465514 -2.4523623,9.2465534 -4.8042621,8.2723654 -6.5383288,6.5382984 -8.2723956,4.8042314 -9.2465834,2.4523324 -9.2465816,-8.6e-6 c 6e-7,-2.452339 0.9741895,-4.804237 2.708256,-6.538301 1.7340665,-1.734065 4.0859648,-2.708252 6.538303974041,-2.70825 C 5.1067066,-9.2465576 9.2465271,-5.1067366 9.2465284,-8.6e-6 c 0,0 0,0 0,0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.41421342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m -3.0000256,-5.9834096 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 0,0 0.61717997,1.62109 0.61717997,1.62109 0,0 -2.29881997,6.01758 -2.29881997,6.01758 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 0,0 1.33007997,-3.18945 1.33007997,-3.18945 0,0 1.23633003,3.25 1.23633003,3.25 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 0,0 -2.05469003,-6.14258 -2.05469003,-6.14258 0,0 0.73047003,-1.75 0.73047003,-1.75 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781003,1.67969 0,0 -0.0117,-0.0156 -0.0117,-0.0156 0,0 -0.80274,2.10156 -0.80274,2.10156 0,0 -0.59179,-1.76562 -0.59179,-1.76562 -0.18242,-1.12808 -1.15864997,-2 -2.33593997,-2 0,0 -2e-5,-3e-5 -2e-5,-3e-5 m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0 m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0"
-         id="path13416"
+         id="inkstitch_path13416"
          inkscape:connector-curvature="0" />
     </symbol>
     <symbol
        id="inkstitch_fill_start">
       <title
-         id="title9432">Fill stitch starting point</title>
+         id="inkstitch_title9432">Fill stitch starting point</title>
       <path
-         id="circle13166-6"
+         id="inkstitch_circle13166-6"
          d="m 9.2465269,-2.6e-6 c -1.9e-6,5.106729 -4.1398247,9.24655 -9.246554026709,9.24655 C -5.106756,9.2465474 -9.2465782,5.1067264 -9.2465801,-2.6e-6 c 2e-7,-5.10673 4.1398229,-9.246553 9.246552973291,-9.246553 2.452338526709,0 4.804235626709,0.974187 6.538300926709,2.708252 1.7340652,1.734066 2.708253,4.085963 2.7082531,6.538301 0,0 0,0 0,0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.74180555;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          d="m 6.5728129,0.0035574 c 0,0 -10.4514,6.03412 -10.4514,6.03412 0,0 0,-12.06823 0,-12.06823 0,0 10.4514,6.03411 10.4514,6.03411"
-         id="path4183"
+         id="inkstitch_path4183"
          inkscape:connector-curvature="0" />
     </symbol>
     <symbol
        id="inkstitch_stop">
       <title
-         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
+         id="inkstitch_title13328">Stop the machine after sewing this object (for applique, etc)</title>
       <path
-         id="circle13330"
+         id="inkstitch_circle13330"
          d="m 9.2465269,-2.6e-6 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553026709,9.24655 C -5.1067554,9.2465474 -9.2465782,5.1067264 -9.2465801,-2.6e-6 c 10e-8,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.538300873291,-2.708252 C 5.106704,-9.2465556 9.2465267,-5.1067326 9.2465269,-2.6e-6 c 0,0 0,0 0,0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
-         id="path13332"
+         id="inkstitch_path13332"
          d="m -3.1690251,-4.6497026 c 0,0 2.51587797,0 2.51587797,0 0,0 0,9.14087 0,9.14087 0,0 -2.51587797,0 -2.51587797,0 0,0 0,-9.14087 0,-9.14087"
          style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
          inkscape:connector-curvature="0" />
       <path
-         id="path13333"
+         id="inkstitch_path13333"
          d="m 0.83097287,-4.6497026 c 0,0 2.51588003,0 2.51588003,0 0,0 0,9.14087 0,9.14087 0,0 -2.51588003,0 -2.51588003,0 0,0 0,-9.14087 0,-9.14087"
          style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
          inkscape:connector-curvature="0" />

--- a/symbols/inkstitch.svg
+++ b/symbols/inkstitch.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="4"
-     inkscape:cx="56.98931"
-     inkscape:cy="305.83326"
+     inkscape:cx="30.48931"
+     inkscape:cy="293.08326"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -45,37 +45,47 @@
      inkscape:object-nodes="false"
      inkscape:snap-nodes="false">
     <inkscape:grid
-       empspacing="2"
-       opacity="0.1254902"
-       color="#f03fff"
-       spacingy="18.897638"
-       spacingx="18.897638"
-       units="mm"
+       type="xygrid"
        id="grid5001"
-       type="xygrid" />
+       units="mm"
+       spacingx="18.897638"
+       spacingy="18.897638"
+       color="#f03fff"
+       opacity="0.1254902"
+       empspacing="2" />
   </sodipodi:namedview>
   <title
      id="title9425">Ink/Stitch Commands</title>
   <defs
      id="defs8377">
     <symbol
-       id="inkstitch_stop">
+       id="inkstitch_fill_end">
       <title
-         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
+         id="title9427">Fill stitch ending point</title>
       <path
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 9.246554,58.4095 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 1e-7,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
-         id="circle13330"
+         id="circle13166"
+         d="m 9.220113,0.0792309 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 1e-7,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m -3.168998,53.75983 c 0,0 2.515878,0 2.515878,0 0,0 0,9.14087 0,9.14087 0,0 -2.515878,0 -2.515878,0 0,0 0,-9.14087 0,-9.14087"
-         id="path13332"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.27154255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -4.570439,-4.5704391 c 0,0 9.140878,0 9.140878,0 0,0 0,9.14087 0,9.14087 0,0 -9.140878,0 -9.140878,0 0,0 0,-9.14087 0,-9.14087"
+         id="rect5371-2"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="inkstitch_trim">
+      <title
+         id="title9282">Trim the thread after sewing this object.</title>
+      <path
+         id="circle13405"
+         d="m 9.2465284,-8.6e-6 c 1.8e-6,2.452339 -0.9741847,4.804237 -2.7082493,6.538304 C 4.8042146,8.2723614 2.4523174,9.2465504 -2.1625959e-5,9.2465514 -2.4523623,9.2465534 -4.8042621,8.2723654 -6.5383288,6.5382984 -8.2723956,4.8042314 -9.2465834,2.4523324 -9.2465816,-8.6e-6 c 6e-7,-2.452339 0.9741895,-4.804237 2.708256,-6.538301 1.7340665,-1.734065 4.0859648,-2.708252 6.538303974041,-2.70825 C 5.1067066,-9.2465576 9.2465271,-5.1067366 9.2465284,-8.6e-6 c 0,0 0,0 0,0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 0.831,53.75983 c 0,0 2.51588,0 2.51588,0 0,0 0,9.14087 0,9.14087 0,0 -2.51588,0 -2.51588,0 0,0 0,-9.14087 0,-9.14087"
-         id="path13333"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.41421342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m -3.0000256,-5.9834096 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 0,0 0.61717997,1.62109 0.61717997,1.62109 0,0 -2.29881997,6.01758 -2.29881997,6.01758 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 0,0 1.33007997,-3.18945 1.33007997,-3.18945 0,0 1.23633003,3.25 1.23633003,3.25 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 0,0 -2.05469003,-6.14258 -2.05469003,-6.14258 0,0 0.73047003,-1.75 0.73047003,-1.75 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781003,1.67969 0,0 -0.0117,-0.0156 -0.0117,-0.0156 0,0 -0.80274,2.10156 -0.80274,2.10156 0,0 -0.59179,-1.76562 -0.59179,-1.76562 -0.18242,-1.12808 -1.15864997,-2 -2.33593997,-2 0,0 -2e-5,-3e-5 -2e-5,-3e-5 m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0 m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0"
+         id="path13416"
          inkscape:connector-curvature="0" />
     </symbol>
     <symbol
@@ -83,45 +93,35 @@
       <title
          id="title9432">Fill stitch starting point</title>
       <path
-         inkscape:connector-curvature="0"
+         id="circle13166-6"
+         d="m 9.2465269,-2.6e-6 c -1.9e-6,5.106729 -4.1398247,9.24655 -9.246554026709,9.24655 C -5.106756,9.2465474 -9.2465782,5.1067264 -9.2465801,-2.6e-6 c 2e-7,-5.10673 4.1398229,-9.246553 9.246552973291,-9.246553 2.452338526709,0 4.804235626709,0.974187 6.538300926709,2.708252 1.7340652,1.734066 2.708253,4.085963 2.7082531,6.538301 0,0 0,0 0,0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 9.246554,58.4095 C 9.2465521,63.516229 5.1067293,67.65605 0,67.65605 c -5.1067289,0 -9.2465511,-4.139821 -9.246553,-9.24655 2e-7,-5.10673 4.1398229,-9.246553 9.246553,-9.246553 2.4523385,0 4.8042356,0.974187 6.5383009,2.708252 1.7340652,1.734066 2.708253,4.085963 2.7082531,6.538301 0,0 0,0 0,0"
-         id="circle13166-6" />
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
+         style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.74180555;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 6.5728129,0.0035574 c 0,0 -10.4514,6.03412 -10.4514,6.03412 0,0 0,-12.06823 0,-12.06823 0,0 10.4514,6.03411 10.4514,6.03411"
          id="path4183"
-         d="m 6.57284,58.41306 c 0,0 -10.4514,6.03412 -10.4514,6.03412 0,0 0,-12.06823 0,-12.06823 0,0 10.4514,6.03411 10.4514,6.03411"
-         style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.74180555;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </symbol>
-    <symbol
-       id="inkstitch_trim">
-      <title
-         id="title9282">Trim the thread after sewing this object.</title>
-      <path
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 9.07045,57.915929 c 1.8e-6,2.452339 -0.9741847,4.804237 -2.7082493,6.538304 -1.7340645,1.734066 -4.0859617,2.708255 -6.5383007,2.708256 -2.4523407,2e-6 -4.8042405,-0.974186 -6.5383072,-2.708253 -1.7340668,-1.734067 -2.7082546,-4.085966 -2.7082528,-6.538307 6e-7,-2.452339 0.9741895,-4.804237 2.708256,-6.538301 1.7340665,-1.734065 4.0859648,-2.708252 6.538304,-2.70825 5.1067282,2e-6 9.2465487,4.139823 9.24655,9.246551 0,0 0,0 0,0"
-         id="circle13405"
-         inkscape:connector-curvature="0" />
-      <path
-         id="path13416"
-         d="m -3,52.426099 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 0,0 0.61718,1.62109 0.61718,1.62109 0,0 -2.29882,6.01758 -2.29882,6.01758 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 0,0 1.33008,-3.18945 1.33008,-3.18945 0,0 1.23633,3.25 1.23633,3.25 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 0,0 -2.05469,-6.14258 -2.05469,-6.14258 0,0 0.73047,-1.75 0.73047,-1.75 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781,1.67969 0,0 -0.0117,-0.0156 -0.0117,-0.0156 0,0 -0.80274,2.10156 -0.80274,2.10156 0,0 -0.59179,-1.76562 -0.59179,-1.76562 -0.18242,-1.12808 -1.15865,-2 -2.33594,-2 0,0 -2e-5,-3e-5 -2e-5,-3e-5 m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0 m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.41421342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          inkscape:connector-curvature="0" />
     </symbol>
     <symbol
-       id="inkstitch_fill_end">
+       id="inkstitch_stop">
       <title
-         id="title9427">Fill stitch ending point</title>
+         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
       <path
-         inkscape:connector-curvature="0"
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 9.260977,58.431186 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 10e-8,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
-         id="circle13166" />
+         id="circle13330"
+         d="m 9.2465269,-2.6e-6 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553026709,9.24655 C -5.1067554,9.2465474 -9.2465782,5.1067264 -9.2465801,-2.6e-6 c 10e-8,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.538300873291,-2.708252 C 5.106704,-9.2465556 9.2465267,-5.1067326 9.2465269,-2.6e-6 c 0,0 0,0 0,0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         id="rect5371-2"
-         d="m -4.529575,53.781516 c 0,0 9.140878,0 9.140878,0 0,0 0,9.14087 0,9.14087 0,0 -9.140878,0 -9.140878,0 0,0 0,-9.14087 0,-9.14087"
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.27154255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
+         id="path13332"
+         d="m -3.1690251,-4.6497026 c 0,0 2.51587797,0 2.51587797,0 0,0 0,9.14087 0,9.14087 0,0 -2.51587797,0 -2.51587797,0 0,0 0,-9.14087 0,-9.14087"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path13333"
+         d="m 0.83097287,-4.6497026 c 0,0 2.51588003,0 2.51588003,0 0,0 0,9.14087 0,9.14087 0,0 -2.51588003,0 -2.51588003,0 0,0 0,-9.14087 0,-9.14087"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         inkscape:connector-curvature="0" />
     </symbol>
   </defs>
   <metadata
@@ -137,53 +137,53 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="display:inline"
-     id="layer1"
+     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     inkscape:label="Layer 1">
+     id="layer1"
+     style="display:inline">
     <flowRoot
-       xml:space="preserve"
-       id="flowRoot37658"
+       transform="translate(0,58.409503)"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;text-anchor:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#050505;stroke-width:1.06500006;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-       transform="translate(0,58.409503)"><flowRegion
+       id="flowRoot37658"
+       xml:space="preserve"><flowRegion
          id="flowRegion37660"><rect
-           id="rect37662"
-           width="217.5"
-           height="62.5"
+           y="71.702759"
            x="20.75"
-           y="71.702759" /></flowRegion><flowPara
-         id="flowPara37664"
-         style="fill:#000000;fill-opacity:1;stroke:none">Create symbols carefully!  They must be centered about the origin before being converted to a symbol.</flowPara></flowRoot>    <use
-       xlink:href="#inkstitch_stop"
-       id="use52651"
+           height="62.5"
+           width="217.5"
+           id="rect37662" /></flowRegion><flowPara
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="flowPara37664">Create symbols carefully!  They must be centered about the origin before being converted to a symbol.</flowPara></flowRoot>    <use
+       xlink:href="#inkstitch_fill_end"
+       id="use9454"
        x="0"
        y="0"
        width="100%"
        height="100%"
-       transform="translate(151.18108,-1.7165886)" />
-    <use
-       xlink:href="#inkstitch_fill_start"
-       id="use52663"
-       x="0"
-       y="0"
-       width="100%"
-       height="100%"
-       transform="translate(113.3858,-1.7165886)" />
+       transform="translate(37.82169,75.511319)" />
     <use
        xlink:href="#inkstitch_trim"
-       id="use52679"
+       id="use9461"
        x="0"
        y="0"
        width="100%"
        height="100%"
-       transform="translate(75.590552,-1.7165891)" />
+       transform="translate(75.590552,75.590552)" />
     <use
-       xlink:href="#inkstitch_fill_end"
-       id="use52699"
+       xlink:href="#inkstitch_fill_start"
+       id="use9468"
        x="0"
        y="0"
        width="100%"
        height="100%"
-       transform="translate(37.780826,-1.7382746)" />
+       transform="translate(113.38583,75.590552)" />
+    <use
+       xlink:href="#inkstitch_stop"
+       id="use9476"
+       x="0"
+       y="0"
+       width="100%"
+       height="100%"
+       transform="translate(151.1811,75.590552)" />
   </g>
 </svg>

--- a/symbols/inkstitch.svg
+++ b/symbols/inkstitch.svg
@@ -18,6 +18,7 @@
    inkscape:version="0.92.3 (unknown)"
    sodipodi:docname="inkstitch.svg">
   <sodipodi:namedview
+     inkscape:snap-object-midpoints="true"
      id="base"
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -25,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="4"
-     inkscape:cx="127.82066"
-     inkscape:cy="323.33371"
+     inkscape:cx="56.98931"
+     inkscape:cy="305.83326"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -38,8 +39,11 @@
      inkscape:window-maximized="1"
      inkscape:measure-start="128.23,226.536"
      inkscape:measure-end="114.217,226.536"
-     inkscape:snap-global="false"
-     showguides="false">
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-others="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-nodes="false">
     <inkscape:grid
        empspacing="2"
        opacity="0.1254902"
@@ -55,82 +59,69 @@
   <defs
      id="defs8377">
     <symbol
-       id="inkstitch_fill_end">
+       id="inkstitch_stop">
       <title
-         id="title9427">Fill stitch starting point</title>
-      <circle
-         inkscape:label="outline"
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
-         id="circle13166"
-         cx="47.235394"
-         cy="105.91732"
-         r="9.2465534" />
+         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
       <path
-         inkscape:connector-curvature="0"
-         id="rect5371-2"
-         d="m 42.691395,101.26765 h 9.140878 v 9.14087 h -9.140878 z"
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.246554,58.4095 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 1e-7,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
+         id="circle13330"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -3.168998,53.75983 c 0,0 2.515878,0 2.515878,0 0,0 0,9.14087 0,9.14087 0,0 -2.515878,0 -2.515878,0 0,0 0,-9.14087 0,-9.14087"
+         id="path13332"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 0.831,53.75983 c 0,0 2.51588,0 2.51588,0 0,0 0,9.14087 0,9.14087 0,0 -2.51588,0 -2.51588,0 0,0 0,-9.14087 0,-9.14087"
+         id="path13333"
+         inkscape:connector-curvature="0" />
     </symbol>
     <symbol
        id="inkstitch_fill_start">
       <title
-         id="title9432">Fill stitch ending point</title>
-      <circle
-         inkscape:label="outline"
+         id="title9432">Fill stitch starting point</title>
+      <path
+         inkscape:connector-curvature="0"
          style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
-         id="circle13166-6"
-         cx="85.223907"
-         cy="106.13256"
-         r="9.2465534" />
+         d="M 9.246554,58.4095 C 9.2465521,63.516229 5.1067293,67.65605 0,67.65605 c -5.1067289,0 -9.2465511,-4.139821 -9.246553,-9.24655 2e-7,-5.10673 4.1398229,-9.246553 9.246553,-9.246553 2.4523385,0 4.8042356,0.974187 6.5383009,2.708252 1.7340652,1.734066 2.708253,4.085963 2.7082531,6.538301 0,0 0,0 0,0"
+         id="circle13166-6" />
       <path
          inkscape:connector-curvature="0"
          id="path4183"
-         d="m 91.796747,106.13612 -10.4514,6.03412 v -12.06823 z"
-         inkscape:transform-center-y="3.0183984e-06"
-         inkscape:transform-center-x="-1.7419043"
+         d="m 6.57284,58.41306 c 0,0 -10.4514,6.03412 -10.4514,6.03412 0,0 0,-12.06823 0,-12.06823 0,0 10.4514,6.03411 10.4514,6.03411"
          style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.74180555;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </symbol>
-    <symbol
-       id="inkstitch_stop">
-      <title
-         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
-      <circle
-         r="9.2465534"
-         cy="105.91732"
-         cx="47.235394"
-         id="circle13330"
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:label="outline" />
-      <path
-         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 44.066395,101.26765 h 2.515878 v 9.14087 h -2.515878 z"
-         id="path13332"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
-         d="m 48.066393,101.26765 h 2.51588 v 9.14087 h -2.51588 z"
-         id="path13333"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         inkscape:label="path13332-7" />
     </symbol>
     <symbol
        id="inkstitch_trim">
       <title
          id="title9282">Trim the thread after sewing this object.</title>
-      <circle
-         inkscape:label="outline"
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
+      <path
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.07045,57.915929 c 1.8e-6,2.452339 -0.9741847,4.804237 -2.7082493,6.538304 -1.7340645,1.734066 -4.0859617,2.708255 -6.5383007,2.708256 -2.4523407,2e-6 -4.8042405,-0.974186 -6.5383072,-2.708253 -1.7340668,-1.734067 -2.7082546,-4.085966 -2.7082528,-6.538307 6e-7,-2.452339 0.9741895,-4.804237 2.708256,-6.538301 1.7340665,-1.734065 4.0859648,-2.708252 6.538304,-2.70825 5.1067282,2e-6 9.2465487,4.139823 9.24655,9.246551 0,0 0,0 0,0"
          id="circle13405"
-         cx="161.5739"
-         cy="106.8505"
-         r="9.2465534" />
+         inkscape:connector-curvature="0" />
+      <path
+         id="path13416"
+         d="m -3,52.426099 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 0,0 0.61718,1.62109 0.61718,1.62109 0,0 -2.29882,6.01758 -2.29882,6.01758 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 0,0 1.33008,-3.18945 1.33008,-3.18945 0,0 1.23633,3.25 1.23633,3.25 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 0,0 -2.05469,-6.14258 -2.05469,-6.14258 0,0 0.73047,-1.75 0.73047,-1.75 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781,1.67969 0,0 -0.0117,-0.0156 -0.0117,-0.0156 0,0 -0.80274,2.10156 -0.80274,2.10156 0,0 -0.59179,-1.76562 -0.59179,-1.76562 -0.18242,-1.12808 -1.15865,-2 -2.33594,-2 0,0 -2e-5,-3e-5 -2e-5,-3e-5 m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0 m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 0,0 0,0 0,0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.41421342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </symbol>
+    <symbol
+       id="inkstitch_fill_end">
+      <title
+         id="title9427">Fill stitch ending point</title>
       <path
          inkscape:connector-curvature="0"
-         id="path13416"
-         d="m 158.75,101.36067 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 l 0.61718,1.62109 -2.29882,6.01758 c 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 l 1.33008,-3.18945 1.23633,3.25 c 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 l -2.05469,-6.14258 0.73047,-1.75 c 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781,1.67969 l -0.0117,-0.0156 -0.80274,2.10156 -0.59179,-1.76562 c -0.18242,-1.12808 -1.15865,-2 -2.33594,-2 z m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 z m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.260977,58.431186 c -1.9e-6,5.106729 -4.1398241,9.24655 -9.246553,9.24655 -5.1067293,0 -9.2465521,-4.139821 -9.246554,-9.24655 10e-8,-2.452338 0.9741879,-4.804235 2.7082531,-6.538301 1.7340653,-1.734065 4.0859624,-2.708252 6.5383009,-2.708252 5.1067301,0 9.2465528,4.139823 9.246553,9.246553 0,0 0,0 0,0"
+         id="circle13166" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect5371-2"
+         d="m -4.529575,53.781516 c 0,0 9.140878,0 9.140878,0 0,0 0,9.14087 0,9.14087 0,0 -9.140878,0 -9.140878,0 0,0 0,-9.14087 0,-9.14087"
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.27154255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
     </symbol>
   </defs>
   <metadata
@@ -147,47 +138,52 @@
   </metadata>
   <g
      style="display:inline"
-     transform="translate(0,-58.409503)"
      id="layer1"
      inkscape:groupmode="layer"
      inkscape:label="Layer 1">
-    <use
-       xlink:href="#inkstitch_fill_end"
-       id="use18860"
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot37658"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.33333302px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;text-anchor:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#050505;stroke-width:1.06500006;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       transform="translate(0,58.409503)"><flowRegion
+         id="flowRegion37660"><rect
+           id="rect37662"
+           width="217.5"
+           height="62.5"
+           x="20.75"
+           y="71.702759" /></flowRegion><flowPara
+         id="flowPara37664"
+         style="fill:#000000;fill-opacity:1;stroke:none">Create symbols carefully!  They must be centered about the origin before being converted to a symbol.</flowPara></flowRoot>    <use
+       xlink:href="#inkstitch_stop"
+       id="use52651"
        x="0"
        y="0"
        width="100%"
-       height="100%" />
+       height="100%"
+       transform="translate(151.18108,-1.7165886)" />
     <use
        xlink:href="#inkstitch_fill_start"
-       id="use18871"
-       x="0"
-       y="0"
-       width="100%"
-       height="100%" />
-    <use
-       style="display:inline"
-       xlink:href="#inkstitch_fill_end"
-       id="use18860-3"
+       id="use52663"
        x="0"
        y="0"
        width="100%"
        height="100%"
-       transform="translate(6.4739226e-8,-1.7570438e-6)" />
-    <use
-       xlink:href="#inkstitch_stop"
-       id="use13373"
-       x="0"
-       y="0"
-       width="100%"
-       height="100%"
-       transform="translate(77.922507,0.57962514)" />
+       transform="translate(113.3858,-1.7165886)" />
     <use
        xlink:href="#inkstitch_trim"
-       id="use13489"
+       id="use52679"
        x="0"
        y="0"
        width="100%"
-       height="100%" />
+       height="100%"
+       transform="translate(75.590552,-1.7165891)" />
+    <use
+       xlink:href="#inkstitch_fill_end"
+       id="use52699"
+       x="0"
+       y="0"
+       width="100%"
+       height="100%"
+       transform="translate(37.780826,-1.7382746)" />
   </g>
 </svg>

--- a/symbols/inkstitch.svg
+++ b/symbols/inkstitch.svg
@@ -24,9 +24,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="64.500275"
-     inkscape:cy="322.07765"
+     inkscape:zoom="4"
+     inkscape:cx="127.82066"
+     inkscape:cy="323.33371"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -90,6 +90,48 @@
          inkscape:transform-center-x="-1.7419043"
          style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.74180555;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </symbol>
+    <symbol
+       id="inkstitch_stop">
+      <title
+         id="title13328">Stop the machine after sewing this object (for applique, etc)</title>
+      <circle
+         r="9.2465534"
+         cy="105.91732"
+         cx="47.235394"
+         id="circle13330"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:label="outline" />
+      <path
+         style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 44.066395,101.26765 h 2.515878 v 9.14087 h -2.515878 z"
+         id="path13332"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.60622311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:4.81866985, 4.81866985;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m 48.066393,101.26765 h 2.51588 v 9.14087 h -2.51588 z"
+         id="path13333"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         inkscape:label="path13332-7" />
+    </symbol>
+    <symbol
+       id="inkstitch_trim">
+      <title
+         id="title9282">Trim the thread after sewing this object.</title>
+      <circle
+         inkscape:label="outline"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06501234;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19503705, 3.19503705;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle13405"
+         cx="161.5739"
+         cy="106.8505"
+         r="9.2465534" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13416"
+         d="m 158.75,101.36067 c -1.30575,0 -2.375,1.06924 -2.375,2.375 0,1.30575 1.06925,2.375 2.375,2.375 0.58687,0 1.11944,-0.22369 1.53516,-0.58007 l 0.61718,1.62109 -2.29882,6.01758 c 0.98655,-0.12511 1.23728,-0.26171 1.67382,-0.97461 l 1.33008,-3.18945 1.23633,3.25 c 0.23227,0.77906 0.84315,0.79218 1.57813,1.07226 l -2.05469,-6.14258 0.73047,-1.75 c 0.42849,0.41682 1.01136,0.67578 1.65234,0.67578 1.30575,0 2.375,-1.06925 2.375,-2.375 0,-1.30576 -1.06925,-2.375 -2.375,-2.375 -1.06233,0 -1.95701,0.71265 -2.25781,1.67969 l -0.0117,-0.0156 -0.80274,2.10156 -0.59179,-1.76562 c -0.18242,-1.12808 -1.15865,-2 -2.33594,-2 z m 0,1 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 z m 6,0 c 0.76531,0 1.375,0.60968 1.375,1.375 0,0.76531 -0.60969,1.375 -1.375,1.375 -0.76531,0 -1.375,-0.60969 -1.375,-1.375 0,-0.76532 0.60969,-1.375 1.375,-1.375 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#050505;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </symbol>
   </defs>
   <metadata
      id="metadata8380">
@@ -119,6 +161,30 @@
     <use
        xlink:href="#inkstitch_fill_start"
        id="use18871"
+       x="0"
+       y="0"
+       width="100%"
+       height="100%" />
+    <use
+       style="display:inline"
+       xlink:href="#inkstitch_fill_end"
+       id="use18860-3"
+       x="0"
+       y="0"
+       width="100%"
+       height="100%"
+       transform="translate(6.4739226e-8,-1.7570438e-6)" />
+    <use
+       xlink:href="#inkstitch_stop"
+       id="use13373"
+       x="0"
+       y="0"
+       width="100%"
+       height="100%"
+       transform="translate(77.922507,0.57962514)" />
+    <use
+       xlink:href="#inkstitch_trim"
+       id="use13489"
        x="0"
        y="0"
        width="100%"


### PR DESCRIPTION
This adds two new symbols: trim and stop.  Trim is a pair of scissors, and stop is a media "pause" symbol.  Like the fill start/end symbols, both are entirely original art and are therefore unencumbered by copyright issues.

As part of testing these, I was reminded that it's impossible to attach a connector to an object that has no fill using Inkscape's UI.  To work around this, I added a new extension, "Attach Commands...".  Select one or more objects, run the extension, choose which commands to add, and it adds them to your SVG and connects them to the selected objects.

It positions the command symbols 30 pixels from the outer border of the selected objects.  If you tell it to add multiple symbols at a time, it will space them evenly around the outer border of the object.  It makes no effort to avoid positioning them on top of any existing objects, but hopefully this at least gives the user a fighting chance of seeing where the new objects are and moving them where they like.