### PR TITLE
convert path to satin

### DIFF
--- a/inkstitch.py
+++ b/inkstitch.py
@@ -10,7 +10,11 @@ parser.add_argument("--extension")
 my_args, remaining_args = parser.parse_known_args()
 
 extension_name = my_args.extension
-extension_class = getattr(extensions, extension_name.capitalize())
+
+# example: foo_bar_baz -> FooBarBaz
+extension_class_name = extension_name.title().replace("_", "")
+
+extension_class = getattr(extensions, extension_class_name)
 extension = extension_class()
 
 exception = None

--- a/inx/inkstitch_convert_to_satin.inx
+++ b/inx/inkstitch_convert_to_satin.inx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <_name>Convert Line to Satin</_name>
+    <id>org.inkstitch.convert_to_satin</id>
+    <dependency type="executable" location="extensions">inkstitch.py</dependency>
+    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <param name="extension" type="string" gui-hidden="true">convert_to_satin</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu _name="Embroidery" />
+        </effects-menu>
+    </effect>
+    <script>
+        <command reldir="extensions" interpreter="python">inkstitch.py</command>
+    </script>
+</inkscape-extension>

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -8,3 +8,4 @@ from output import Output
 from zip import Zip
 from flip import Flip
 from commands import Commands
+from convert_to_satin import ConvertToSatin

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -12,7 +12,7 @@ from ..i18n import _
 from ..elements import SatinColumn
 from ..utils import get_bundled_dir, cache
 from ..svg.tags import SVG_DEFS_TAG, SVG_GROUP_TAG, SVG_USE_TAG, SVG_PATH_TAG, INKSCAPE_GROUPMODE, XLINK_HREF, CONNECTION_START, CONNECTION_END, CONNECTOR_TYPE
-from ..svg import get_node_transform
+from ..svg import get_correction_transform
 
 
 class Commands(InkstitchExtension):
@@ -48,21 +48,6 @@ class Commands(InkstitchExtension):
         if self.defs.find(path) is None:
             self.defs.append(deepcopy(self.symbol_defs.find(path)))
 
-    def get_correction_transform(self, node):
-        # if we want to place our new nodes in the same group as this node,
-        # then we'll need to factor in the effects of any transforms set on
-        # the parents of this node.
-
-        # we can ignore the transform on the node itself since it won't apply
-        # to the objects we add
-        transform = get_node_transform(node.getparent())
-
-        # now invert it, so that we can position our objects in absolute
-        # coordinates
-        transform = simpletransform.invertTransform(transform)
-
-        return simpletransform.formatTransform(transform)
-
     def add_connector(self, symbol, element):
         # I'd like it if I could position the connector endpoint nicely but inkscape just
         # moves it to the element's center immediately after the extension runs.
@@ -74,7 +59,7 @@ class Commands(InkstitchExtension):
                 "id": self.uniqueId("connector"),
                 "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
                 "style": "stroke:#000000;stroke-width:1px;stroke-opacity:0.5;fill:none;",
-                "transform": self.get_correction_transform(symbol),
+                "transform": get_correction_transform(symbol),
                 CONNECTION_START: "#%s" % symbol.get('id'),
                 CONNECTION_END: "#%s" % element.node.get('id'),
                 CONNECTOR_TYPE: "polyline",
@@ -126,7 +111,7 @@ class Commands(InkstitchExtension):
                     "width": "100%",
                     "x": str(pos.x),
                     "y": str(pos.y),
-                    "transform": self.get_correction_transform(element.node)
+                    "transform": get_correction_transform(element.node)
                 }
             )
 

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -5,6 +5,7 @@ import numpy
 from numpy import diff, sign, setdiff1d
 from scipy.signal import argrelmin
 import math
+from copy import deepcopy
 
 from .base import InkstitchExtension
 from ..svg.tags import SVG_PATH_TAG
@@ -39,6 +40,11 @@ class ConvertToSatin(InkstitchExtension):
                     rails, rungs = self.path_to_satin(path, element.stroke_width)
                 except ValueError:
                     inkex.errormsg(_("Cannot convert %s to a satin column because it intersects itself.  Try breaking it up into multiple paths.") % element.node.get('id'))
+
+                    # revert any changes we've made
+                    self.document = deepcopy(self.original_document)
+
+                    return
 
                 parent.insert(index, self.satin_to_svg_node(rails, rungs, correction_transform))
 

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -1,0 +1,119 @@
+import inkex
+from shapely import geometry as shgeo
+from itertools import chain
+
+from .base import InkstitchExtension
+from ..svg.tags import SVG_PATH_TAG
+from ..svg import get_correction_transform, PIXELS_PER_MM
+from ..elements import Stroke
+from ..utils import Point
+
+
+class ConvertToSatin(InkstitchExtension):
+    """Convert a line to a satin column of the same width."""
+
+    def effect(self):
+        if not self.get_elements():
+            return
+
+        if not self.selected:
+            inkex.errormsg(_("Please select at least one line to convert to a satin column."))
+            return
+
+        if not all(isinstance(item, Stroke) for item in self.elements):
+            # L10N: Convert To Satin extension, user selected one or more objects that were not lines.
+            inkex.errormsg(_("Only simple lines may be converted to satin columns."))
+            return
+
+        for element in self.elements:
+            parent = element.node.getparent()
+            index = parent.index(element.node)
+            correction_transform = get_correction_transform(element.node)
+
+            for path in element.paths:
+                try:
+                    rails, rungs = self.path_to_satin(path, element.stroke_width)
+                except ValueError:
+                    inkex.errormsg(_("Cannot convert %s to a satin column because it intersects itself.  Try breaking it up into multiple paths.") % element.node.get('id'))
+
+                parent.insert(index, self.satin_to_svg_node(rails, rungs, correction_transform))
+
+            parent.remove(element.node)
+
+    def path_to_satin(self, path, stroke_width):
+        path = shgeo.LineString(path)
+
+        left_rail = path.parallel_offset(stroke_width / 2.0, 'left')
+        right_rail = path.parallel_offset(stroke_width / 2.0, 'right')
+
+        if not isinstance(left_rail, shgeo.LineString) or \
+           not isinstance(right_rail, shgeo.LineString):
+                # If the parallel offsets come out as anything but a LineString, that means the
+                # path intersects itself, when taking its stroke width into consideration.  See
+                # the last example for parallel_offset() in the Shapely documentation:
+                #   https://shapely.readthedocs.io/en/latest/manual.html#object.parallel_offset
+                raise ValueError()
+
+        # for whatever reason, shapely returns a right-side offset's coordinates in reverse
+        left_rail = list(left_rail.coords)
+        right_rail = list(reversed(right_rail.coords))
+
+        rungs = self.generate_rungs(path, stroke_width)
+
+        return (left_rail, right_rail), rungs
+
+    def generate_rungs(self, path, stroke_width):
+        rungs = []
+
+        # approximately 1cm between rungs, and we don't want them at the very start or end
+        num_rungs = int(path.length / PIXELS_PER_MM / 10) - 1
+
+        if num_rungs < 1 or num_rungs == 2:
+            # avoid 2 rungs because it can be ambiguous (which are the rails and which are the
+            # rungs?)
+            num_rungs += 1
+
+        distance_between_rungs = path.length / (num_rungs + 1)
+
+        for i in xrange(num_rungs):
+            rung_center = path.interpolate((i + 1) * distance_between_rungs)
+            rung_center = Point(rung_center.x, rung_center.y)
+
+            # TODO: use bezierslopeatt or whatever
+            # we need to calculate the normal at this point so grab another point just a little
+            # further down the path, effectively grabbing a small segment of the path
+            segment_end = path.interpolate((i + 1) * distance_between_rungs + 0.1)
+            segment_end = Point(segment_end.x, segment_end.y)
+
+            tangent = segment_end - rung_center
+            normal = tangent.unit().rotate_left()
+            offset = normal * stroke_width * 0.75
+
+            rung_start = rung_center + offset
+            rung_end = rung_center - offset
+
+            rungs.append((rung_start.as_tuple(), rung_end.as_tuple()))
+
+        return rungs
+        import sys
+        print >> sys.stderr, rails, rungs
+
+
+
+    def satin_to_svg_node(self, rails, rungs, correction_transform):
+        d = ""
+        for path in chain(rails, rungs):
+            d += "M"
+            for x, y in path:
+                d += "%s,%s " % (x, y)
+            d += " "
+
+        return inkex.etree.Element(SVG_PATH_TAG,
+            {
+                "id": self.uniqueId("path"),
+                "style": "stroke:#000000;stroke-width:1px;fill:none",
+                "transform": correction_transform,
+                "d": d,
+                "embroider_satin_column": "true",
+            }
+        )

--- a/lib/svg/__init__.py
+++ b/lib/svg/__init__.py
@@ -1,3 +1,3 @@
 from .svg import color_block_to_point_lists, render_stitch_plan
 from .units import *
-from .path import apply_transforms, get_node_transform
+from .path import apply_transforms, get_node_transform, get_correction_transform

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -23,3 +23,20 @@ def get_node_transform(node):
     transform = simpletransform.composeTransform(viewbox_transform, transform)
 
     return transform
+
+def get_correction_transform(node):
+    """Get a transform to apply to new siblings of this SVG node"""
+
+    # if we want to place our new nodes in the same group/layer as this node,
+    # then we'll need to factor in the effects of any transforms set on
+    # the parents of this node.
+
+    # we can ignore the transform on the node itself since it won't apply
+    # to the objects we add
+    transform = get_node_transform(node.getparent())
+
+    # now invert it, so that we can position our objects in absolute
+    # coordinates
+    transform = simpletransform.invertTransform(transform)
+
+    return simpletransform.formatTransform(transform)

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -15,8 +15,10 @@ def get_node_transform(node):
     # start with the identity transform
     transform = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 
-    # combine this node's transform with all parent groups' transforms
-    transform = simpletransform.composeParents(node, transform)
+    # this if is because sometimes inkscape likes to create paths outside of a layer?!
+    if node.getparent() is not None:
+        # combine this node's transform with all parent groups' transforms
+        transform = simpletransform.composeParents(node, transform)
 
     # add in the transform implied by the viewBox
     viewbox_transform = get_viewbox_transform(node.getroottree().getroot())

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-30 14:57-0400\n"
+"POT-Creation-Date: 2018-07-30 16:03-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,17 +238,17 @@ msgstr ""
 msgid "Please choose one or more commands to attach."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:20
+#: lib/extensions/convert_to_satin.py:24
 msgid "Please select at least one line to convert to a satin column."
 msgstr ""
 
 #. : Convert To Satin extension, user selected one or more objects that were
 #. not lines.
-#: lib/extensions/convert_to_satin.py:25
+#: lib/extensions/convert_to_satin.py:29
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:37
+#: lib/extensions/convert_to_satin.py:41
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-31 08:40-0400\n"
+"POT-Creation-Date: 2018-07-31 09:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,17 +238,17 @@ msgstr ""
 msgid "Please choose one or more commands to attach."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:25
+#: lib/extensions/convert_to_satin.py:29
 msgid "Please select at least one line to convert to a satin column."
 msgstr ""
 
 #. : Convert To Satin extension, user selected one or more objects that were
 #. not lines.
-#: lib/extensions/convert_to_satin.py:30
+#: lib/extensions/convert_to_satin.py:34
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:43
+#: lib/extensions/convert_to_satin.py:55
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-30 16:40-0400\n"
+"POT-Creation-Date: 2018-07-31 08:40-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:42
+#: lib/extensions/convert_to_satin.py:43
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-25 21:18-0400\n"
+"POT-Creation-Date: 2018-07-30 14:57-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -230,12 +230,29 @@ msgstr ""
 msgid "Tip: use Path -> Object to Path to convert non-paths."
 msgstr ""
 
-#: lib/extensions/commands.py:140
+#: lib/extensions/commands.py:125
 msgid "Please select one or more objects to which to attach commands."
 msgstr ""
 
-#: lib/extensions/commands.py:148
+#: lib/extensions/commands.py:133
 msgid "Please choose one or more commands to attach."
+msgstr ""
+
+#: lib/extensions/convert_to_satin.py:20
+msgid "Please select at least one line to convert to a satin column."
+msgstr ""
+
+#. : Convert To Satin extension, user selected one or more objects that were
+#. not lines.
+#: lib/extensions/convert_to_satin.py:25
+msgid "Only simple lines may be converted to satin columns."
+msgstr ""
+
+#: lib/extensions/convert_to_satin.py:37
+#, python-format
+msgid ""
+"Cannot convert %s to a satin column because it intersects itself.  Try "
+"breaking it up into multiple paths."
 msgstr ""
 
 #: lib/extensions/embroider.py:41

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-07-30 16:03-0400\n"
+"POT-Creation-Date: 2018-07-30 16:40-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -238,17 +238,17 @@ msgstr ""
 msgid "Please choose one or more commands to attach."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:24
+#: lib/extensions/convert_to_satin.py:25
 msgid "Please select at least one line to convert to a satin column."
 msgstr ""
 
 #. : Convert To Satin extension, user selected one or more objects that were
 #. not lines.
-#: lib/extensions/convert_to_satin.py:29
+#: lib/extensions/convert_to_satin.py:30
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:41
+#: lib/extensions/convert_to_satin.py:42
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "


### PR DESCRIPTION
Draw a path, set a stroke width, select it, and run this extension.  Your path will be replaced by a satin column object with rungs added in.

The algorithm that chooses the rungs is kind of nifty.  It finds the sharp corners and avoids placing rungs there, instead placing them a bit before and after the corner.  Try it on a square and you'll see that it does a pretty good job of routing the stitching around the corner:

![convert_satin_example](https://user-images.githubusercontent.com/4446653/43422183-ece6a538-9416-11e8-94d0-e24f66fa4ff3.png)

Notably, this extension can't handle a path whose stroke intersects itself.  For example, a line in the shape of the greek capital letter omega (Ω) can't be converted if its stroke width is big enough that the left and right parts touch at the bottom.  I have some ideas for how to remove this limitation down the road.

closes #49 

