### PR TITLE
fix output extension on windows

### DIFF
--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -36,6 +36,10 @@ class Output(InkstitchExtension):
 
         write_embroidery_file(temp_file.name, stitch_plan, self.document.getroot())
 
+        if sys.platform == "win32":
+            import msvcrt
+            msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
         # inkscape will read the file contents from stdout and copy
         # to the destination file that the user chose
         with open(temp_file.name) as output_file:


### PR DESCRIPTION
This PR properly sets stdout to binary mode before outputting the machine embroidery file as part of the output extension.  I'm hoping this will fix #258.