### PR TITLE
name commands better

### DIFF
--- a/inx/inkstitch_attach_commands.inx
+++ b/inx/inkstitch_attach_commands.inx
@@ -4,8 +4,8 @@
     <id>org.inkstitch.commands</id>
     <dependency type="executable" location="extensions">inkstitch.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
-    <param name="fill_start" type="boolean" _gui-text="Fill starting position">false</param>
-    <param name="fill_end" type="boolean" _gui-text="Fill ending position">false</param>
+    <param name="fill_start" type="boolean" _gui-text="Fill stitch starting position">false</param>
+    <param name="fill_end" type="boolean" _gui-text="Fill stitch ending position">false</param>
     <param name="stop" type="boolean" _gui-text="Stop after sewing this object">false</param>
     <param name="trim" type="boolean" _gui-text="Trim thread after sewing this object">false</param>
     <param name="ignore_object" type="boolean" _gui-text="Ignore this object (do not stitch)">false</param>

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -3,13 +3,42 @@ import cubicsuperpath
 
 from .svg import apply_transforms
 from .svg.tags import SVG_USE_TAG, SVG_SYMBOL_TAG, CONNECTION_START, CONNECTION_END, XLINK_HREF
+from .utils import cache
+from .i18n import _
 
+COMMANDS = {
+    # l10n: command attached to an object
+    "fill_start": _("Fill stitch starting position"),
+
+    # l10n: command attached to an object
+    "fill_end": _("Fill stitch ending position"),
+
+    # l10n: command attached to an object
+    "stop": _("Stop (pause machine) after sewing this object"),
+
+    # l10n: command attached to an object
+    "trim": _("Trim thread after sewing this object"),
+
+    # l10n: command attached to an object
+    "ignore_object": _("Ignore this object (do not stitch)"),
+
+    # l10n: command that affects entire layer
+    "ignore_layer": _("Ignore layer (do not stitch any objects in this layer)")
+}
+
+OBJECT_COMMANDS = [ "fill_start", "fill_end", "stop", "trim", "ignore_object" ]
+LAYER_COMMANDS = [ "ignore_layer" ]
 
 class CommandParseError(Exception):
     pass
 
 
 class BaseCommand(object):
+    @property
+    @cache
+    def description(self):
+        return get_command_description(self.command)
+
     def parse_symbol(self):
         if self.symbol.tag != SVG_SYMBOL_TAG:
             raise CommandParseError("use points to non-symbol")
@@ -86,6 +115,9 @@ class StandaloneCommand(BaseCommand):
             raise CommandParseError("use points to non-symbol")
 
         self.parse_symbol()
+
+def get_command_description(command):
+    return COMMANDS[command]
 
 
 def find_commands(node):

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -3,13 +3,14 @@ import sys
 import inkex
 
 from .commands import CommandsExtension
+from ..commands import LAYER_COMMANDS, get_command_description
 from ..i18n import _
-from ..svg.tags import SVG_USE_TAG, XLINK_HREF
+from ..svg.tags import *
 from ..svg import get_correction_transform
 
 
 class LayerCommands(CommandsExtension):
-    COMMANDS = ["ignore_layer"]
+    COMMANDS = LAYER_COMMANDS
 
     def ensure_current_layer(self):
         # if no layer is selected, inkex defaults to the root, which isn't
@@ -37,6 +38,7 @@ class LayerCommands(CommandsExtension):
             node = inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
                 {
                     "id": self.uniqueId("use"),
+                    INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
                     XLINK_HREF: "#inkstitch_%s" % command,
                     "height": "100%",
                     "width": "100%",

--- a/lib/extensions/object_commands.py
+++ b/lib/extensions/object_commands.py
@@ -7,14 +7,15 @@ from random import random
 from shapely import geometry as shgeo
 
 from .commands import CommandsExtension
+from ..commands import OBJECT_COMMANDS, get_command_description
 from ..i18n import _
 from ..elements import SatinColumn
-from ..svg.tags import SVG_GROUP_TAG, SVG_USE_TAG, SVG_PATH_TAG, INKSCAPE_GROUPMODE, XLINK_HREF, CONNECTION_START, CONNECTION_END, CONNECTOR_TYPE
+from ..svg.tags import *
 from ..svg import get_correction_transform
 
 
 class ObjectCommands(CommandsExtension):
-    COMMANDS = ["fill_start", "fill_end", "stop", "trim", "ignore_object"]
+    COMMANDS = OBJECT_COMMANDS
 
     def add_connector(self, symbol, element):
         # I'd like it if I could position the connector endpoint nicely but inkscape just
@@ -27,14 +28,16 @@ class ObjectCommands(CommandsExtension):
                 "id": self.uniqueId("connector"),
                 "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
                 "style": "stroke:#000000;stroke-width:1px;stroke-opacity:0.5;fill:none;",
-                "transform": get_correction_transform(symbol),
                 CONNECTION_START: "#%s" % symbol.get('id'),
                 CONNECTION_END: "#%s" % element.node.get('id'),
                 CONNECTOR_TYPE: "polyline",
+
+                # l10n: the name of the line that connects a command to the object it applies to
+                INKSCAPE_LABEL: _("connector")
             }
         )
 
-        symbol.getparent().insert(symbol.getparent().index(symbol), path)
+        symbol.getparent().insert(0, path)
 
     def get_command_pos(self, element, index, total):
         # Put command symbols 30 pixels out from the shape, spaced evenly around it.
@@ -71,7 +74,15 @@ class ObjectCommands(CommandsExtension):
 
             pos = self.get_command_pos(element, i, len(commands))
 
-            symbol = inkex.etree.SubElement(element.node.getparent(), SVG_USE_TAG,
+            group = inkex.etree.SubElement(element.node.getparent(), SVG_GROUP_TAG,
+                {
+                    "id": self.uniqueId("group"),
+                    INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+                    "transform": get_correction_transform(element.node)
+                }
+            )
+
+            symbol = inkex.etree.SubElement(group, SVG_USE_TAG,
                 {
                     "id": self.uniqueId("use"),
                     XLINK_HREF: "#inkstitch_%s" % command,
@@ -79,7 +90,9 @@ class ObjectCommands(CommandsExtension):
                     "width": "100%",
                     "x": str(pos.x),
                     "y": str(pos.y),
-                    "transform": get_correction_transform(element.node)
+
+                    # l10n: the name of a command symbol (example: scissors icon for trim command)
+                    INKSCAPE_LABEL: _("command marker"),
                 }
             )
 

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-17 16:19-0400\n"
+"POT-Creation-Date: 2018-08-17 22:45-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,36 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.5.3\n"
+
+#. : command attached to an object
+#: lib/commands.py:11
+msgid "Fill stitch starting position"
+msgstr ""
+
+#. : command attached to an object
+#: lib/commands.py:14
+msgid "Fill stitch ending position"
+msgstr ""
+
+#. : command attached to an object
+#: lib/commands.py:17
+msgid "Stop (pause machine) after sewing this object"
+msgstr ""
+
+#. : command attached to an object
+#: lib/commands.py:20
+msgid "Trim thread after sewing this object"
+msgstr ""
+
+#. : command attached to an object
+#: lib/commands.py:23
+msgid "Ignore this object (do not stitch)"
+msgstr ""
+
+#. : command that affects entire layer
+#: lib/commands.py:26
+msgid "Ignore layer (do not stitch any objects in this layer)"
+msgstr ""
 
 #: lib/elements/auto_fill.py:11
 msgid "Auto-Fill"
@@ -432,11 +462,25 @@ msgstr ""
 msgid "Please choose one or more commands to add."
 msgstr ""
 
-#: lib/extensions/object_commands.py:93
+#. : the name of the line that connects a command to the object it applies to
+#: lib/extensions/object_commands.py:36
+msgid "connector"
+msgstr ""
+
+#: lib/extensions/object_commands.py:80
+msgid "Ink/Stitch Command"
+msgstr ""
+
+#. : the name of a command symbol (example: scissors icon for trim command)
+#: lib/extensions/object_commands.py:95
+msgid "command marker"
+msgstr ""
+
+#: lib/extensions/object_commands.py:106
 msgid "Please select one or more objects to which to attach commands."
 msgstr ""
 
-#: lib/extensions/object_commands.py:101
+#: lib/extensions/object_commands.py:114
 msgid "Please choose one or more commands to attach."
 msgstr ""
 

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-17 22:45-0400\n"
+"POT-Creation-Date: 2018-08-17 23:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -458,17 +458,17 @@ msgstr ""
 msgid "Ink/Stitch Add-ons Installer"
 msgstr ""
 
-#: lib/extensions/layer_commands.py:28
+#: lib/extensions/layer_commands.py:29
 msgid "Please choose one or more commands to add."
+msgstr ""
+
+#: lib/extensions/layer_commands.py:41 lib/extensions/object_commands.py:80
+msgid "Ink/Stitch Command"
 msgstr ""
 
 #. : the name of the line that connects a command to the object it applies to
 #: lib/extensions/object_commands.py:36
 msgid "connector"
-msgstr ""
-
-#: lib/extensions/object_commands.py:80
-msgid "Ink/Stitch Command"
 msgstr ""
 
 #. : the name of a command symbol (example: scissors icon for trim command)


### PR DESCRIPTION
This adds useful names for the command symbols and connectors created by Attach Commands and Add Layer Commands.

fixes #238 