### PR TITLE
fix output extension on windows

### DIFF
--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -37,6 +37,7 @@ class Output(InkstitchExtension):
         write_embroidery_file(temp_file.name, stitch_plan, self.document.getroot())
 
         if sys.platform == "win32":
+            print >> sys.stderr, "setting stdout to binary mode"
             import msvcrt
             msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
@@ -44,6 +45,7 @@ class Output(InkstitchExtension):
         # to the destination file that the user chose
         with open(temp_file.name) as output_file:
             sys.stdout.write(output_file.read())
+            sys.stdout.flush()
 
         # clean up the temp file
         os.remove(temp_file.name)

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -36,6 +36,10 @@ class Output(InkstitchExtension):
 
         write_embroidery_file(temp_file.name, stitch_plan, self.document.getroot())
 
+        if sys.platform == "win32":
+            import msvcrt
+            msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
         # inkscape will read the file contents from stdout and copy
         # to the destination file that the user chose
         with open(temp_file.name) as output_file:

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -37,13 +37,12 @@ class Output(InkstitchExtension):
         write_embroidery_file(temp_file.name, stitch_plan, self.document.getroot())
 
         if sys.platform == "win32":
-            print >> sys.stderr, "setting stdout to binary mode"
             import msvcrt
             msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
         # inkscape will read the file contents from stdout and copy
         # to the destination file that the user chose
-        with open(temp_file.name) as output_file:
+        with open(temp_file.name, "rb") as output_file:
             sys.stdout.write(output_file.read())
             sys.stdout.flush()
 

--- a/stub.py
+++ b/stub.py
@@ -33,6 +33,10 @@ args[0] = binary_path
 extension = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout, stderr = extension.communicate()
 
+if sys.platform == "win32":
+    import msvcrt
+    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
 stdout = stdout.strip()
 if stdout:
     print stdout.strip(),


### PR DESCRIPTION
This PR properly sets stdout to binary mode before outputting the machine embroidery file as part of the output extension. I'm hoping this will fix #258.