### PR TITLE
locales patch

### DIFF
--- a/translations/messages_fr_FR.po
+++ b/translations/messages_fr_FR.po
@@ -420,7 +420,8 @@ msgstr ""
 #: lib/extensions/embroider.py:38
 msgid "\n\n"
 "Seeing a 'no such option' message?  Please restart Inkscape to fix."
-msgstr "Vous voyez un message 'aucune option' ? Veuillez redémarrer Inkscape pour corriger."
+msgstr "\n\n"
+"Vous voyez un message 'aucune option' ? Veuillez redémarrer Inkscape pour corriger."
 
 #: lib/extensions/flip.py:35
 msgid "Please select one or more satin columns to flip."

--- a/translations/messages_pt_PT.po
+++ b/translations/messages_pt_PT.po
@@ -420,7 +420,8 @@ msgstr ""
 #: lib/extensions/embroider.py:38
 msgid "\n\n"
 "Seeing a 'no such option' message?  Please restart Inkscape to fix."
-msgstr "Vê uma mensagem \"não existe tal opção\"? Por favor reiniciar o Inkscape."
+msgstr "\n\n"
+"Vê uma mensagem \"não existe tal opção\"? Por favor reiniciar o Inkscape."
 
 #: lib/extensions/flip.py:35
 msgid "Please select one or more satin columns to flip."


### PR DESCRIPTION
remove the annoying message:
```bash
translations/messages_fr_FR.po:423: 'msgid' and 'msgstr' entries do not both begin with '\n'
msgfmt: found 1 fatal error
translations/messages_pt_PT.po:423: 'msgid' and 'msgstr' entries do not both begin with '\n'
msgfmt: found 1 fatal error
```