### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
       # libgirepository1.0-dev that doesn't exist in Trusty.
       sudo apt-get install python-gi python-gi-cairo libgirepository1.0-dev
 
-      # wxPython doen't publish linux wheels in pypi
+      # wxPython doesn't publish linux wheels in pypi
       wget -q https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04/wxPython-4.0.3-cp27-cp27mu-linux_x86_64.whl
       pip install wxPython-4.0.3-cp27-cp27mu-linux_x86_64.whl
 
@@ -90,7 +90,8 @@ install:
       wget -q http://download.microsoft.com/download/1/1/1/1116b75a-9ec3-481a-a3c8-1777b5381140/vcredist_x86.exe
       wine vcredist_x86.exe /q
 
-      wget -q https://www.python.org/ftp/python/2.7.14/python-2.7.14.msi --output-document=python.msi
+      # python 2.7.15
+      wget -q https://www.python.org/ftp/python/2.7.15/python-2.7.15.msi --output-document=python.msi
       wine msiexec /i python.msi /qn TARGETDIR=C:\\Python
 
       wine c:\\Python\\python.exe c:\\Python\\scripts\\pip.exe install pyinstaller --upgrade


### PR DESCRIPTION
wxPython 4.0.1 -> 4.0.3 , python 2.7.14 -> 2.7.15

For upstream versions (win,mac) we can further use [conda-forge](https://conda-forge.org/).
* [shapely](https://github.com/conda-forge/shapely-feedstock)
* [wxPython](https://github.com/conda-forge/wxpython-feedstock)
* [python](https://github.com/conda-forge/python-feedstock) 2.x ?

If we use coda-forge, we don't have to build the dependencies ourselves.