### PR TITLE
fix inx generation

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -11,12 +11,15 @@ from object_commands import ObjectCommands
 from layer_commands import LayerCommands
 from convert_to_satin import ConvertToSatin
 
-from base import InkstitchExtension
-import inspect
-
-extensions = []
-for item in locals().values():
-    if inspect.isclass(item) and \
-       issubclass(item, InkstitchExtension) and \
-       item is not InkstitchExtension:
-            extensions.append(item)
+__all__ = extensions = [Embroider,
+                        Install,
+                        Params,
+                        Print,
+                        Simulate,
+                        Input,
+                        Output,
+                        Zip,
+                        Flip,
+                        ObjectCommands,
+                        LayerCommands,
+                        ConvertToSatin]

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -14,6 +14,7 @@ import wx
 import inkex
 
 from ..utils import guess_inkscape_config_path, get_bundled_dir
+from ..i18n import _
 
 
 class InstallerFrame(wx.Frame):

--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -98,6 +98,10 @@ class InstallerFrame(wx.Frame):
                 shutil.copy(palette_file, dest)
 
 class Install(inkex.Effect):
+    @classmethod
+    def name(cls):
+        return "install"
+
     def effect(self):
         app = wx.App()
         installer_frame = InstallerFrame(None, title=_("Ink/Stitch Add-ons Installer"), size=(550, 250))

--- a/lib/inx/extensions.py
+++ b/lib/inx/extensions.py
@@ -3,6 +3,18 @@ import pyembroidery
 from .utils import build_environment, write_inx_file
 from .outputs import pyembroidery_output_formats
 from ..extensions import extensions, Input, Output
+from ..commands import LAYER_COMMANDS, OBJECT_COMMANDS, COMMANDS
+
+
+def layer_commands():
+    # We purposefully avoid using commands.get_command_description() here.  We
+    # want to call _() on the description inside the actual template so that
+    # we use the translation language selected in build_environment().
+    return [(command, COMMANDS[command]) for command in LAYER_COMMANDS]
+
+
+def object_commands():
+    return [(command, COMMANDS[command]) for command in OBJECT_COMMANDS]
 
 
 def pyembroidery_debug_formats():
@@ -21,4 +33,6 @@ def generate_extension_inx_files():
         name = extension.name()
         template = env.get_template('%s.inx' % name)
         write_inx_file(name, template.render(formats=pyembroidery_output_formats(),
-                                             debug_formats=pyembroidery_debug_formats()))
+                                             debug_formats=pyembroidery_debug_formats(),
+                                             layer_commands=layer_commands(),
+                                             object_commands=object_commands()))

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -28,7 +28,7 @@ def build_environment():
 def write_inx_file(name, contents):
     inx_file_name = "inkstitch_%s_%s.inx" % (name, current_locale)
     with open(os.path.join(inx_path, inx_file_name), 'w') as inx_file:
-        print >> inx_file.encode("utf-8"), contents
+        print >> inx_file, contents.encode("utf-8")
 
 def iterate_inx_locales():
     global current_translation, current_locale

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -28,7 +28,7 @@ def build_environment():
 def write_inx_file(name, contents):
     inx_file_name = "inkstitch_%s_%s.inx" % (name, current_locale)
     with open(os.path.join(inx_path, inx_file_name), 'w') as inx_file:
-        print >> inx_file, contents
+        print >> inx_file.encode("utf-8"), contents
 
 def iterate_inx_locales():
     global current_translation, current_locale

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-23 20:56-0400\n"
+"POT-Creation-Date: 2018-08-23 21:24-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -409,52 +409,52 @@ msgstr ""
 msgid "Please select one or more satin columns to flip."
 msgstr ""
 
-#: lib/extensions/install.py:30
+#: lib/extensions/install.py:31
 msgid ""
 "Ink/Stitch can install files (\"add-ons\") that make it easier to use "
 "Inkscape to create machine embroidery designs.  These add-ons will be "
 "installed:"
 msgstr ""
 
-#: lib/extensions/install.py:31
+#: lib/extensions/install.py:32
 msgid "thread manufacturer color palettes"
 msgstr ""
 
-#: lib/extensions/install.py:32
+#: lib/extensions/install.py:33
 msgid "Ink/Stitch visual commands (Object -> Symbols...)"
 msgstr ""
 
-#: lib/extensions/install.py:41
+#: lib/extensions/install.py:42
 msgid "Install"
 msgstr ""
 
-#: lib/extensions/install.py:44 lib/extensions/params.py:380
+#: lib/extensions/install.py:45 lib/extensions/params.py:380
 msgid "Cancel"
 msgstr ""
 
-#: lib/extensions/install.py:58
+#: lib/extensions/install.py:59
 msgid "Choose Inkscape directory"
 msgstr ""
 
-#: lib/extensions/install.py:68
+#: lib/extensions/install.py:69
 msgid "Inkscape add-on installation failed"
 msgstr ""
 
-#: lib/extensions/install.py:69
+#: lib/extensions/install.py:70
 msgid "Installation Failed"
 msgstr ""
 
-#: lib/extensions/install.py:73
+#: lib/extensions/install.py:74
 msgid ""
 "Inkscape add-on files have been installed.  Please restart Inkscape to "
 "load the new add-ons."
 msgstr ""
 
-#: lib/extensions/install.py:74
+#: lib/extensions/install.py:75
 msgid "Installation Completed"
 msgstr ""
 
-#: lib/extensions/install.py:107
+#: lib/extensions/install.py:108
 msgid "Ink/Stitch Add-ons Installer"
 msgstr ""
 

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-22 14:12-0400\n"
+"POT-Creation-Date: 2018-08-22 14:16-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1113,7 +1113,10 @@ msgstr ""
 msgid "Convert Line to Satin"
 msgstr ""
 
-#: templates/convert_to_satin.inx:12 templates/embroider.inx:23
+#. This is used for the submenu under Extensions -> Ink/Stitch.  Translate this
+#. to your language's word for its language, e.g. "Español" for the spanish
+#. translation.
+#: templates/convert_to_satin.inx:12 templates/embroider.inx:24
 #: templates/flip.inx:12 templates/install.inx:12
 #: templates/layer_commands.inx:16 templates/object_commands.inx:14
 #: templates/params.inx:12 templates/print.inx:12 templates/simulate.inx:12

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-22 14:16-0400\n"
+"POT-Creation-Date: 2018-08-23 20:56-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1118,7 +1118,7 @@ msgstr ""
 #. translation.
 #: templates/convert_to_satin.inx:12 templates/embroider.inx:24
 #: templates/flip.inx:12 templates/install.inx:12
-#: templates/layer_commands.inx:16 templates/object_commands.inx:14
+#: templates/layer_commands.inx:16 templates/object_commands.inx:15
 #: templates/params.inx:12 templates/print.inx:12 templates/simulate.inx:12
 msgid "English"
 msgstr ""

--- a/messages.po
+++ b/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-08-20 20:42-0400\n"
+"POT-Creation-Date: 2018-08-22 14:12-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -454,7 +454,7 @@ msgstr ""
 msgid "Installation Completed"
 msgstr ""
 
-#: lib/extensions/install.py:103
+#: lib/extensions/install.py:107
 msgid "Ink/Stitch Add-ons Installer"
 msgstr ""
 

--- a/templates/embroider.inx
+++ b/templates/embroider.inx
@@ -20,6 +20,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
+                {# L10N This is used for the submenu under Extensions -> Ink/Stitch.  Translate this to your language's word for its language, e.g. "Español" for the spanish translation. #}
                 <submenu name="{% trans %}English{% endtrans %}" />
             </submenu>
         </effects-menu>

--- a/templates/layer_commands.inx
+++ b/templates/layer_commands.inx
@@ -11,11 +11,11 @@
     <param name="extension" type="string" gui-hidden="true">layer_commands</param>
     <effect>
         <object-type>all</object-type>
-        <submenu name="Ink/Stitch">
+        <effects-menu>
             <submenu name="Ink/Stitch">
                 <submenu name="{% trans %}English{% endtrans %}" />
             </submenu>
-        </submenu>
+        </effects-menu>
     </effect>
     <script>
         <command reldir="extensions" interpreter="python">inkstitch.py</command>

--- a/templates/object_commands.inx
+++ b/templates/object_commands.inx
@@ -5,15 +5,16 @@
     <dependency type="executable" location="extensions">inkstitch.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
     {% for command, description in object_commands %}
-    <param name="{{ object }}" type="boolean" _gui-text="{{ _(description ) }}">false</param>
+    <param name="{{ command }}" type="boolean" _gui-text="{{ _(description ) }}">false</param>
     {% endfor %}
+    <param name="extension" type="string" gui-hidden="true">object_commands</param>
     <effect>
         <object-type>all</object-type>
-        <submenu name="Ink/Stitch">
+        <effects-menu>
             <submenu name="Ink/Stitch">
                 <submenu name="{% trans %}English{% endtrans %}" />
             </submenu>
-        </submenu>
+        </effects-menu>
     </effect>
     <script>
         <command reldir="extensions" interpreter="python">inkstitch.py</command>


### PR DESCRIPTION
Fixes the following issues with INX generation:
  * didn't properly handle unicode strings
  * Install extension was missing
  * added context for the "English" string

@AkiraNorthstar It appears that I set a trap for you! ;)  I intended the string "English" to be translated to the German word for "German", not the German word for "English".  It's used for the submenu in the Extensions menu.  I added a context comment to make that obvious.  Sorry about that!

I realize that this could be problematic if I actually need the string "English" translated to the German word for "English" elsewhere in Ink/Stitch.  I think that's pretty unlikely, but if we need that, I'll figure out a solution then.