### PR TITLE
fix coding style and enforce style checks in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ script:
         travis_wait 60 ssh -o StrictHostKeyChecking=no -i .ssh/id_rsa -N -R 9999:localhost:9999 debug@lex.gd
     fi
     if [ -n "$LINT" ]; then
-      flake8 . --count --max-complexity=10 --max-line-length=150 --statistics --exclude=pyembroidery,__init__.py
+      make style
     elif [ "$BUILD" = "linux" -o "$BUILD" = "osx" ]; then
       make dist
     elif [ "$BUILD" = "windows" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,8 +144,7 @@ script:
         travis_wait 60 ssh -o StrictHostKeyChecking=no -i .ssh/id_rsa -N -R 9999:localhost:9999 debug@lex.gd
     fi
     if [ -n "$LINT" ]; then
-      flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude=embroidermodder
-      flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=embroidermodder
+      flake8 . --count --max-complexity=10 --max-line-length=150 --statistics --exclude=pyembroidery,__init__.py
     elif [ "$BUILD" = "linux" -o "$BUILD" = "osx" ]; then
       make dist
     elif [ "$BUILD" = "windows" ]; then

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,7 @@ locales:
 	else \
 		mkdir -p locales; \
 	fi
+
+.PHONY: style
+style:
+	flake8 . --count --max-complexity=10 --max-line-length=150 --statistics --exclude=pyembroidery,__init__.py

--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,4 @@ locales:
 
 .PHONY: style
 style:
-	flake8 . --count --max-complexity=10 --max-line-length=150 --statistics --exclude=pyembroidery,__init__.py
+	flake8 . --count --max-complexity=10 --max-line-length=150 --statistics --exclude=pyembroidery,__init__.py,simulator.py,params.py

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -26,8 +26,9 @@ COMMANDS = {
     "ignore_layer": N_("Ignore layer (do not stitch any objects in this layer)")
 }
 
-OBJECT_COMMANDS = [ "fill_start", "fill_end", "stop", "trim", "ignore_object" ]
-LAYER_COMMANDS = [ "ignore_layer" ]
+OBJECT_COMMANDS = ["fill_start", "fill_end", "stop", "trim", "ignore_object"]
+LAYER_COMMANDS = ["ignore_layer"]
+
 
 class CommandParseError(Exception):
     pass
@@ -50,7 +51,7 @@ class BaseCommand(object):
         else:
             raise CommandParseError("symbol is not an Ink/Stitch command")
 
-    def get_node_by_url(self,url):
+    def get_node_by_url(self, url):
         # url will be #path12345.  Find the corresponding object.
         if url is None:
             raise CommandParseError("url is None")
@@ -116,6 +117,7 @@ class StandaloneCommand(BaseCommand):
 
         self.parse_symbol()
 
+
 def get_command_description(command):
     return _(COMMANDS[command])
 
@@ -138,6 +140,7 @@ def find_commands(node):
 
     return commands
 
+
 def layer_commands(layer, command):
     """Find standalone (unconnected) command symbols in this layer."""
 
@@ -149,6 +152,7 @@ def layer_commands(layer, command):
                 commands.append(command)
 
     return commands
+
 
 def standalone_commands(svg):
     """Find all unconnected command symbols in the SVG."""
@@ -164,6 +168,7 @@ def standalone_commands(svg):
             pass
 
     return commands
+
 
 def is_command(node):
     return CONNECTION_START in node.attrib or CONNECTION_END in node.attrib

--- a/lib/elements/auto_fill.py
+++ b/lib/elements/auto_fill.py
@@ -31,11 +31,11 @@ class AutoFill(Fill):
 
     @property
     @param('running_stitch_length_mm',
-            _('Running stitch length (traversal between sections)'),
-            tooltip=_('Length of stitches around the outline of the fill region used when moving from section to section.'),
-            unit='mm',
-            type='float',
-            default=1.5)
+           _('Running stitch length (traversal between sections)'),
+           tooltip=_('Length of stitches around the outline of the fill region used when moving from section to section.'),
+           unit='mm',
+           type='float',
+           default=1.5)
     def running_stitch_length(self):
         return max(self.get_float_param("running_stitch_length_mm", 1.5), 0.01)
 
@@ -46,11 +46,11 @@ class AutoFill(Fill):
 
     @property
     @param('fill_underlay_angle',
-            _('Fill angle'),
-            tooltip=_('default: fill angle + 90 deg'),
-            unit='deg',
-            group=_('AutoFill Underlay'),
-            type='float')
+           _('Fill angle'),
+           tooltip=_('default: fill angle + 90 deg'),
+           unit='deg',
+           group=_('AutoFill Underlay'),
+           type='float')
     @cache
     def fill_underlay_angle(self):
         underlay_angle = self.get_float_param("fill_underlay_angle")
@@ -62,43 +62,43 @@ class AutoFill(Fill):
 
     @property
     @param('fill_underlay_row_spacing_mm',
-            _('Row spacing'),
-            tooltip=_('default: 3x fill row spacing'),
-            unit='mm',
-            group=_('AutoFill Underlay'),
-            type='float')
+           _('Row spacing'),
+           tooltip=_('default: 3x fill row spacing'),
+           unit='mm',
+           group=_('AutoFill Underlay'),
+           type='float')
     @cache
     def fill_underlay_row_spacing(self):
         return self.get_float_param("fill_underlay_row_spacing_mm") or self.row_spacing * 3
 
     @property
     @param('fill_underlay_max_stitch_length_mm',
-            _('Max stitch length'),
-            tooltip=_('default: equal to fill max stitch length'),
-            unit='mm',
-            group=_('AutoFill Underlay'), type='float')
+           _('Max stitch length'),
+           tooltip=_('default: equal to fill max stitch length'),
+           unit='mm',
+           group=_('AutoFill Underlay'), type='float')
     @cache
     def fill_underlay_max_stitch_length(self):
         return self.get_float_param("fill_underlay_max_stitch_length_mm") or self.max_stitch_length
 
     @property
     @param('fill_underlay_inset_mm',
-            _('Inset'),
-            tooltip=_('Shrink the shape before doing underlay, to prevent underlay from showing around the outside of the fill.'),
-            unit='mm',
-            group=_('AutoFill Underlay'),
-            type='float',
-            default=0)
+           _('Inset'),
+           tooltip=_('Shrink the shape before doing underlay, to prevent underlay from showing around the outside of the fill.'),
+           unit='mm',
+           group=_('AutoFill Underlay'),
+           type='float',
+           default=0)
     def fill_underlay_inset(self):
         return self.get_float_param('fill_underlay_inset_mm', 0)
 
     @property
     @param('expand_mm',
-            _('Expand'),
-            tooltip=_('Expand the shape before fill stitching, to compensate for gaps between shapes.'),
-            unit='mm',
-            type='float',
-            default=0)
+           _('Expand'),
+           tooltip=_('Expand the shape before fill stitching, to compensate for gaps between shapes.'),
+           unit='mm',
+           type='float',
+           default=0)
     def expand(self):
         return self.get_float_param('expand_mm', 0)
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -157,7 +157,7 @@ class EmbroideryElement(object):
         doc_width, doc_height = get_doc_size(svg)
         viewbox = svg.get('viewBox', '0 0 %s %s' % (doc_width, doc_height))
         viewbox = viewbox.strip().replace(',', ' ').split()
-        return  doc_width / float(viewbox[2])
+        return doc_width / float(viewbox[2])
 
     @property
     @cache
@@ -230,7 +230,7 @@ class EmbroideryElement(object):
             return commands[0]
         elif len(commands) > 1:
             raise ValueError(_("%(id)s has more than one command of type '%(command)s' linked to it") %
-                                dict(id=self.node.get(id), command=command))
+                             dict(id=self.node.get(id), command=command))
         else:
             return None
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -1,6 +1,5 @@
 import sys
 from copy import deepcopy
-from shapely import geometry as shgeo
 
 from ..i18n import _
 from ..utils import cache
@@ -8,7 +7,6 @@ from ..svg import PIXELS_PER_MM, convert_length, get_doc_size, apply_transforms
 from ..commands import find_commands
 
 # inkscape-provided utilities
-import simpletransform
 import simplestyle
 import cubicsuperpath
 from cspsubdiv import cspsubdiv

--- a/lib/elements/fill.py
+++ b/lib/elements/fill.py
@@ -44,7 +44,8 @@ class Fill(EmbroideryElement):
     @param(
         'flip',
         _('Flip fill (start right-to-left)'),
-        tooltip=_('The flip option can help you with routing your stitch path.  When you enable flip, stitching goes from right-to-left instead of left-to-right.'),
+        tooltip=_('The flip option can help you with routing your stitch path.  '
+                  'When you enable flip, stitching goes from right-to-left instead of left-to-right.'),
         type='boolean',
         default=False)
     def flip(self):

--- a/lib/elements/fill.py
+++ b/lib/elements/fill.py
@@ -5,7 +5,7 @@ from .element import param, EmbroideryElement, Patch
 from ..i18n import _
 from ..svg import PIXELS_PER_MM
 from ..utils import cache
-from ..stitches import running_stitch, auto_fill, legacy_fill
+from ..stitches import legacy_fill
 
 
 class Fill(EmbroideryElement):

--- a/lib/elements/fill.py
+++ b/lib/elements/fill.py
@@ -16,21 +16,21 @@ class Fill(EmbroideryElement):
 
     @property
     @param('auto_fill',
-            _('Manually routed fill stitching'),
-            tooltip=_('AutoFill is the default method for generating fill stitching.'),
-            type='toggle',
-            inverse=True,
-            default=True)
+           _('Manually routed fill stitching'),
+           tooltip=_('AutoFill is the default method for generating fill stitching.'),
+           type='toggle',
+           inverse=True,
+           default=True)
     def auto_fill(self):
         return self.get_boolean_param('auto_fill', True)
 
     @property
     @param('angle',
-            _('Angle of lines of stitches'),
-            tooltip=_('The angle increases in a counter-clockwise direction.  0 is horizontal.  Negative angles are allowed.'),
-            unit='deg',
-            type='float',
-            default=0)
+           _('Angle of lines of stitches'),
+           tooltip=_('The angle increases in a counter-clockwise direction.  0 is horizontal.  Negative angles are allowed.'),
+           unit='deg',
+           type='float',
+           default=0)
     @cache
     def angle(self):
         return math.radians(self.get_float_param('angle', 0))
@@ -41,21 +41,22 @@ class Fill(EmbroideryElement):
         return self.get_style("fill", "#000000")
 
     @property
-    @param('flip',
-            _('Flip fill (start right-to-left)'),
-            tooltip=_('The flip option can help you with routing your stitch path.  When you enable flip, stitching goes from right-to-left instead of left-to-right.'),
-            type='boolean',
-            default=False)
+    @param(
+        'flip',
+        _('Flip fill (start right-to-left)'),
+        tooltip=_('The flip option can help you with routing your stitch path.  When you enable flip, stitching goes from right-to-left instead of left-to-right.'),
+        type='boolean',
+        default=False)
     def flip(self):
         return self.get_boolean_param("flip", False)
 
     @property
     @param('row_spacing_mm',
-            _('Spacing between rows'),
-            tooltip=_('Distance between rows of stitches.'),
-            unit='mm',
-            type='float',
-            default=0.25)
+           _('Spacing between rows'),
+           tooltip=_('Distance between rows of stitches.'),
+           unit='mm',
+           type='float',
+           default=0.25)
     def row_spacing(self):
         return max(self.get_float_param("row_spacing_mm", 0.25), 0.1 * PIXELS_PER_MM)
 
@@ -65,20 +66,20 @@ class Fill(EmbroideryElement):
 
     @property
     @param('max_stitch_length_mm',
-            _('Maximum fill stitch length'),
-            tooltip=_('The length of each stitch in a row.  Shorter stitch may be used at the start or end of a row.'),
-            unit='mm',
-            type='float',
-            default=3.0)
+           _('Maximum fill stitch length'),
+           tooltip=_('The length of each stitch in a row.  Shorter stitch may be used at the start or end of a row.'),
+           unit='mm',
+           type='float',
+           default=3.0)
     def max_stitch_length(self):
         return max(self.get_float_param("max_stitch_length_mm", 3.0), 0.1 * PIXELS_PER_MM)
 
     @property
     @param('staggers',
-            _('Stagger rows this many times before repeating'),
-            tooltip=_('Setting this dictates how many rows apart the stitches will be before they fall in the same column position.'),
-            type='int',
-            default=4)
+           _('Stagger rows this many times before repeating'),
+           tooltip=_('Setting this dictates how many rows apart the stitches will be before they fall in the same column position.'),
+           type='int',
+           default=4)
     def staggers(self):
         return self.get_int_param("staggers", 4)
 

--- a/lib/elements/polyline.py
+++ b/lib/elements/polyline.py
@@ -1,7 +1,6 @@
 from shapely import geometry as shgeo
 
-from .element import param, EmbroideryElement, Patch
-from ..i18n import _
+from .element import EmbroideryElement, Patch
 from ..utils.geometry import Point
 from ..utils import cache
 

--- a/lib/elements/polyline.py
+++ b/lib/elements/polyline.py
@@ -21,13 +21,13 @@ class Polyline(EmbroideryElement):
 
     @property
     def points(self):
-       # example: "1,2 0,0 1.5,3 4,2"
+        # example: "1,2 0,0 1.5,3 4,2"
 
-       points = self.node.get('points')
-       points = points.split(" ")
-       points = [[float(coord) for coord in point.split(",")] for point in points]
+        points = self.node.get('points')
+        points = points.split(" ")
+        points = [[float(coord) for coord in point.split(",")] for point in points]
 
-       return points
+        return points
 
     @property
     @cache

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -29,22 +29,23 @@ class SatinColumn(EmbroideryElement):
 
     @property
     @param('zigzag_spacing_mm',
-            _('Zig-zag spacing (peak-to-peak)'),
-            tooltip=_('Peak-to-peak distance between zig-zags.'),
-            unit='mm',
-            type='float',
-            default=0.4)
+           _('Zig-zag spacing (peak-to-peak)'),
+           tooltip=_('Peak-to-peak distance between zig-zags.'),
+           unit='mm',
+           type='float',
+           default=0.4)
     def zigzag_spacing(self):
         # peak-to-peak distance between zigzags
         return max(self.get_float_param("zigzag_spacing_mm", 0.4), 0.01)
 
     @property
-    @param('pull_compensation_mm',
-            _('Pull compensation'),
-            tooltip=_('Satin stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape.  This setting expands each pair of needle penetrations outward from the center of the satin column.'),
-            unit='mm',
-            type='float',
-            default=0)
+    @param(
+        'pull_compensation_mm',
+        _('Pull compensation'),
+        tooltip=_('Satin stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape.  This setting expands each pair of needle penetrations outward from the center of the satin column.'),
+        unit='mm',
+        type='float',
+        default=0)
     def pull_compensation(self):
         # In satin stitch, the stitches have a tendency to pull together and
         # narrow the entire column.  We can compensate for this by stitching
@@ -65,12 +66,12 @@ class SatinColumn(EmbroideryElement):
 
     @property
     @param('contour_underlay_inset_mm',
-            _('Contour underlay inset amount'),
-            tooltip=_('Shrink the outline, to prevent the underlay from showing around the outside of the satin column.'),
-            unit='mm',
-            group=_('Contour Underlay'),
-            type='float',
-            default=0.4)
+           _('Contour underlay inset amount'),
+           tooltip=_('Shrink the outline, to prevent the underlay from showing around the outside of the satin column.'),
+           unit='mm',
+           group=_('Contour Underlay'),
+           type='float',
+           default=0.4)
     def contour_underlay_inset(self):
         # how far inside the edge of the column to stitch the underlay
         return self.get_float_param("contour_underlay_inset_mm", 0.4)
@@ -94,23 +95,23 @@ class SatinColumn(EmbroideryElement):
 
     @property
     @param('zigzag_underlay_spacing_mm',
-            _('Zig-Zag spacing (peak-to-peak)'),
-            tooltip=_('Distance between peaks of the zig-zags.'),
-            unit='mm',
-            group=_('Zig-zag Underlay'),
-            type='float',
-            default=3)
+           _('Zig-Zag spacing (peak-to-peak)'),
+           tooltip=_('Distance between peaks of the zig-zags.'),
+           unit='mm',
+           group=_('Zig-zag Underlay'),
+           type='float',
+           default=3)
     def zigzag_underlay_spacing(self):
         return max(self.get_float_param("zigzag_underlay_spacing_mm", 3), 0.01)
 
     @property
     @param('zigzag_underlay_inset_mm',
-            _('Inset amount'),
-            tooltip=_('default: half of contour underlay inset'),
-            unit='mm',
-            group=_('Zig-zag Underlay'),
-            type='float',
-            default="")
+           _('Inset amount'),
+           tooltip=_('default: half of contour underlay inset'),
+           unit='mm',
+           group=_('Zig-zag Underlay'),
+           type='float',
+           default="")
     def zigzag_underlay_inset(self):
         # how far in from the edge of the satin the points in the zigzags
         # should be
@@ -147,7 +148,6 @@ class SatinColumn(EmbroideryElement):
         else:
             return self.flatten_beziers_with_rungs()
 
-
     def flatten_beziers_with_rungs(self):
         input_paths = [self.flatten([path]) for path in self.csp]
         input_paths = [shgeo.LineString(path[0]) for path in input_paths]
@@ -176,15 +176,16 @@ class SatinColumn(EmbroideryElement):
 
             #print >> dbg, "rails and rungs", [str(rail) for rail in rails], [str(rung) for rung in rungs]
             if len(linestrings.geoms) < len(rungs.geoms) + 1:
-                self.fatal(_("satin column: One or more of the rungs doesn't intersect both rails.") + "  " + _("Each rail should intersect both rungs once."))
+                self.fatal(_("satin column: One or more of the rungs doesn't intersect both rails.") +
+                           "  " + _("Each rail should intersect both rungs once."))
             elif len(linestrings.geoms) > len(rungs.geoms) + 1:
-                self.fatal(_("satin column: One or more of the rungs intersects the rails more than once.") + "  " + _("Each rail should intersect both rungs once."))
+                self.fatal(_("satin column: One or more of the rungs intersects the rails more than once.") +
+                           "  " + _("Each rail should intersect both rungs once."))
 
             paths = [[Point(*coord) for coord in ls.coords] for ls in linestrings.geoms]
             result.append(paths)
 
         return zip(*result)
-
 
     def simple_flatten_beziers(self):
         # Given a pair of paths made up of bezier segments, flatten
@@ -223,8 +224,8 @@ class SatinColumn(EmbroideryElement):
 
         if len(self.csp) == 2:
             if len(self.csp[0]) != len(self.csp[1]):
-                self.fatal(_("satin column: object %(id)s has two paths with an unequal number of points (%(length1)d and %(length2)d)") % \
-                             dict(id=node_id, length1=len(self.csp[0]), length2=len(self.csp[1])))
+                self.fatal(_("satin column: object %(id)s has two paths with an unequal number of points (%(length1)d and %(length2)d)") %
+                           dict(id=node_id, length1=len(self.csp[0]), length2=len(self.csp[1])))
 
     def offset_points(self, pos1, pos2, offset_px):
         # Expand or contract two points about their midpoint.  This is
@@ -442,7 +443,6 @@ class SatinColumn(EmbroideryElement):
             patch.add_stitch(left)
 
         return patch
-
 
     def to_patches(self, last_patch):
         # Stitch a variable-width satin column, zig-zagging between two paths.

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -42,7 +42,8 @@ class SatinColumn(EmbroideryElement):
     @param(
         'pull_compensation_mm',
         _('Pull compensation'),
-        tooltip=_('Satin stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape.  This setting expands each pair of needle penetrations outward from the center of the satin column.'),
+        tooltip=_('Satin stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape.  '
+                  'This setting expands each pair of needle penetrations outward from the center of the satin column.'),
         unit='mm',
         type='float',
         default=0)
@@ -174,7 +175,7 @@ class SatinColumn(EmbroideryElement):
             # handle null intersections here?
             linestrings = shops.split(rail, rungs)
 
-            #print >> dbg, "rails and rungs", [str(rail) for rail in rails], [str(rung) for rung in rungs]
+            # print >> dbg, "rails and rungs", [str(rail) for rail in rails], [str(rung) for rung in rungs]
             if len(linestrings.geoms) < len(rungs.geoms) + 1:
                 self.fatal(_("satin column: One or more of the rungs doesn't intersect both rails.") +
                            "  " + _("Each rail should intersect both rungs once."))

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -41,7 +41,9 @@ class Stroke(EmbroideryElement):
     @param(
         'bean_stitch_repeats',
         _('Bean stitch number of repeats'),
-        tooltip=_('Backtrack each stitch this many times.  A value of 1 would triple each stitch (forward, back, forward).  A value of 2 would quintuple each stitch, etc.  Only applies to running stitch.'),
+        tooltip=_('Backtrack each stitch this many times.  '
+                  'A value of 1 would triple each stitch (forward, back, forward).  '
+                  'A value of 2 would quintuple each stitch, etc.  Only applies to running stitch.'),
         type='int',
         default=0,
         sort_index=2)

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -28,44 +28,45 @@ class Stroke(EmbroideryElement):
 
     @property
     @param('running_stitch_length_mm',
-            _('Running stitch length'),
-            tooltip=_('Length of stitches in running stitch mode.'),
-            unit='mm',
-            type='float',
-            default=1.5,
-            sort_index=3)
+           _('Running stitch length'),
+           tooltip=_('Length of stitches in running stitch mode.'),
+           unit='mm',
+           type='float',
+           default=1.5,
+           sort_index=3)
     def running_stitch_length(self):
         return max(self.get_float_param("running_stitch_length_mm", 1.5), 0.01)
 
     @property
-    @param('bean_stitch_repeats',
-           _('Bean stitch number of repeats'),
-           tooltip=_('Backtrack each stitch this many times.  A value of 1 would triple each stitch (forward, back, forward).  A value of 2 would quintuple each stitch, etc.  Only applies to running stitch.'),
-           type='int',
-           default=0,
-           sort_index=2)
+    @param(
+        'bean_stitch_repeats',
+        _('Bean stitch number of repeats'),
+        tooltip=_('Backtrack each stitch this many times.  A value of 1 would triple each stitch (forward, back, forward).  A value of 2 would quintuple each stitch, etc.  Only applies to running stitch.'),
+        type='int',
+        default=0,
+        sort_index=2)
     def bean_stitch_repeats(self):
         return self.get_int_param("bean_stitch_repeats", 0)
 
     @property
     @param('zigzag_spacing_mm',
-            _('Zig-zag spacing (peak-to-peak)'),
-            tooltip=_('Length of stitches in zig-zag mode.'),
-            unit='mm',
-            type='float',
-            default=0.4,
-            sort_index=3)
+           _('Zig-zag spacing (peak-to-peak)'),
+           tooltip=_('Length of stitches in zig-zag mode.'),
+           unit='mm',
+           type='float',
+           default=0.4,
+           sort_index=3)
     @cache
     def zigzag_spacing(self):
         return max(self.get_float_param("zigzag_spacing_mm", 0.4), 0.01)
 
     @property
     @param('repeats',
-            _('Repeats'),
-            tooltip=_('Defines how many times to run down and back along the path.'),
-            type='int',
-            default="1",
-            sort_index=1)
+           _('Repeats'),
+           tooltip=_('Defines how many times to run down and back along the path.'),
+           type='int',
+           default="1",
+           sort_index=1)
     def repeats(self):
         return self.get_int_param("repeats", 1)
 
@@ -86,11 +87,11 @@ class Stroke(EmbroideryElement):
 
     @property
     @param('manual_stitch',
-            _('Manual stitch placement'),
-            tooltip=_("Stitch every node in the path.  Stitch length and zig-zag spacing are ignored."),
-            type='boolean',
-            default=False,
-            sort_index=0)
+           _('Manual stitch placement'),
+           tooltip=_("Stitch every node in the path.  Stitch length and zig-zag spacing are ignored."),
+           type='boolean',
+           default=False,
+           sort_index=0)
     def manual_stitch_mode(self):
         return self.get_boolean_param('manual_stitch')
 
@@ -121,9 +122,9 @@ class Stroke(EmbroideryElement):
             global warned_about_legacy_running_stitch
             if not warned_about_legacy_running_stitch:
                 warned_about_legacy_running_stitch = True
-                print >> sys.stderr, _("Legacy running stitch setting detected!\n\nIt looks like you're using a stroke " + \
-                    "smaller than 0.5 units to indicate a running stitch, which is deprecated.  Instead, please set " + \
-                    "your stroke to be dashed to indicate running stitch.  Any kind of dash will work.")
+                print >> sys.stderr, _("Legacy running stitch setting detected!\n\nIt looks like you're using a stroke " +
+                                       "smaller than 0.5 units to indicate a running stitch, which is deprecated.  Instead, please set " +
+                                       "your stroke to be dashed to indicate running stitch.  Any kind of dash will work.")
 
             # still allow the deprecated setting to work in order to support old files
             return True
@@ -173,7 +174,6 @@ class Stroke(EmbroideryElement):
         stitches = running_stitch(repeated_path, stitch_length)
 
         return Patch(self.color, stitches)
-
 
     def to_patches(self, last_patch):
         patches = []

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -19,4 +19,4 @@ for item in locals().values():
     if inspect.isclass(item) and \
        issubclass(item, InkstitchExtension) and \
        item is not InkstitchExtension:
-            extensions.append(item)
+        extensions.append(item)

--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -109,11 +109,11 @@ class InkstitchExtension(inkex.Effect):
                 g.set("style", "display:none")
 
     def no_elements_error(self):
-            if self.selected:
-                inkex.errormsg(_("No embroiderable paths selected."))
-            else:
-                inkex.errormsg(_("No embroiderable paths found in document."))
-            inkex.errormsg(_("Tip: use Path -> Object to Path to convert non-paths."))
+        if self.selected:
+            inkex.errormsg(_("No embroiderable paths selected."))
+        else:
+            inkex.errormsg(_("No embroiderable paths found in document."))
+        inkex.errormsg(_("Tip: use Path -> Object to Path to convert non-paths."))
 
     def descendants(self, node, selected=False):
         nodes = []
@@ -176,7 +176,6 @@ class InkstitchExtension(inkex.Effect):
 
                 return classes
 
-
     def get_elements(self):
         self.elements = []
         for node in self.get_nodes():
@@ -211,7 +210,6 @@ class InkstitchExtension(inkex.Effect):
             svg_filename = svg_filename[:-4]
 
         return svg_filename
-
 
     def parse(self):
         """Override inkex.Effect to add Ink/Stitch xml namespace"""

--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -5,10 +5,10 @@ from copy import deepcopy
 from collections import MutableMapping
 from stringcase import snakecase
 
-from ..svg.tags import *
+from ..svg.tags import SVG_GROUP_TAG, INKSCAPE_GROUPMODE, SVG_DEFS_TAG, EMBROIDERABLE_TAGS, SVG_POLYLINE_TAG
 from ..elements import AutoFill, Fill, Stroke, SatinColumn, Polyline, EmbroideryElement
-from ..utils import cache
 from ..commands import is_command, layer_commands
+from ..i18n import _
 
 
 SVG_METADATA_TAG = inkex.addNS("metadata", "svg")

--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import inkex
 from copy import deepcopy
 

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -51,7 +51,9 @@ class ConvertToSatin(InkstitchExtension):
                 try:
                     rails, rungs = self.path_to_satin(path, element.stroke_width, style_args)
                 except SelfIntersectionError:
-                    inkex.errormsg(_("Cannot convert %s to a satin column because it intersects itself.  Try breaking it up into multiple paths.") % element.node.get('id'))
+                    inkex.errormsg(
+                        _("Cannot convert %s to a satin column because it intersects itself.  Try breaking it up into multiple paths.") %
+                        element.node.get('id'))
 
                     # revert any changes we've made
                     self.document = deepcopy(self.original_document)
@@ -84,7 +86,7 @@ class ConvertToSatin(InkstitchExtension):
         """Convert svg line join style to shapely parallel offset arguments."""
 
         args = {
-                    'join_style': shgeo.JOIN_STYLE.round
+            'join_style': shgeo.JOIN_STYLE.round
         }
 
         element_join_style = element.get_style('stroke-linejoin')
@@ -113,7 +115,7 @@ class ConvertToSatin(InkstitchExtension):
                 # path intersects itself, when taking its stroke width into consideration.  See
                 # the last example for parallel_offset() in the Shapely documentation:
                 #   https://shapely.readthedocs.io/en/latest/manual.html#object.parallel_offset
-                raise SelfIntersectionError()
+            raise SelfIntersectionError()
 
         # for whatever reason, shapely returns a right-side offset's coordinates in reverse
         left_rail = list(left_rail.coords)
@@ -244,7 +246,7 @@ class ConvertToSatin(InkstitchExtension):
             # millimeters before this one.
             if last_rung_center is not None and \
                (rung_center - last_rung_center).length() < 2 * PIXELS_PER_MM:
-                    continue
+                continue
             else:
                 last_rung_center = rung_center
 
@@ -269,7 +271,6 @@ class ConvertToSatin(InkstitchExtension):
 
         return rungs
 
-
     def satin_to_svg_node(self, rails, rungs, correction_transform):
         d = ""
         for path in chain(rails, rungs):
@@ -279,11 +280,11 @@ class ConvertToSatin(InkstitchExtension):
             d += " "
 
         return inkex.etree.Element(SVG_PATH_TAG,
-            {
-                "id": self.uniqueId("path"),
-                "style": "stroke:#000000;stroke-width:1px;fill:none",
-                "transform": correction_transform,
-                "d": d,
-                "embroider_satin_column": "true",
-            }
-        )
+                                   {
+                                       "id": self.uniqueId("path"),
+                                       "style": "stroke:#000000;stroke-width:1px;fill:none",
+                                       "transform": correction_transform,
+                                       "d": d,
+                                       "embroider_satin_column": "true",
+                                   }
+                                   )

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -11,6 +11,7 @@ from ..svg.tags import SVG_PATH_TAG
 from ..svg import get_correction_transform, PIXELS_PER_MM
 from ..elements import Stroke
 from ..utils import Point
+from ..i18n import _
 
 
 class SelfIntersectionError(Exception):

--- a/lib/extensions/embroider.py
+++ b/lib/extensions/embroider.py
@@ -1,7 +1,4 @@
-import sys
-import traceback
 import os
-import inkex
 
 from .base import InkstitchExtension
 from ..i18n import _

--- a/lib/extensions/flip.py
+++ b/lib/extensions/flip.py
@@ -7,6 +7,7 @@ from .base import InkstitchExtension
 from ..i18n import _
 from ..elements import SatinColumn
 
+
 class Flip(InkstitchExtension):
     def subpath_to_linestring(self, subpath):
         return shgeo.LineString()

--- a/lib/extensions/flip.py
+++ b/lib/extensions/flip.py
@@ -1,4 +1,3 @@
-import sys
 import inkex
 import cubicsuperpath
 from shapely import geometry as shgeo

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -1,15 +1,11 @@
 import os
-from os.path import realpath, dirname, join as path_join
-import sys
 from inkex import etree
 import inkex
 import pyembroidery
 
 from ..svg import PIXELS_PER_MM, render_stitch_plan
 from ..svg.tags import INKSCAPE_LABEL
-from ..i18n import _
-from ..stitch_plan import StitchPlan, ColorBlock
-from ..utils.io import save_stdout
+from ..stitch_plan import StitchPlan
 
 
 class Input(object):

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -28,12 +28,11 @@ class Input(object):
                                        trim=(command == pyembroidery.TRIM))
 
         extents = stitch_plan.extents
-        svg = etree.Element("svg", nsmap=inkex.NSS, attrib=
-                            {
-                                "width": str(extents[0] * 2),
-                                "height": str(extents[1] * 2),
-                                "viewBox": "0 0 %s %s" % (extents[0] * 2, extents[1] * 2),
-                            })
+        svg = etree.Element("svg", nsmap=inkex.NSS, attrib={
+            "width": str(extents[0] * 2),
+            "height": str(extents[1] * 2),
+            "viewBox": "0 0 %s %s" % (extents[0] * 2, extents[1] * 2),
+        })
         render_stitch_plan(svg, stitch_plan)
 
         # rename the Stitch Plan layer so that it doesn't get overwritten by Embroider

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -3,17 +3,12 @@
 import sys
 import traceback
 import os
-from os.path import realpath, dirname
 from glob import glob
-from threading import Thread
-import socket
-import errno
-import time
-import logging
 import wx
 import inkex
 
 from ..utils import guess_inkscape_config_path, get_bundled_dir
+from ..i18n import _
 
 
 class InstallerFrame(wx.Frame):
@@ -64,7 +59,7 @@ class InstallerFrame(wx.Frame):
         try:
             self.install_addons('palettes')
             self.install_addons('symbols')
-        except Exception as e:
+        except Exception:
             wx.MessageDialog(self,
                              _('Inkscape add-on installation failed') + ': \n' + traceback.format_exc(),
                              _('Installation Failed'),

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -27,8 +27,10 @@ class InstallerFrame(wx.Frame):
 
         text_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        text = _('Ink/Stitch can install files ("add-ons") that make it easier to use Inkscape to create machine embroidery designs.  These add-ons will be installed:') + \
-            "\n\n   • " + _("thread manufacturer color palettes") + "\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)")
+        text = (_('Ink/Stitch can install files ("add-ons") that make it easier to use Inkscape to create machine embroidery designs.  '
+                  'These add-ons will be installed:') +
+                "\n\n   • " + _("thread manufacturer color palettes") +
+                "\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)"))
 
         static_text = wx.StaticText(panel, label=text)
         font = wx.Font(12, wx.DEFAULT, wx.NORMAL, wx.NORMAL)

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -28,22 +28,21 @@ class InstallerFrame(wx.Frame):
         text_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
         text = _('Ink/Stitch can install files ("add-ons") that make it easier to use Inkscape to create machine embroidery designs.  These add-ons will be installed:') + \
-                 "\n\n   • " + _("thread manufacturer color palettes") + \
-                 "\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)")
+            "\n\n   • " + _("thread manufacturer color palettes") + "\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)")
 
         static_text = wx.StaticText(panel, label=text)
         font = wx.Font(12, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
         static_text.SetFont(font)
-        text_sizer.Add(static_text, proportion=0, flag=wx.ALL|wx.EXPAND, border=10)
-        sizer.Add(text_sizer, proportion=3, flag=wx.ALL|wx.EXPAND, border=0)
+        text_sizer.Add(static_text, proportion=0, flag=wx.ALL | wx.EXPAND, border=10)
+        sizer.Add(text_sizer, proportion=3, flag=wx.ALL | wx.EXPAND, border=0)
 
         buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
         install_button = wx.Button(panel, wx.ID_ANY, _("Install"))
         install_button.SetBitmap(wx.ArtProvider.GetBitmap(wx.ART_TICK_MARK))
-        buttons_sizer.Add(install_button, proportion=0, flag=wx.ALIGN_RIGHT|wx.ALL, border=5)
+        buttons_sizer.Add(install_button, proportion=0, flag=wx.ALIGN_RIGHT | wx.ALL, border=5)
         cancel_button = wx.Button(panel, wx.ID_CANCEL, _("Cancel"))
-        buttons_sizer.Add(cancel_button, proportion=0, flag=wx.ALIGN_RIGHT|wx.ALL, border=5)
-        sizer.Add(buttons_sizer, proportion=1, flag=wx.ALIGN_RIGHT|wx.ALIGN_BOTTOM)
+        buttons_sizer.Add(cancel_button, proportion=0, flag=wx.ALIGN_RIGHT | wx.ALL, border=5)
+        sizer.Add(buttons_sizer, proportion=1, flag=wx.ALIGN_RIGHT | wx.ALIGN_BOTTOM)
 
         panel.SetSizer(sizer)
         panel.Layout()
@@ -63,7 +62,7 @@ class InstallerFrame(wx.Frame):
         try:
             self.install_addons('palettes')
             self.install_addons('symbols')
-        except Exception, e:
+        except Exception as e:
             wx.MessageDialog(self,
                              _('Inkscape add-on installation failed') + ': \n' + traceback.format_exc(),
                              _('Installation Failed'),
@@ -96,6 +95,7 @@ class InstallerFrame(wx.Frame):
 
             for palette_file in files:
                 shutil.copy(palette_file, dest)
+
 
 class Install(inkex.Effect):
     def effect(self):

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -34,13 +34,13 @@ class LayerCommands(CommandsExtension):
             self.ensure_symbol(command)
 
             inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
-                                          {
-                                              "id": self.uniqueId("use"),
-                                              INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
-                                              XLINK_HREF: "#inkstitch_%s" % command,
-                                              "height": "100%",
-                                              "width": "100%",
-                                              "x": str(i * 20),
-                                              "y": "-10",
-                                              "transform": correction_transform
-                                          })
+                                   {
+                                      "id": self.uniqueId("use"),
+                                      INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+                                      XLINK_HREF: "#inkstitch_%s" % command,
+                                      "height": "100%",
+                                      "width": "100%",
+                                      "x": str(i * 20),
+                                      "y": "-10",
+                                      "transform": correction_transform
+                                   })

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -1,11 +1,9 @@
-import os
-import sys
 import inkex
 
 from .commands import CommandsExtension
 from ..commands import LAYER_COMMANDS, get_command_description
 from ..i18n import _
-from ..svg.tags import *
+from ..svg.tags import SVG_USE_TAG, INKSCAPE_LABEL, XLINK_HREF
 from ..svg import get_correction_transform
 
 
@@ -35,7 +33,7 @@ class LayerCommands(CommandsExtension):
         for i, command in enumerate(commands):
             self.ensure_symbol(command)
 
-            node = inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
+            inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
                                           {
                                               "id": self.uniqueId("use"),
                                               INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
@@ -46,5 +44,3 @@ class LayerCommands(CommandsExtension):
                                               "y": "-10",
                                               "transform": correction_transform
                                           })
-
-        namedview = self.document.xpath("//sodipodi:namedview", namespaces=inkex.NSS)

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -36,15 +36,15 @@ class LayerCommands(CommandsExtension):
             self.ensure_symbol(command)
 
             node = inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
-                {
-                    "id": self.uniqueId("use"),
-                    INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
-                    XLINK_HREF: "#inkstitch_%s" % command,
-                    "height": "100%",
-                    "width": "100%",
-                    "x": str(i * 20),
-                    "y": "-10",
-                    "transform": correction_transform
-                })
+                                          {
+                                              "id": self.uniqueId("use"),
+                                              INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+                                              XLINK_HREF: "#inkstitch_%s" % command,
+                                              "height": "100%",
+                                              "width": "100%",
+                                              "x": str(i * 20),
+                                              "y": "-10",
+                                              "transform": correction_transform
+                                          })
 
         namedview = self.document.xpath("//sodipodi:namedview", namespaces=inkex.NSS)

--- a/lib/extensions/object_commands.py
+++ b/lib/extensions/object_commands.py
@@ -1,16 +1,10 @@
-import os
-import sys
 import inkex
-import simpletransform
-import cubicsuperpath
 from random import random
-from shapely import geometry as shgeo
 
 from .commands import CommandsExtension
 from ..commands import OBJECT_COMMANDS, get_command_description
 from ..i18n import _
-from ..elements import SatinColumn
-from ..svg.tags import *
+from ..svg.tags import SVG_PATH_TAG, CONNECTION_START, CONNECTION_END, CONNECTOR_TYPE, INKSCAPE_LABEL, SVG_GROUP_TAG, SVG_USE_TAG, XLINK_HREF
 from ..svg import get_correction_transform
 
 

--- a/lib/extensions/object_commands.py
+++ b/lib/extensions/object_commands.py
@@ -24,18 +24,18 @@ class ObjectCommands(CommandsExtension):
         end_pos = element.shape.centroid
 
         path = inkex.etree.Element(SVG_PATH_TAG,
-            {
-                "id": self.uniqueId("connector"),
-                "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
-                "style": "stroke:#000000;stroke-width:1px;stroke-opacity:0.5;fill:none;",
-                CONNECTION_START: "#%s" % symbol.get('id'),
-                CONNECTION_END: "#%s" % element.node.get('id'),
-                CONNECTOR_TYPE: "polyline",
+                                   {
+                                       "id": self.uniqueId("connector"),
+                                       "d": "M %s,%s %s,%s" % (start_pos[0], start_pos[1], end_pos.x, end_pos.y),
+                                       "style": "stroke:#000000;stroke-width:1px;stroke-opacity:0.5;fill:none;",
+                                       CONNECTION_START: "#%s" % symbol.get('id'),
+                                       CONNECTION_END: "#%s" % element.node.get('id'),
+                                       CONNECTOR_TYPE: "polyline",
 
-                # l10n: the name of the line that connects a command to the object it applies to
-                INKSCAPE_LABEL: _("connector")
-            }
-        )
+                                       # l10n: the name of the line that connects a command to the object it applies to
+                                       INKSCAPE_LABEL: _("connector")
+                                   }
+                                   )
 
         symbol.getparent().insert(0, path)
 
@@ -75,26 +75,26 @@ class ObjectCommands(CommandsExtension):
             pos = self.get_command_pos(element, i, len(commands))
 
             group = inkex.etree.SubElement(element.node.getparent(), SVG_GROUP_TAG,
-                {
-                    "id": self.uniqueId("group"),
-                    INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
-                    "transform": get_correction_transform(element.node)
-                }
+                                           {
+                "id": self.uniqueId("group"),
+                INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+                "transform": get_correction_transform(element.node)
+            }
             )
 
             symbol = inkex.etree.SubElement(group, SVG_USE_TAG,
-                {
-                    "id": self.uniqueId("use"),
-                    XLINK_HREF: "#inkstitch_%s" % command,
-                    "height": "100%",
-                    "width": "100%",
-                    "x": str(pos.x),
-                    "y": str(pos.y),
+                                            {
+                                                "id": self.uniqueId("use"),
+                                                XLINK_HREF: "#inkstitch_%s" % command,
+                                                "height": "100%",
+                                                "width": "100%",
+                                                "x": str(pos.x),
+                                                "y": str(pos.y),
 
-                    # l10n: the name of a command symbol (example: scissors icon for trim command)
-                    INKSCAPE_LABEL: _("command marker"),
-                }
-            )
+                                                # l10n: the name of a command symbol (example: scissors icon for trim command)
+                                                INKSCAPE_LABEL: _("command marker"),
+                                            }
+                                            )
 
             self.add_connector(symbol, element)
 

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -1,15 +1,12 @@
 import sys
-import traceback
 import os
-import inkex
 import tempfile
 
 from .base import InkstitchExtension
 from ..i18n import _
 from ..output import write_embroidery_file
 from ..stitch_plan import patches_to_stitch_plan
-from ..svg import render_stitch_plan, PIXELS_PER_MM
-from ..utils.io import save_stdout
+from ..svg import PIXELS_PER_MM
 
 
 class Output(InkstitchExtension):

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -11,6 +11,7 @@ from ..stitch_plan import patches_to_stitch_plan
 from ..svg import render_stitch_plan, PIXELS_PER_MM
 from ..utils.io import save_stdout
 
+
 class Output(InkstitchExtension):
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self)

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 
 from .base import InkstitchExtension
-from ..i18n import _
 from ..output import write_embroidery_file
 from ..stitch_plan import patches_to_stitch_plan
 from ..svg import PIXELS_PER_MM

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -44,7 +44,7 @@ def load_defaults():
         with open(defaults_path(), 'r') as defaults_file:
             defaults = json.load(defaults_file)
             return defaults
-    except:
+    except BaseException:
         return {}
 
 
@@ -196,11 +196,11 @@ class PrintPreviewServer(Thread):
             threads = []
             for color_block in self.stitch_plan:
                 threads.append({
-                                'hex': color_block.color.hex_digits,
-                                'name': color_block.color.name,
-                                'manufacturer': color_block.color.manufacturer,
-                                'number': color_block.color.number,
-                             })
+                    'hex': color_block.color.hex_digits,
+                    'name': color_block.color.name,
+                    'manufacturer': color_block.color.manufacturer,
+                    'number': color_block.color.number,
+                })
 
             return jsonify(threads)
 
@@ -225,10 +225,10 @@ class PrintPreviewServer(Thread):
                     break
 
                 if self.last_request_time is not None and \
-                    (time.time() - self.last_request_time) > 3:
-                        self.stop()
-                        break
-        except:
+                        (time.time() - self.last_request_time) > 3:
+                    self.stop()
+                    break
+        except BaseException:
             # seems like sometimes this thread blows up during shutdown
             pass
 
@@ -244,7 +244,7 @@ class PrintPreviewServer(Thread):
         while True:
             try:
                 self.app.run(self.host, self.port, threaded=True)
-            except socket.error, e:
+            except socket.error as e:
                 if e.errno == errno.EADDRINUSE:
                     self.port += 1
                     continue
@@ -265,11 +265,11 @@ class PrintInfoFrame(wx.Frame):
         text = wx.StaticText(panel, label=_("A print preview has been opened in your web browser.  This window will stay open in order to communicate with the JavaScript code running in your browser.\n\nThis window will close after you close the print preview in your browser, or you can close it manually if necessary."))
         font = wx.Font(14, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
         text.SetFont(font)
-        sizer.Add(text, proportion=1, flag=wx.ALL|wx.EXPAND, border=20)
+        sizer.Add(text, proportion=1, flag=wx.ALL | wx.EXPAND, border=20)
 
         stop_button = wx.Button(panel, id=wx.ID_CLOSE)
         stop_button.Bind(wx.EVT_BUTTON, self.close_button_clicked)
-        sizer.Add(stop_button, proportion=0, flag=wx.ALIGN_CENTER|wx.ALL, border=10)
+        sizer.Add(stop_button, proportion=0, flag=wx.ALIGN_CENTER | wx.ALL, border=10)
 
         panel.SetSizer(sizer)
         panel.Layout()
@@ -289,13 +289,13 @@ class PrintInfoFrame(wx.Frame):
 
 class Print(InkstitchExtension):
     def build_environment(self):
-        if getattr( sys, 'frozen', False ) :
+        if getattr(sys, 'frozen', False):
             template_dir = os.path.join(sys._MEIPASS, "print", "templates")
         else:
             template_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "print", "templates"))
 
         env = Environment(
-            loader = FileSystemLoader(template_dir),
+            loader=FileSystemLoader(template_dir),
             autoescape=select_autoescape(['html', 'xml']),
             extensions=['jinja2.ext.i18n']
         )
@@ -308,8 +308,8 @@ class Print(InkstitchExtension):
     def strip_namespaces(self, svg):
         # namespace prefixes seem to trip up HTML, so get rid of them
         for element in svg.iter():
-            if element.tag[0]=='{':
-                element.tag = element.tag[element.tag.index('}',1) + 1:]
+            if element.tag[0] == '{':
+                element.tag = element.tag[element.tag.index('}', 1) + 1:]
 
     def render_svgs(self, stitch_plan, realistic=False):
         svg = deepcopy(self.document).getroot()
@@ -352,25 +352,25 @@ class Print(InkstitchExtension):
         template = env.get_template('index.html')
 
         return template.render(
-            view = {'client_overview': False, 'client_detailedview': False, 'operator_overview': True, 'operator_detailedview': True},
-            logo = {'src' : '', 'title' : 'LOGO'},
-            date = date.today(),
-            client = "",
-            job = {
-                    'title': '',
-                    'num_colors': stitch_plan.num_colors,
-                    'num_color_blocks': len(stitch_plan),
-                    'num_stops': stitch_plan.num_stops,
-                    'num_trims': stitch_plan.num_trims,
-                    'dimensions': stitch_plan.dimensions_mm,
-                    'num_stitches': stitch_plan.num_stitches,
-                    'estimated_time': '', # TODO
-                    'estimated_thread': '', # TODO
-                  },
-            svg_overview = overview_svg,
-            color_blocks = stitch_plan.color_blocks,
-            palettes = ThreadCatalog().palette_names(),
-            selected_palette = selected_palette,
+            view={'client_overview': False, 'client_detailedview': False, 'operator_overview': True, 'operator_detailedview': True},
+            logo={'src': '', 'title': 'LOGO'},
+            date=date.today(),
+            client="",
+            job={
+                'title': '',
+                'num_colors': stitch_plan.num_colors,
+                'num_color_blocks': len(stitch_plan),
+                'num_stops': stitch_plan.num_stops,
+                'num_trims': stitch_plan.num_trims,
+                'dimensions': stitch_plan.dimensions_mm,
+                'num_stitches': stitch_plan.num_stitches,
+                'estimated_time': '',  # TODO
+                'estimated_thread': '',  # TODO
+            },
+            svg_overview=overview_svg,
+            color_blocks=stitch_plan.color_blocks,
+            palettes=ThreadCatalog().palette_names(),
+            selected_palette=selected_palette,
         )
 
     def effect(self):
@@ -396,12 +396,12 @@ class Print(InkstitchExtension):
         html = self.render_html(stitch_plan, overview_svg, palette)
 
         print_server = PrintPreviewServer(
-                        html=html,
-                        metadata=self.get_inkstitch_metadata(),
-                        stitch_plan=stitch_plan,
-                        realistic_overview_svg=realistic_overview_svg,
-                        realistic_color_block_svgs=realistic_color_block_svgs
-                       )
+            html=html,
+            metadata=self.get_inkstitch_metadata(),
+            stitch_plan=stitch_plan,
+            realistic_overview_svg=realistic_overview_svg,
+            realistic_color_block_svgs=realistic_color_block_svgs
+        )
         print_server.start()
 
         time.sleep(1)

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -262,7 +262,10 @@ class PrintInfoFrame(wx.Frame):
         panel = wx.Panel(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
 
-        text = wx.StaticText(panel, label=_("A print preview has been opened in your web browser.  This window will stay open in order to communicate with the JavaScript code running in your browser.\n\nThis window will close after you close the print preview in your browser, or you can close it manually if necessary."))
+        message = _("A print preview has been opened in your web browser.  "
+                    "This window will stay open in order to communicate with the JavaScript code running in your browser.\n\n"
+                    "This window will close after you close the print preview in your browser, or you can close it manually if necessary.")
+        text = wx.StaticText(panel, label=message)
         font = wx.Font(14, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
         text.SetFont(font)
         sizer.Add(text, proportion=1, flag=wx.ALL | wx.EXPAND, border=20)

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -1,5 +1,4 @@
 import sys
-import traceback
 import os
 from threading import Thread
 import socket
@@ -13,15 +12,14 @@ import json
 import inkex
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from datetime import date
-import base64
 from flask import Flask, request, Response, send_from_directory, jsonify
 import webbrowser
 import requests
 
 from .base import InkstitchExtension
 from ..i18n import _, translation as inkstitch_translation
-from ..svg import PIXELS_PER_MM, render_stitch_plan
-from ..svg.tags import SVG_GROUP_TAG, INKSCAPE_GROUPMODE
+from ..svg import render_stitch_plan
+from ..svg.tags import INKSCAPE_GROUPMODE
 from ..stitch_plan import patches_to_stitch_plan
 from ..threads import ThreadCatalog
 

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -107,7 +107,7 @@ class PrintPreviewServer(Thread):
         else:
             self.resources_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', 'print', 'resources'))
 
-    def __setup_app(self):
+    def __setup_app(self):  # noqa: C901
         self.__set_resources_path()
         self.app = Flask(__name__)
 

--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -1,7 +1,5 @@
 import sys
-import traceback
 import os
-import inkex
 import tempfile
 from zipfile import ZipFile
 import pyembroidery
@@ -10,8 +8,7 @@ from .base import InkstitchExtension
 from ..i18n import _
 from ..output import write_embroidery_file
 from ..stitch_plan import patches_to_stitch_plan
-from ..svg import render_stitch_plan, PIXELS_PER_MM
-from ..utils.io import save_stdout
+from ..svg import PIXELS_PER_MM
 
 
 class Zip(InkstitchExtension):

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -9,7 +9,10 @@ locale_dir = None
 # Use N_ to mark a string for translation but _not_ immediately translate it.
 # reference: https://docs.python.org/3/library/gettext.html#deferred-translations
 # Makefile configures pybabel to treat N_() the same as _()
+
+
 def N_(message): return message
+
 
 def _set_locale_dir():
     global locale_dir
@@ -22,11 +25,13 @@ def _set_locale_dir():
 
     locale_dir = os.path.join(locale_dir, 'locales')
 
+
 def localize(languages=None):
     global translation, _
 
     translation = gettext.translation("inkstitch", locale_dir, fallback=True)
     _ = translation.gettext
+
 
 _set_locale_dir()
 localize()

--- a/lib/inx/generate.py
+++ b/lib/inx/generate.py
@@ -1,9 +1,7 @@
-import os
-
 from .inputs import generate_input_inx_files
 from .outputs import generate_output_inx_files
 from .extensions import generate_extension_inx_files
-from .utils import iterate_inx_locales, inx_path
+from .utils import iterate_inx_locales
 
 
 def generate_inx_files():

--- a/lib/inx/generate.py
+++ b/lib/inx/generate.py
@@ -5,6 +5,7 @@ from .outputs import generate_output_inx_files
 from .extensions import generate_extension_inx_files
 from .utils import iterate_inx_locales, inx_path
 
+
 def generate_inx_files():
     for locale in iterate_inx_locales():
         generate_input_inx_files()

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -3,7 +3,7 @@ import gettext
 from os.path import dirname
 from jinja2 import Environment, FileSystemLoader
 
-from ..i18n import translation as default_translation, locale_dir, _, N_
+from ..i18n import translation as default_translation, locale_dir, N_
 
 
 _top_path = dirname(dirname(dirname(os.path.realpath(__file__))))

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -13,10 +13,11 @@ template_path = os.path.join(_top_path, "templates")
 current_translation = default_translation
 current_locale = "en_US"
 
+
 def build_environment():
     env = Environment(
-        loader = FileSystemLoader(template_path),
-        autoescape = True,
+        loader=FileSystemLoader(template_path),
+        autoescape=True,
         extensions=['jinja2.ext.i18n']
     )
 
@@ -25,10 +26,12 @@ def build_environment():
 
     return env
 
+
 def write_inx_file(name, contents):
     inx_file_name = "inkstitch_%s_%s.inx" % (name, current_locale)
     with open(os.path.join(inx_path, inx_file_name), 'w') as inx_file:
         print >> inx_file, contents
+
 
 def iterate_inx_locales():
     global current_translation, current_locale

--- a/lib/output.py
+++ b/lib/output.py
@@ -19,6 +19,7 @@ def get_command(stitch):
     else:
         return pyembroidery.NEEDLE_AT
 
+
 def _string_to_floats(string):
     floats = string.split(',')
     return [float(num) for num in floats]
@@ -32,7 +33,7 @@ def get_origin(svg):
     all_guides = namedview.findall(inkex.addNS('guide', 'sodipodi'))
     label_attribute = inkex.addNS('label', 'inkscape')
     guides = [guide for guide in all_guides
-                    if guide.get(label_attribute, "").startswith("embroidery origin")]
+              if guide.get(label_attribute, "").startswith("embroidery origin")]
 
     # document size used below
     doc_size = list(get_doc_size(svg))
@@ -56,7 +57,6 @@ def get_origin(svg):
         # inkscape's Y axis is reversed from SVG's, and the guide is in inkscape coordinates
         position = Point(*_string_to_floats(guide.get('position')))
         position.y = doc_size[1] - position.y
-
 
         # This one baffles me.  I think inkscape might have gotten the order of
         # their vector wrong?
@@ -98,17 +98,17 @@ def write_embroidery_file(file_path, stitch_plan, svg):
     # also multiply by 10 to get tenths of a millimeter as required by pyembroidery
     scale = 10 / PIXELS_PER_MM
 
-    settings =  {
-                    # correct for the origin
-                    "translate": -origin,
+    settings = {
+        # correct for the origin
+        "translate": -origin,
 
-                    # convert from pixels to millimeters
-                    # also multiply by 10 to get tenths of a millimeter as required by pyembroidery
-                    "scale": (scale, scale),
+        # convert from pixels to millimeters
+        # also multiply by 10 to get tenths of a millimeter as required by pyembroidery
+        "scale": (scale, scale),
 
-                    # This forces a jump at the start of the design and after each trim,
-                    # even if we're close enough not to need one.
-                    "full_jump": True,
-                }
+        # This forces a jump at the start of the design and after each trim,
+        # even if we're close enough not to need one.
+        "full_jump": True,
+    }
 
     pyembroidery.write(pattern, file_path, settings)

--- a/lib/simulator.py
+++ b/lib/simulator.py
@@ -5,7 +5,7 @@ import colorsys
 from itertools import izip
 
 from .svg import PIXELS_PER_MM, color_block_to_point_lists
-
+from .i18n import _
 
 class EmbroiderySimulator(wx.Frame):
     def __init__(self, *args, **kwargs):

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -15,15 +15,15 @@ class Stitch(Point):
 
     def __repr__(self):
         return "Stitch(%s, %s, %s, %s, %s, %s, %s, %s%s)" % (self.x,
-                                                       self.y,
-                                                       self.color,
-                                                       "JUMP" if self.jump else " ",
-                                                       "TRIM" if self.trim else " ",
-                                                       "STOP" if self.stop else " ",
-                                                       "NO TIES" if self.no_ties else " ",
-                                                       "FAKE " if self.fake_color_change else "",
-                                                       "COLOR CHANGE" if self.color_change else " "
-                                                      )
+                                                             self.y,
+                                                             self.color,
+                                                             "JUMP" if self.jump else " ",
+                                                             "TRIM" if self.trim else " ",
+                                                             "STOP" if self.stop else " ",
+                                                             "NO TIES" if self.no_ties else " ",
+                                                             "FAKE " if self.fake_color_change else "",
+                                                             "COLOR CHANGE" if self.color_change else " "
+                                                             )
 
     def copy(self):
         return Stitch(self.x, self.y, self.color, self.jump, self.stop, self.trim, self.color_change, self.no_ties)

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -209,8 +209,8 @@ class ColorBlock(object):
                 # Don't consider jumps, stops, color changes, or trims as candidates for filtering
                 pass
             else:
-                l = (stitch - stitches[-1]).length()
-                if l <= 0.1 * PIXELS_PER_MM:
+                length = (stitch - stitches[-1]).length()
+                if length <= 0.1 * PIXELS_PER_MM:
                     # duplicate stitch, skip this one
                     continue
 

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -1,14 +1,12 @@
 import sys
 import shapely
 import networkx
-import math
 from itertools import groupby, izip
 from collections import deque
 
 from .fill import intersect_region_with_grating, row_num, stitch_row
 from .running_stitch import running_stitch
 from ..i18n import _
-from ..svg import PIXELS_PER_MM
 from ..utils.geometry import Point as InkstitchPoint, cut
 
 
@@ -367,7 +365,6 @@ def find_stitch_path(graph, segments, starting_point=None, ending_point=None):
     the order of most-recently-visited first.
     """
 
-    original_graph = graph
     graph = graph.copy()
     num_segments = len(segments)
     segments_visited = 0

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -37,6 +37,7 @@ def adjust_stagger(stitch, angle, row_spacing, max_stitch_length, staggers):
 
     return stitch - offset * east(angle)
 
+
 def stitch_row(stitches, beg, end, angle, row_spacing, max_stitch_length, staggers):
     # We want our stitches to look like this:
     #
@@ -162,6 +163,7 @@ def intersect_region_with_grating(shape, angle, row_spacing, end_row_spacing=Non
             current_row_y += row_spacing
 
     return rows
+
 
 def section_to_stitches(group_of_segments, angle, row_spacing, max_stitch_length, staggers):
     stitches = []

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -120,7 +120,7 @@ def intersect_region_with_grating(shape, angle, row_spacing, end_row_spacing=Non
 
     height = abs(end - start)
 
-    #print >> dbg, "grating:", start, end, height, row_spacing, end_row_spacing
+    # print >> dbg, "grating:", start, end, height, row_spacing, end_row_spacing
 
     # offset start slightly so that rows are always an even multiple of
     # row_spacing_px from the origin.  This makes it so that abutting

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -1,6 +1,5 @@
 import shapely
 import math
-import sys
 
 from ..svg import PIXELS_PER_MM
 from ..utils import cache, Point as InkstitchPoint
@@ -167,9 +166,7 @@ def intersect_region_with_grating(shape, angle, row_spacing, end_row_spacing=Non
 
 def section_to_stitches(group_of_segments, angle, row_spacing, max_stitch_length, staggers):
     stitches = []
-    first_segment = True
     swap = False
-    last_end = None
 
     for segment in group_of_segments:
         (beg, end) = segment
@@ -240,7 +237,7 @@ def pull_runs(rows, shape, row_spacing):
 
         # print >> sys.stderr, len(run)
         runs.append(run)
-        rows = [row for row in rows if len(row) > 0]
+        rows = [r for r in rows if len(r) > 0]
 
         count += 1
 

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -3,6 +3,7 @@ import cubicsuperpath
 
 from .units import get_viewbox_transform
 
+
 def apply_transforms(path, node):
     transform = get_node_transform(node)
 
@@ -10,6 +11,7 @@ def apply_transforms(path, node):
     simpletransform.applyTransformToPath(transform, path)
 
     return path
+
 
 def get_node_transform(node):
     # start with the identity transform
@@ -25,6 +27,7 @@ def get_node_transform(node):
     transform = simpletransform.composeTransform(viewbox_transform, transform)
 
     return transform
+
 
 def get_correction_transform(node, child=False):
     """Get a transform to apply to new siblings or children of this SVG node"""

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -1,5 +1,4 @@
 import simpletransform
-import cubicsuperpath
 
 from .units import get_viewbox_transform
 

--- a/lib/svg/realistic_rendering.py
+++ b/lib/svg/realistic_rendering.py
@@ -2,7 +2,7 @@ import simplepath
 import math
 
 from .units import PIXELS_PER_MM
-from ..utils import cache, Point
+from ..utils import Point
 
 # The stitch vector path looks like this:
 #  _______

--- a/lib/svg/realistic_rendering.py
+++ b/lib/svg/realistic_rendering.py
@@ -102,6 +102,7 @@ realistic_filter = """
     </filter>
 """
 
+
 def realistic_stitch(start, end):
     """Generate a stitch vector path given a start and end point."""
 

--- a/lib/svg/svg.py
+++ b/lib/svg/svg.py
@@ -1,4 +1,6 @@
-import simpletransform, simplestyle, inkex
+import simpletransform
+import simplestyle
+import inkex
 
 from .units import get_viewbox_transform
 from .tags import SVG_GROUP_TAG, INKSCAPE_LABEL, INKSCAPE_GROUPMODE, SVG_PATH_TAG, SVG_DEFS_TAG
@@ -11,13 +13,13 @@ def color_block_to_point_lists(color_block):
     point_lists = [[]]
 
     for stitch in color_block:
-         if stitch.trim:
-              if point_lists[-1]:
-                  point_lists.append([])
-                  continue
+        if stitch.trim:
+            if point_lists[-1]:
+                point_lists.append([])
+                continue
 
-         if not stitch.jump and not stitch.color_change:
-              point_lists[-1].append(stitch.as_tuple())
+        if not stitch.jump and not stitch.color_change:
+            point_lists[-1].append(stitch.as_tuple())
 
     return point_lists
 
@@ -51,12 +53,13 @@ def color_block_to_realistic_stitches(color_block, svg):
                         'stroke': 'none',
                         'filter': 'url(#realistic-stitch-filter)'
                     }),
-                'd': realistic_stitch(start, point),
-                'transform': get_correction_transform(svg)
-                }))
+                 'd': realistic_stitch(start, point),
+                 'transform': get_correction_transform(svg)
+                 }))
             start = point
 
     return paths
+
 
 def color_block_to_paths(color_block, svg):
     paths = []
@@ -68,19 +71,20 @@ def color_block_to_paths(color_block, svg):
             SVG_PATH_TAG,
             {'style': simplestyle.formatStyle(
                 {'stroke': color,
-                'stroke-width': "0.4",
-                'fill': 'none'}),
-            'd': "M" + " ".join(" ".join(str(coord) for coord in point) for point in point_list),
-            'transform': get_correction_transform(svg),
-            'embroider_manual_stitch': 'true',
-            'embroider_trim_after': 'true',
-            }))
+                 'stroke-width': "0.4",
+                 'fill': 'none'}),
+             'd': "M" + " ".join(" ".join(str(coord) for coord in point) for point in point_list),
+             'transform': get_correction_transform(svg),
+             'embroider_manual_stitch': 'true',
+             'embroider_trim_after': 'true',
+             }))
 
     # no need to trim at the end of a thread color
     if paths:
         paths[-1].attrib.pop('embroider_trim_after')
 
     return paths
+
 
 def render_stitch_plan(svg, stitch_plan, realistic=False):
     layer = svg.find(".//*[@id='__inkstitch_stitch_plan__']")

--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -6,8 +6,9 @@ from ..utils import cache
 PIXELS_PER_MM = 96 / 25.4
 
 # cribbed from inkscape-silhouette
-def parse_length_with_units( str ):
 
+
+def parse_length_with_units(str):
     '''
     Parse an SVG value which may or may not have units attached
     This version is greatly simplified in that it only allows: no units,
@@ -39,8 +40,8 @@ def parse_length_with_units( str ):
         u = '%'
         s = s[:-1]
     try:
-        v = float( s )
-    except:
+        v = float(s)
+    except BaseException:
         raise ValueError(_("parseLengthWithUnits: unknown unit %s") % s)
 
     return v, u
@@ -53,16 +54,16 @@ def convert_length(length):
         return value
 
     if units == 'pt':
-       value /= 72
-       units = 'in'
+        value /= 72
+        units = 'in'
 
     if units == 'pc':
-       value /= 6
-       units = 'in'
+        value /= 6
+        units = 'in'
 
     if units == 'cm':
-       value *= 10
-       units = 'mm'
+        value *= 10
+        units = 'mm'
 
     if units == 'mm':
         value = value / 25.4
@@ -74,6 +75,7 @@ def convert_length(length):
         return value * 96
 
     raise ValueError(_("Unknown unit: %s") % units)
+
 
 @cache
 def get_viewbox(svg):
@@ -95,6 +97,7 @@ def get_doc_size(svg):
     doc_height = convert_length(height)
 
     return doc_width, doc_height
+
 
 @cache
 def get_viewbox_transform(node):

--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -1,6 +1,7 @@
 import simpletransform
 
 from ..utils import cache
+from ..i18n import _
 
 # modern versions of Inkscape use 96 pixels per inch as per the CSS standard
 PIXELS_PER_MM = 96 / 25.4

--- a/lib/threads/catalog.py
+++ b/lib/threads/catalog.py
@@ -85,7 +85,9 @@ class _ThreadCatalog(Sequence):
             if palette.name == name:
                 return palette
 
+
 _catalog = None
+
 
 def ThreadCatalog():
     """Singleton _ThreadCatalog factory"""

--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -3,6 +3,7 @@ import re
 import colorsys
 from pyembroidery.EmbThread import EmbThread
 
+
 class ThreadColor(object):
     hex_str_re = re.compile('#([0-9a-z]{3}|[0-9a-z]{6})', re.I)
 

--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -41,8 +41,11 @@ class ThreadPalette(Set):
             if self.name.lower().startswith('name: ink/stitch: '):
                 self.name = self.name[18:]
 
-            columns_line = palette.readline()
-            headers_line = palette.readline()
+            # number of columns
+            palette.readline()
+
+            # headers
+            palette.readline()
 
             for line in palette:
                 fields = line.split("\t", 3)

--- a/lib/utils/cache.py
+++ b/lib/utils/cache.py
@@ -4,5 +4,7 @@ except ImportError:
     from backports.functools_lru_cache import lru_cache
 
 # simplify use of lru_cache decorator
+
+
 def cache(*args, **kwargs):
     return lru_cache(maxsize=None)(*args, **kwargs)

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -17,13 +17,14 @@ def cut(line, distance):
         last_point = p
         if traveled == distance:
             return [
-                LineString(coords[:i+1]),
+                LineString(coords[:i + 1]),
                 LineString(coords[i:])]
         if traveled > distance:
             cp = line.interpolate(distance)
             return [
                 LineString(coords[:i] + [(cp.x, cp.y)]),
                 LineString([(cp.x, cp.y)] + coords[i:])]
+
 
 def cut_path(points, length):
     """Return a subsection of at the start of the path that is length units long.

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -80,7 +80,7 @@ class Point:
         if isinstance(other, (int, float)):
             return self * (1.0 / other)
         else:
-            raise ValueErorr("cannot divide Point by %s" % type(other))
+            raise ValueError("cannot divide Point by %s" % type(other))
 
     def __repr__(self):
         return "Point(%s,%s)" % (self.x, self.y)

--- a/lib/utils/inkscape.py
+++ b/lib/utils/inkscape.py
@@ -1,6 +1,7 @@
 from os.path import realpath, expanduser, join as path_join
 import sys
 
+
 def guess_inkscape_config_path():
     if getattr(sys, 'frozen', None):
         path = realpath(path_join(sys._MEIPASS, "..", "..", ".."))

--- a/lib/utils/io.py
+++ b/lib/utils/io.py
@@ -19,6 +19,8 @@ def restore_stderr():
 
 # It's probably possible to generalize this code, but when I tried,
 # the result was incredibly unreadable.
+
+
 def save_stdout():
     null = open(os.devnull, 'w')
     sys.stdout_dup = os.dup(sys.stdout.fileno())

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-21 20:32-0400\n"
+"POT-Creation-Date: 2018-08-21 20:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -156,35 +156,35 @@ msgid ""
 "enable flip, stitching goes from right-to-left instead of left-to-right."
 msgstr ""
 
-#: lib/elements/fill.py:55
+#: lib/elements/fill.py:56
 msgid "Spacing between rows"
 msgstr ""
 
-#: lib/elements/fill.py:56
+#: lib/elements/fill.py:57
 msgid "Distance between rows of stitches."
 msgstr ""
 
-#: lib/elements/fill.py:69
+#: lib/elements/fill.py:70
 msgid "Maximum fill stitch length"
 msgstr ""
 
-#: lib/elements/fill.py:70
+#: lib/elements/fill.py:71
 msgid ""
 "The length of each stitch in a row.  Shorter stitch may be used at the "
 "start or end of a row."
 msgstr ""
 
-#: lib/elements/fill.py:79
+#: lib/elements/fill.py:80
 msgid "Stagger rows this many times before repeating"
 msgstr ""
 
-#: lib/elements/fill.py:80
+#: lib/elements/fill.py:81
 msgid ""
 "Setting this dictates how many rows apart the stitches will be before "
 "they fall in the same column position."
 msgstr ""
 
-#: lib/elements/fill.py:113
+#: lib/elements/fill.py:114
 #, python-format
 msgid ""
 "shape %s is so small that it cannot be filled with stitches.  Please make"
@@ -203,7 +203,7 @@ msgstr ""
 msgid "\"E\" stitch"
 msgstr ""
 
-#: lib/elements/satin_column.py:32 lib/elements/stroke.py:53
+#: lib/elements/satin_column.py:32 lib/elements/stroke.py:55
 msgid "Zig-zag spacing (peak-to-peak)"
 msgstr ""
 
@@ -222,93 +222,93 @@ msgid ""
 "penetrations outward from the center of the satin column."
 msgstr ""
 
-#: lib/elements/satin_column.py:56
+#: lib/elements/satin_column.py:57
 msgid "Contour underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:56 lib/elements/satin_column.py:63
-#: lib/elements/satin_column.py:72
+#: lib/elements/satin_column.py:57 lib/elements/satin_column.py:64
+#: lib/elements/satin_column.py:73
 msgid "Contour Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:63 lib/elements/satin_column.py:87
+#: lib/elements/satin_column.py:64 lib/elements/satin_column.py:88
 msgid "Stitch length"
 msgstr ""
 
-#: lib/elements/satin_column.py:69
+#: lib/elements/satin_column.py:70
 msgid "Contour underlay inset amount"
 msgstr ""
 
-#: lib/elements/satin_column.py:70
+#: lib/elements/satin_column.py:71
 msgid ""
 "Shrink the outline, to prevent the underlay from showing around the "
 "outside of the satin column."
 msgstr ""
 
-#: lib/elements/satin_column.py:80
+#: lib/elements/satin_column.py:81
 msgid "Center-walk underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:80 lib/elements/satin_column.py:87
+#: lib/elements/satin_column.py:81 lib/elements/satin_column.py:88
 msgid "Center-Walk Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:92
+#: lib/elements/satin_column.py:93
 msgid "Zig-zag underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:92 lib/elements/satin_column.py:101
-#: lib/elements/satin_column.py:112
+#: lib/elements/satin_column.py:93 lib/elements/satin_column.py:102
+#: lib/elements/satin_column.py:113
 msgid "Zig-zag Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:98
+#: lib/elements/satin_column.py:99
 msgid "Zig-Zag spacing (peak-to-peak)"
 msgstr ""
 
-#: lib/elements/satin_column.py:99
+#: lib/elements/satin_column.py:100
 msgid "Distance between peaks of the zig-zags."
 msgstr ""
 
-#: lib/elements/satin_column.py:109
+#: lib/elements/satin_column.py:110
 msgid "Inset amount"
 msgstr ""
 
-#: lib/elements/satin_column.py:110
+#: lib/elements/satin_column.py:111
 msgid "default: half of contour underlay inset"
 msgstr ""
 
-#: lib/elements/satin_column.py:147
+#: lib/elements/satin_column.py:148
 #, python-format
 msgid "satin column: %(id)s: at least two subpaths required (%(num)d found)"
 msgstr ""
 
-#: lib/elements/satin_column.py:172
+#: lib/elements/satin_column.py:173
 msgid ""
 "One or more rails crosses itself, and this is not allowed.  Please split "
 "into multiple satin columns."
 msgstr ""
 
-#: lib/elements/satin_column.py:179
+#: lib/elements/satin_column.py:180
 msgid "satin column: One or more of the rungs doesn't intersect both rails."
 msgstr ""
 
-#: lib/elements/satin_column.py:180 lib/elements/satin_column.py:183
+#: lib/elements/satin_column.py:181 lib/elements/satin_column.py:184
 msgid "Each rail should intersect both rungs once."
 msgstr ""
 
-#: lib/elements/satin_column.py:182
+#: lib/elements/satin_column.py:183
 msgid ""
 "satin column: One or more of the rungs intersects the rails more than "
 "once."
 msgstr ""
 
-#: lib/elements/satin_column.py:223
+#: lib/elements/satin_column.py:224
 #, python-format
 msgid "satin column: object %s has a fill (but should not)"
 msgstr ""
 
-#: lib/elements/satin_column.py:227
+#: lib/elements/satin_column.py:228
 #, python-format
 msgid ""
 "satin column: object %(id)s has two paths with an unequal number of "
@@ -338,29 +338,29 @@ msgid ""
 "stitch, etc.  Only applies to running stitch."
 msgstr ""
 
-#: lib/elements/stroke.py:54
+#: lib/elements/stroke.py:56
 msgid "Length of stitches in zig-zag mode."
 msgstr ""
 
-#: lib/elements/stroke.py:65
+#: lib/elements/stroke.py:67
 msgid "Repeats"
 msgstr ""
 
-#: lib/elements/stroke.py:66
+#: lib/elements/stroke.py:68
 msgid "Defines how many times to run down and back along the path."
 msgstr ""
 
-#: lib/elements/stroke.py:90
+#: lib/elements/stroke.py:92
 msgid "Manual stitch placement"
 msgstr ""
 
-#: lib/elements/stroke.py:91
+#: lib/elements/stroke.py:93
 msgid ""
 "Stitch every node in the path.  Stitch length and zig-zag spacing are "
 "ignored."
 msgstr ""
 
-#: lib/elements/stroke.py:125
+#: lib/elements/stroke.py:127
 msgid ""
 "Legacy running stitch setting detected!\n"
 "\n"
@@ -416,45 +416,45 @@ msgid ""
 "installed:"
 msgstr ""
 
-#: lib/extensions/install.py:31
+#: lib/extensions/install.py:32
 msgid "thread manufacturer color palettes"
 msgstr ""
 
-#: lib/extensions/install.py:31
+#: lib/extensions/install.py:33
 msgid "Ink/Stitch visual commands (Object -> Symbols...)"
 msgstr ""
 
-#: lib/extensions/install.py:40
+#: lib/extensions/install.py:42
 msgid "Install"
 msgstr ""
 
-#: lib/extensions/install.py:43 lib/extensions/params.py:380
+#: lib/extensions/install.py:45 lib/extensions/params.py:380
 msgid "Cancel"
 msgstr ""
 
-#: lib/extensions/install.py:57
+#: lib/extensions/install.py:59
 msgid "Choose Inkscape directory"
 msgstr ""
 
-#: lib/extensions/install.py:67
+#: lib/extensions/install.py:69
 msgid "Inkscape add-on installation failed"
 msgstr ""
 
-#: lib/extensions/install.py:68
+#: lib/extensions/install.py:70
 msgid "Installation Failed"
 msgstr ""
 
-#: lib/extensions/install.py:72
+#: lib/extensions/install.py:74
 msgid ""
 "Inkscape add-on files have been installed.  Please restart Inkscape to "
 "load the new add-ons."
 msgstr ""
 
-#: lib/extensions/install.py:73
+#: lib/extensions/install.py:75
 msgid "Installation Completed"
 msgstr ""
 
-#: lib/extensions/install.py:103
+#: lib/extensions/install.py:105
 msgid "Ink/Stitch Add-ons Installer"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgid ""
 " or you can close it manually if necessary."
 msgstr ""
 
-#: lib/extensions/print_pdf.py:411
+#: lib/extensions/print_pdf.py:414
 msgid "Ink/Stitch Print"
 msgstr ""
 

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-20 20:42-0400\n"
+"POT-Creation-Date: 2018-08-21 20:32-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -146,45 +146,45 @@ msgid ""
 "Negative angles are allowed."
 msgstr ""
 
-#: lib/elements/fill.py:45
+#: lib/elements/fill.py:46
 msgid "Flip fill (start right-to-left)"
 msgstr ""
 
-#: lib/elements/fill.py:46
+#: lib/elements/fill.py:47
 msgid ""
 "The flip option can help you with routing your stitch path.  When you "
 "enable flip, stitching goes from right-to-left instead of left-to-right."
 msgstr ""
 
-#: lib/elements/fill.py:54
+#: lib/elements/fill.py:55
 msgid "Spacing between rows"
 msgstr ""
 
-#: lib/elements/fill.py:55
+#: lib/elements/fill.py:56
 msgid "Distance between rows of stitches."
 msgstr ""
 
-#: lib/elements/fill.py:68
+#: lib/elements/fill.py:69
 msgid "Maximum fill stitch length"
 msgstr ""
 
-#: lib/elements/fill.py:69
+#: lib/elements/fill.py:70
 msgid ""
 "The length of each stitch in a row.  Shorter stitch may be used at the "
 "start or end of a row."
 msgstr ""
 
-#: lib/elements/fill.py:78
+#: lib/elements/fill.py:79
 msgid "Stagger rows this many times before repeating"
 msgstr ""
 
-#: lib/elements/fill.py:79
+#: lib/elements/fill.py:80
 msgid ""
 "Setting this dictates how many rows apart the stitches will be before "
 "they fall in the same column position."
 msgstr ""
 
-#: lib/elements/fill.py:112
+#: lib/elements/fill.py:113
 #, python-format
 msgid ""
 "shape %s is so small that it cannot be filled with stitches.  Please make"
@@ -203,7 +203,7 @@ msgstr ""
 msgid "\"E\" stitch"
 msgstr ""
 
-#: lib/elements/satin_column.py:32 lib/elements/stroke.py:52
+#: lib/elements/satin_column.py:32 lib/elements/stroke.py:53
 msgid "Zig-zag spacing (peak-to-peak)"
 msgstr ""
 
@@ -211,74 +211,74 @@ msgstr ""
 msgid "Peak-to-peak distance between zig-zags."
 msgstr ""
 
-#: lib/elements/satin_column.py:43
+#: lib/elements/satin_column.py:44
 msgid "Pull compensation"
 msgstr ""
 
-#: lib/elements/satin_column.py:44
+#: lib/elements/satin_column.py:45
 msgid ""
 "Satin stitches pull the fabric together, resulting in a column narrower "
 "than you draw in Inkscape.  This setting expands each pair of needle "
 "penetrations outward from the center of the satin column."
 msgstr ""
 
-#: lib/elements/satin_column.py:55
+#: lib/elements/satin_column.py:56
 msgid "Contour underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:55 lib/elements/satin_column.py:62
-#: lib/elements/satin_column.py:71
+#: lib/elements/satin_column.py:56 lib/elements/satin_column.py:63
+#: lib/elements/satin_column.py:72
 msgid "Contour Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:62 lib/elements/satin_column.py:86
+#: lib/elements/satin_column.py:63 lib/elements/satin_column.py:87
 msgid "Stitch length"
 msgstr ""
 
-#: lib/elements/satin_column.py:68
+#: lib/elements/satin_column.py:69
 msgid "Contour underlay inset amount"
 msgstr ""
 
-#: lib/elements/satin_column.py:69
+#: lib/elements/satin_column.py:70
 msgid ""
 "Shrink the outline, to prevent the underlay from showing around the "
 "outside of the satin column."
 msgstr ""
 
-#: lib/elements/satin_column.py:79
+#: lib/elements/satin_column.py:80
 msgid "Center-walk underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:79 lib/elements/satin_column.py:86
+#: lib/elements/satin_column.py:80 lib/elements/satin_column.py:87
 msgid "Center-Walk Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:91
+#: lib/elements/satin_column.py:92
 msgid "Zig-zag underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:91 lib/elements/satin_column.py:100
-#: lib/elements/satin_column.py:111
+#: lib/elements/satin_column.py:92 lib/elements/satin_column.py:101
+#: lib/elements/satin_column.py:112
 msgid "Zig-zag Underlay"
 msgstr ""
 
-#: lib/elements/satin_column.py:97
+#: lib/elements/satin_column.py:98
 msgid "Zig-Zag spacing (peak-to-peak)"
 msgstr ""
 
-#: lib/elements/satin_column.py:98
+#: lib/elements/satin_column.py:99
 msgid "Distance between peaks of the zig-zags."
 msgstr ""
 
-#: lib/elements/satin_column.py:108
+#: lib/elements/satin_column.py:109
 msgid "Inset amount"
 msgstr ""
 
-#: lib/elements/satin_column.py:109
+#: lib/elements/satin_column.py:110
 msgid "default: half of contour underlay inset"
 msgstr ""
 
-#: lib/elements/satin_column.py:146
+#: lib/elements/satin_column.py:147
 #, python-format
 msgid "satin column: %(id)s: at least two subpaths required (%(num)d found)"
 msgstr ""
@@ -293,22 +293,22 @@ msgstr ""
 msgid "satin column: One or more of the rungs doesn't intersect both rails."
 msgstr ""
 
-#: lib/elements/satin_column.py:179 lib/elements/satin_column.py:181
+#: lib/elements/satin_column.py:180 lib/elements/satin_column.py:183
 msgid "Each rail should intersect both rungs once."
 msgstr ""
 
-#: lib/elements/satin_column.py:181
+#: lib/elements/satin_column.py:182
 msgid ""
 "satin column: One or more of the rungs intersects the rails more than "
 "once."
 msgstr ""
 
-#: lib/elements/satin_column.py:222
+#: lib/elements/satin_column.py:223
 #, python-format
 msgid "satin column: object %s has a fill (but should not)"
 msgstr ""
 
-#: lib/elements/satin_column.py:226
+#: lib/elements/satin_column.py:227
 #, python-format
 msgid ""
 "satin column: object %(id)s has two paths with an unequal number of "
@@ -327,40 +327,40 @@ msgstr ""
 msgid "Length of stitches in running stitch mode."
 msgstr ""
 
-#: lib/elements/stroke.py:42
+#: lib/elements/stroke.py:43
 msgid "Bean stitch number of repeats"
 msgstr ""
 
-#: lib/elements/stroke.py:43
+#: lib/elements/stroke.py:44
 msgid ""
 "Backtrack each stitch this many times.  A value of 1 would triple each "
 "stitch (forward, back, forward).  A value of 2 would quintuple each "
 "stitch, etc.  Only applies to running stitch."
 msgstr ""
 
-#: lib/elements/stroke.py:53
+#: lib/elements/stroke.py:54
 msgid "Length of stitches in zig-zag mode."
 msgstr ""
 
-#: lib/elements/stroke.py:64
+#: lib/elements/stroke.py:65
 msgid "Repeats"
 msgstr ""
 
-#: lib/elements/stroke.py:65
+#: lib/elements/stroke.py:66
 msgid "Defines how many times to run down and back along the path."
 msgstr ""
 
-#: lib/elements/stroke.py:89
+#: lib/elements/stroke.py:90
 msgid "Manual stitch placement"
 msgstr ""
 
-#: lib/elements/stroke.py:90
+#: lib/elements/stroke.py:91
 msgid ""
 "Stitch every node in the path.  Stitch length and zig-zag spacing are "
 "ignored."
 msgstr ""
 
-#: lib/elements/stroke.py:124
+#: lib/elements/stroke.py:125
 msgid ""
 "Legacy running stitch setting detected!\n"
 "\n"
@@ -391,7 +391,7 @@ msgstr ""
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:54
+#: lib/extensions/convert_to_satin.py:55
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "
@@ -405,7 +405,7 @@ msgid ""
 "Seeing a 'no such option' message?  Please restart Inkscape to fix."
 msgstr ""
 
-#: lib/extensions/flip.py:35
+#: lib/extensions/flip.py:36
 msgid "Please select one or more satin columns to flip."
 msgstr ""
 
@@ -420,37 +420,37 @@ msgstr ""
 msgid "thread manufacturer color palettes"
 msgstr ""
 
-#: lib/extensions/install.py:32
+#: lib/extensions/install.py:31
 msgid "Ink/Stitch visual commands (Object -> Symbols...)"
 msgstr ""
 
-#: lib/extensions/install.py:41
+#: lib/extensions/install.py:40
 msgid "Install"
 msgstr ""
 
-#: lib/extensions/install.py:44 lib/extensions/params.py:380
+#: lib/extensions/install.py:43 lib/extensions/params.py:380
 msgid "Cancel"
 msgstr ""
 
-#: lib/extensions/install.py:58
+#: lib/extensions/install.py:57
 msgid "Choose Inkscape directory"
 msgstr ""
 
-#: lib/extensions/install.py:68
+#: lib/extensions/install.py:67
 msgid "Inkscape add-on installation failed"
 msgstr ""
 
-#: lib/extensions/install.py:69
+#: lib/extensions/install.py:68
 msgid "Installation Failed"
 msgstr ""
 
-#: lib/extensions/install.py:73
+#: lib/extensions/install.py:72
 msgid ""
 "Inkscape add-on files have been installed.  Please restart Inkscape to "
 "load the new add-ons."
 msgstr ""
 
-#: lib/extensions/install.py:74
+#: lib/extensions/install.py:73
 msgid "Installation Completed"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgstr ""
 #. If you translate this string, that will tell Ink/Stitch to
 #. generate menu items for this language in Inkscape's "Extensions"
 #. menu.
-#: lib/inx/utils.py:43
+#: lib/inx/utils.py:46
 msgid "Generate INX files"
 msgstr ""
 
@@ -663,28 +663,28 @@ msgstr ""
 msgid "Stitch #"
 msgstr ""
 
-#: lib/stitches/auto_fill.py:168
+#: lib/stitches/auto_fill.py:169
 msgid ""
 "Unable to autofill.  This most often happens because your shape is made "
 "up of multiple sections that aren't connected."
 msgstr ""
 
-#: lib/stitches/auto_fill.py:393
+#: lib/stitches/auto_fill.py:398
 msgid ""
 "Unexpected error while generating fill stitches. Please send your SVG "
 "file to lexelby@github."
 msgstr ""
 
-#: lib/svg/svg.py:90
+#: lib/svg/svg.py:94
 msgid "Stitch Plan"
 msgstr ""
 
-#: lib/svg/units.py:44
+#: lib/svg/units.py:45
 #, python-format
 msgid "parseLengthWithUnits: unknown unit %s"
 msgstr ""
 
-#: lib/svg/units.py:76
+#: lib/svg/units.py:77
 #, python-format
 msgid "Unknown unit: %s"
 msgstr ""

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-21 20:50-0400\n"
+"POT-Creation-Date: 2018-08-21 21:43-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,7 +119,7 @@ msgid ""
 "shapes."
 msgstr ""
 
-#: lib/elements/element.py:232
+#: lib/elements/element.py:230
 #, python-format
 msgid "%(id)s has more than one command of type '%(command)s' linked to it"
 msgstr ""
@@ -381,106 +381,106 @@ msgstr ""
 msgid "Tip: use Path -> Object to Path to convert non-paths."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:28
+#: lib/extensions/convert_to_satin.py:29
 msgid "Please select at least one line to convert to a satin column."
 msgstr ""
 
 #. : Convert To Satin extension, user selected one or more objects that were
 #. not lines.
-#: lib/extensions/convert_to_satin.py:33
+#: lib/extensions/convert_to_satin.py:34
 msgid "Only simple lines may be converted to satin columns."
 msgstr ""
 
-#: lib/extensions/convert_to_satin.py:55
+#: lib/extensions/convert_to_satin.py:56
 #, python-format
 msgid ""
 "Cannot convert %s to a satin column because it intersects itself.  Try "
 "breaking it up into multiple paths."
 msgstr ""
 
-#: lib/extensions/embroider.py:41
+#: lib/extensions/embroider.py:38
 msgid ""
 "\n"
 "\n"
 "Seeing a 'no such option' message?  Please restart Inkscape to fix."
 msgstr ""
 
-#: lib/extensions/flip.py:36
+#: lib/extensions/flip.py:35
 msgid "Please select one or more satin columns to flip."
 msgstr ""
 
-#: lib/extensions/install.py:30
+#: lib/extensions/install.py:25
 msgid ""
 "Ink/Stitch can install files (\"add-ons\") that make it easier to use "
 "Inkscape to create machine embroidery designs.  These add-ons will be "
 "installed:"
 msgstr ""
 
-#: lib/extensions/install.py:32
+#: lib/extensions/install.py:27
 msgid "thread manufacturer color palettes"
 msgstr ""
 
-#: lib/extensions/install.py:33
+#: lib/extensions/install.py:28
 msgid "Ink/Stitch visual commands (Object -> Symbols...)"
 msgstr ""
 
-#: lib/extensions/install.py:42
+#: lib/extensions/install.py:37
 msgid "Install"
 msgstr ""
 
-#: lib/extensions/install.py:45 lib/extensions/params.py:380
+#: lib/extensions/install.py:40 lib/extensions/params.py:380
 msgid "Cancel"
 msgstr ""
 
-#: lib/extensions/install.py:59
+#: lib/extensions/install.py:54
 msgid "Choose Inkscape directory"
 msgstr ""
 
-#: lib/extensions/install.py:69
+#: lib/extensions/install.py:64
 msgid "Inkscape add-on installation failed"
 msgstr ""
 
-#: lib/extensions/install.py:70
+#: lib/extensions/install.py:65
 msgid "Installation Failed"
 msgstr ""
 
-#: lib/extensions/install.py:74
+#: lib/extensions/install.py:69
 msgid ""
 "Inkscape add-on files have been installed.  Please restart Inkscape to "
 "load the new add-ons."
 msgstr ""
 
-#: lib/extensions/install.py:75
+#: lib/extensions/install.py:70
 msgid "Installation Completed"
 msgstr ""
 
-#: lib/extensions/install.py:105
+#: lib/extensions/install.py:100
 msgid "Ink/Stitch Add-ons Installer"
 msgstr ""
 
-#: lib/extensions/layer_commands.py:29
+#: lib/extensions/layer_commands.py:27
 msgid "Please choose one or more commands to add."
 msgstr ""
 
-#: lib/extensions/layer_commands.py:41 lib/extensions/object_commands.py:80
+#: lib/extensions/layer_commands.py:39 lib/extensions/object_commands.py:74
 msgid "Ink/Stitch Command"
 msgstr ""
 
 #. : the name of the line that connects a command to the object it applies to
-#: lib/extensions/object_commands.py:36
+#: lib/extensions/object_commands.py:30
 msgid "connector"
 msgstr ""
 
 #. : the name of a command symbol (example: scissors icon for trim command)
-#: lib/extensions/object_commands.py:95
+#: lib/extensions/object_commands.py:89
 msgid "command marker"
 msgstr ""
 
-#: lib/extensions/object_commands.py:106
+#: lib/extensions/object_commands.py:100
 msgid "Please select one or more objects to which to attach commands."
 msgstr ""
 
-#: lib/extensions/object_commands.py:114
+#: lib/extensions/object_commands.py:108
 msgid "Please choose one or more commands to attach."
 msgstr ""
 
@@ -578,15 +578,15 @@ msgid ""
 "\"Overwrite\""
 msgstr ""
 
-#: lib/extensions/print_pdf.py:134
+#: lib/extensions/print_pdf.py:132
 msgid "Closing..."
 msgstr ""
 
-#: lib/extensions/print_pdf.py:134
+#: lib/extensions/print_pdf.py:132
 msgid "It is safe to close this window now."
 msgstr ""
 
-#: lib/extensions/print_pdf.py:265
+#: lib/extensions/print_pdf.py:263
 msgid ""
 "A print preview has been opened in your web browser.  This window will "
 "stay open in order to communicate with the JavaScript code running in "
@@ -596,7 +596,7 @@ msgid ""
 " or you can close it manually if necessary."
 msgstr ""
 
-#: lib/extensions/print_pdf.py:414
+#: lib/extensions/print_pdf.py:412
 msgid "Ink/Stitch Print"
 msgstr ""
 
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Embroidery Simulation"
 msgstr ""
 
-#: lib/extensions/zip.py:52
+#: lib/extensions/zip.py:49
 msgid "No embroidery file formats selected."
 msgstr ""
 
@@ -663,13 +663,13 @@ msgstr ""
 msgid "Stitch #"
 msgstr ""
 
-#: lib/stitches/auto_fill.py:169
+#: lib/stitches/auto_fill.py:167
 msgid ""
 "Unable to autofill.  This most often happens because your shape is made "
 "up of multiple sections that aren't connected."
 msgstr ""
 
-#: lib/stitches/auto_fill.py:398
+#: lib/stitches/auto_fill.py:395
 msgid ""
 "Unexpected error while generating fill stitches. Please send your SVG "
 "file to lexelby@github."
@@ -679,12 +679,12 @@ msgstr ""
 msgid "Stitch Plan"
 msgstr ""
 
-#: lib/svg/units.py:45
+#: lib/svg/units.py:46
 #, python-format
 msgid "parseLengthWithUnits: unknown unit %s"
 msgstr ""
 
-#: lib/svg/units.py:77
+#: lib/svg/units.py:78
 #, python-format
 msgid "Unknown unit: %s"
 msgstr ""

--- a/stub.py
+++ b/stub.py
@@ -34,7 +34,7 @@ args[0] = binary_path
 try:
     extension = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = extension.communicate()
-except:
+except BaseException:
     print >> sys.stderr, "Unexpected error launching Ink/Stitch."
     print >> sys.stderr, "If you're having trouble, please file an issue here, including the text below: https://github.com/inkstitch/inkstitch/issues\n"
     print >> sys.stderr, "Tried to launch:", binary_path

--- a/stub.py
+++ b/stub.py
@@ -36,7 +36,8 @@ try:
     stdout, stderr = extension.communicate()
 except BaseException:
     print >> sys.stderr, "Unexpected error launching Ink/Stitch."
-    print >> sys.stderr, "If you're having trouble, please file an issue here, including the text below: https://github.com/inkstitch/inkstitch/issues\n"
+    print >> sys.stderr, "If you're having trouble, please file an issue here, including the text below:"
+    print >> sys.stderr, "  https://github.com/inkstitch/inkstitch/issues\n"
     print >> sys.stderr, "Tried to launch:", binary_path
     print >> sys.stderr, "Arguments:", args
     print >> sys.stderr, "Debugging information:\n"


### PR DESCRIPTION
This branch corrects all PEP8 violations and all bugs reported by flake8.  It also sets the `flake8` step as mandatory so that the build fails if a style problem is detected.

The tool `autopep8` can often be useful in fixing PEP8 violations (error codes starting with E, like E302).

I haven't touched params.py or simulator.py yet because @kaalleen is working on them and I don't want to cause merge failures.  I'll rebase this branch on master once #284 is merged and then fix the style in those files.

Enforcing style is a bit draconian, but I feel it's important as we try to attract more contributors to the project.  Code that is stylistically consistent is easier for new contributors to understand.  If a specific style violation can't be avoided, add a tag like this to the end of the offending line:

`  # noqa: C901`