### PR TITLE
Add simulator tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Want to learn more?
 
 * Check out our list of [features](https://inkstitch.org/features/)
 * [Quick Install](https://inkstitch.org/docs/install/) on Linux and Windows (Mac support in the works!)
-* See some [photos](https://inkstitch.org/tutorials/inspiration/lexelby/) showing what Ink/Stitch can do
+* See some [photos](https://inkstitch.org/tutorials/inspiration/) showing what Ink/Stitch can do
 * Watch some [videos](https://inkstitch.org/tutorials/video/) of Ink/Stitch in action
 * ...and lots more on our [website](https://inkstitch.org)
 

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -26,13 +26,13 @@ class EmbroiderySimulator(wx.Frame):
 
         self.panel = wx.Panel(self, wx.ID_ANY)
         self.panel.SetFocus()
-                
+        
         tooltip = _('Simulation Controls') + '\n'
         tooltip += _('+\tor\tarrow up\tSpeed up') + '\n'
         tooltip += _('-\tor\tarrow down\tSlow down') + '\n'
-        tooltip += _('R\t\t\t\t\tRestart animation') + '\n'
-        tooltip += _('P\t\t\t\t\tPause simulation') + '\n'
-        tooltip += _('Q\t\t\t\t\tClose')
+        tooltip += 'R\t\t\t\t\t' +  _('Restart animation') + '\n'
+        tooltip += 'P\t\t\t\t\t' + _('Pause animation') + '\n'
+        tooltip += 'Q\t\t\t\t\t' + _('Close')
         self.SetToolTip(tooltip)
 
         self.load(stitch_plan)

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -27,23 +27,21 @@ class EmbroiderySimulator(wx.Frame):
         self.panel = wx.Panel(self, wx.ID_ANY)
         self.panel.SetFocus()
 
-        tooltip = _('Simulation Controls') + '\n'
-        tooltip += _('+\tor\tarrow up\tSpeed up') + '\n'
-        tooltip += _('-\tor\tarrow down\tSlow down') + '\n'
-        tooltip += 'R\t\t\t\t\t' +  _('Restart animation') + '\n'
-        tooltip += 'P\t\t\t\t\t' + _('Pause animation') + '\n'
-        tooltip += 'Q\t\t\t\t\t' + _('Close')
-        self.SetToolTip(tooltip)
-
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.button_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.button_label = [_("Speed up"), _("Slow down"), _("Pause"), _("Restart"), _("Quit")]
+        self.button_label = (
+            [_("Speed up"),_('Press + or arrow up to speed up')],
+            [_("Slow down"),_('Press - or arrow down to slow down')],
+            [_("Pause"),_("Press P to pause the animation")],
+            [_("Restart"),_("Press R to restart the animation")],
+            [_("Quit"),_("Press Q to close the simulation window")])
         self.buttons = []
         for i in range(0, len(self.button_label)):
-            self.buttons.append(wx.Button(self, -1, self.button_label[i]))
+            self.buttons.append(wx.Button(self, -1, self.button_label[i][0]))
             self.button_sizer.Add(self.buttons[i], 1, wx.EXPAND)
-            self.buttons[i].Bind( wx.EVT_BUTTON, self.on_key_down )
+            self.buttons[i].Bind(wx.EVT_BUTTON, self.on_key_down)
+            self.buttons[i].SetToolTip(self.button_label[i][1])
 
         self.sizer.Add(self.panel, 1, wx.EXPAND)
         self.sizer.Add(self.button_sizer, 0, wx.EXPAND)
@@ -94,6 +92,7 @@ class EmbroiderySimulator(wx.Frame):
             keycode = event.GetKeyCode()
         else:
             keycode = event.GetEventObject().GetLabelText()
+            self.panel.SetFocus()
 
         if keycode == ord("+") or keycode == ord("=") or keycode == wx.WXK_UP or keycode == "Speed up":
             if self.frame_period == 1:

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -26,6 +26,13 @@ class EmbroiderySimulator(wx.Frame):
 
         self.panel = wx.Panel(self, wx.ID_ANY)
         self.panel.SetFocus()
+                
+        tooltip = _('Simulation Controls') + '\n'
+        tooltip += _('+\tor\tarrow up\tSpeed up') + '\n'
+        tooltip += _('-\tor\tarrow down\tSlow down') + '\n'
+        tooltip += _('r\t\t\t\t\tRestart animation') + '\n'
+        tooltip += _('q\t\t\t\t\tClose')
+        self.SetToolTip(tooltip)
 
         self.load(stitch_plan)
 

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -195,7 +195,7 @@ class EmbroiderySimulator(wx.Frame):
 
         self.width = width
         self.height = height
-        self.scale = min(float(self.max_width) / width, float(self.max_height - 80) / height)
+        self.scale = min(float(self.max_width) / width, float(self.max_height - 60) / height)
 
         # make room for decorations and the margin
         self.scale *= 0.95

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -19,7 +19,7 @@ class EmbroiderySimulator(wx.Frame):
 
         screen_rect = wx.Display(0).ClientArea
         self.max_width = kwargs.pop('max_width', screen_rect.GetWidth())
-        self.max_height = kwargs.pop('max_height', screen_rect.GetHeight() - 100)
+        self.max_height = kwargs.pop('max_height', screen_rect.GetHeight())
         self.scale = 1
 
         wx.Frame.__init__(self, *args, **kwargs)
@@ -38,7 +38,7 @@ class EmbroiderySimulator(wx.Frame):
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.button_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.button_label = ["Speed up", "Slow down", "Pause", "Restart", "Quit"]
+        self.button_label = [_("Speed up"), _("Slow down"), _("Pause"), _("Restart"), _("Quit")]
         self.buttons = []
         for i in range(0, len(self.button_label)):
             self.buttons.append(wx.Button(self, -1, self.button_label[i]))
@@ -195,7 +195,7 @@ class EmbroiderySimulator(wx.Frame):
 
         self.width = width
         self.height = height
-        self.scale = min(float(self.max_width) / width, float(self.max_height) / height)
+        self.scale = min(float(self.max_width) / width, float(self.max_height - 80) / height)
 
         # make room for decorations and the margin
         self.scale *= 0.95
@@ -239,8 +239,13 @@ class EmbroiderySimulator(wx.Frame):
         decorations_width = window_width - client_width
         decorations_height = window_height - client_height + 40
 
-        self.SetSize((self.width * self.scale + decorations_width + self.margin * 2,
-                      self.height * self.scale + decorations_height + self.margin * 2))
+        setsize_window_width = self.width * self.scale + decorations_width + self.margin * 2
+        setsize_window_height = (self.height) * self.scale + decorations_height + self.margin * 2
+
+        if setsize_window_width < 600:
+            setsize_window_width = 600
+
+        self.SetSize(( setsize_window_width, setsize_window_height))
 
         e.Skip()
 

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -30,8 +30,9 @@ class EmbroiderySimulator(wx.Frame):
         tooltip = _('Simulation Controls') + '\n'
         tooltip += _('+\tor\tarrow up\tSpeed up') + '\n'
         tooltip += _('-\tor\tarrow down\tSlow down') + '\n'
-        tooltip += _('r\t\t\t\t\tRestart animation') + '\n'
-        tooltip += _('q\t\t\t\t\tClose')
+        tooltip += _('R\t\t\t\t\tRestart animation') + '\n'
+        tooltip += _('P\t\t\t\t\tPause simulation') + '\n'
+        tooltip += _('Q\t\t\t\t\tClose')
         self.SetToolTip(tooltip)
 
         self.load(stitch_plan)


### PR DESCRIPTION
It would be nice to know how to control the simulation from within Ink/Stitch without reading the documentation. This adds a tooltip to the simulator.