### PR TITLE
add E stitch for satin columns

### DIFF
--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-25 21:18-0400\n"
+"POT-Creation-Date: 2018-07-27 21:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,87 +100,91 @@ msgstr ""
 msgid "Custom satin column"
 msgstr ""
 
-#: lib/elements/satin_column.py:25 lib/elements/stroke.py:35
+#: lib/elements/satin_column.py:22
+msgid "\"E\" stitch"
+msgstr ""
+
+#: lib/elements/satin_column.py:31 lib/elements/stroke.py:35
 msgid "Zig-zag spacing (peak-to-peak)"
 msgstr ""
 
-#: lib/elements/satin_column.py:31
+#: lib/elements/satin_column.py:37
 msgid "Pull compensation"
 msgstr ""
 
-#: lib/elements/satin_column.py:39
+#: lib/elements/satin_column.py:45
 msgid "Contour underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:39 lib/elements/satin_column.py:46
-#: lib/elements/satin_column.py:51
+#: lib/elements/satin_column.py:45 lib/elements/satin_column.py:52
+#: lib/elements/satin_column.py:57
 msgid "Contour Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:46 lib/elements/satin_column.py:64
+#: lib/elements/satin_column.py:52 lib/elements/satin_column.py:70
 msgid "Stitch length"
 msgstr ""
 
-#: lib/elements/satin_column.py:51
+#: lib/elements/satin_column.py:57
 msgid "Contour underlay inset amount"
 msgstr ""
 
-#: lib/elements/satin_column.py:57
+#: lib/elements/satin_column.py:63
 msgid "Center-walk underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:57 lib/elements/satin_column.py:64
+#: lib/elements/satin_column.py:63 lib/elements/satin_column.py:70
 msgid "Center-Walk Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:69
+#: lib/elements/satin_column.py:75
 msgid "Zig-zag underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:69 lib/elements/satin_column.py:74
-#: lib/elements/satin_column.py:79
+#: lib/elements/satin_column.py:75 lib/elements/satin_column.py:80
+#: lib/elements/satin_column.py:85
 msgid "Zig-zag Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:74
+#: lib/elements/satin_column.py:80
 msgid "Zig-Zag spacing (peak-to-peak)"
 msgstr ""
 
-#: lib/elements/satin_column.py:79
+#: lib/elements/satin_column.py:85
 msgid "Inset amount (default: half of contour underlay inset)"
 msgstr ""
 
-#: lib/elements/satin_column.py:112
+#: lib/elements/satin_column.py:118
 #, python-format
 msgid "satin column: %(id)s: at least two subpaths required (%(num)d found)"
 msgstr ""
 
-#: lib/elements/satin_column.py:138
+#: lib/elements/satin_column.py:144
 msgid ""
 "One or more rails crosses itself, and this is not allowed.  Please split "
 "into multiple satin columns."
 msgstr ""
 
-#: lib/elements/satin_column.py:145
+#: lib/elements/satin_column.py:151
 msgid "satin column: One or more of the rungs doesn't intersect both rails."
 msgstr ""
 
-#: lib/elements/satin_column.py:145 lib/elements/satin_column.py:147
+#: lib/elements/satin_column.py:151 lib/elements/satin_column.py:153
 msgid "Each rail should intersect both rungs once."
 msgstr ""
 
-#: lib/elements/satin_column.py:147
+#: lib/elements/satin_column.py:153
 msgid ""
 "satin column: One or more of the rungs intersects the rails more than "
 "once."
 msgstr ""
 
-#: lib/elements/satin_column.py:188
+#: lib/elements/satin_column.py:194
 #, python-format
 msgid "satin column: object %s has a fill (but should not)"
 msgstr ""
 
-#: lib/elements/satin_column.py:192
+#: lib/elements/satin_column.py:198
 #, python-format
 msgid ""
 "satin column: object %(id)s has two paths with an unequal number of "


### PR DESCRIPTION
Click a checkbox to switch a satin column from zig-zags to E stitch.  Only the top stitching is affected, not the underlay.  I imagine one would probably not use E stitch with underlay :)

If the points are facing the wrong way, just use the "flip satin column rails" extension.

E stitch is only implemented for satin columns, not for simple satin.  Mathematically, it would be fairly easy to do it for simple satin too, but that comes with a number of complications:

1. Which side should the points be on?
2. Going around corners, it's going to be _really_ terrible.

I'd much rather just implement #49 if folks want an easy way to make E stitch (or any satin column).