### PR TITLE
Build with xcode8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)
   - language: generic
     os: osx
+    osx_image: xcode8.3
     sudo: required
     env: BUILD=osx
     if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)


### PR DESCRIPTION
In issue #275 it was found out, that the current macOS build will not run in macOS Yosemite.
Here, I will try if a version build for an older macOS version still runs on the newest macOS.