### PR TITLE
switch build method for pyembroidery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pyembroidery"]
+	path = pyembroidery
+	url = https://github.com/inkstitch/pyembroidery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyembroidery2
+pyembroidery/
 backports.functools_lru_cache
 wxPython
 networkx


### PR DESCRIPTION
This removes the pyembroidery2 module and instead installs pyembroidery directly from a git submodule.  I've also removed pyembroidery2 from pypi.