### PR TITLE
Multiple osx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ matrix:
     sudo: required
     env: BUILD=osx
     if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)
+  - language: generic
+    os: osx
+    osx_image: xcode8
+    sudo: required
+    env: BUILD=osx
+    if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)
 
   - language: java
     sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)
   - language: generic
     os: osx
+    osx_image: xcode9.4
     sudo: required
     env: BUILD=osx
     if: type != cron AND (tag =~ ^v[0-9.]+$ OR branch != master)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ EXTENSIONS:=inkstitch
 # This gets the branch name or the name of the tag
 VERSION:=$(subst /,-,$(TRAVIS_BRANCH))
 OS:=$(TRAVIS_OS_NAME)
+ifneq ($(TRAVIS_OSX_IMAGE),)
+OS:= $(OS)-$(TRAVIS_OSX_IMAGE)
+endif
 ARCH:=$(shell uname -m)
 
 dist: distclean locales inx


### PR DESCRIPTION
 When running the plugin on OSX 10.11 (El Capitano), it fails due to missing symbols. This changeset enables multiple OSX builds for xcode8 and xcode9.4, and also adds the xcode version to the generated tarball's name. Please find this Travis build as a reference:
https://travis-ci.org/zgyarmati/inkstitch/builds/423575680
The build itself failed due to the unchanged secret keys, but the logs demonstrate that the plugin built for both OSX versions and and the tarballs are named accordingly.
 Please feel free to squash these commits into one, they are just separated for easier review.