### PR TITLE
more bug fixes

### DIFF
--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -2,7 +2,7 @@ from ..utils.geometry import Point
 
 
 class Stitch(Point):
-    def __init__(self, x, y, color=None, jump=False, stop=False, trim=False, color_change=False, fake_color_change=False, no_ties=False):
+    def __init__(self, x, y=None, color=None, jump=False, stop=False, trim=False, color_change=False, fake_color_change=False, no_ties=False):
         self.x = x
         self.y = y
         self.color = color
@@ -12,6 +12,12 @@ class Stitch(Point):
         self.color_change = color_change
         self.fake_color_change = fake_color_change
         self.no_ties = no_ties
+
+        # Allow creating a Stitch from a Point
+        if isinstance(x, Point):
+            point = x
+            self.x = point.x
+            self.y = point.y
 
     def __repr__(self):
         return "Stitch(%s, %s, %s, %s, %s, %s, %s, %s%s)" % (self.x,

--- a/lib/stitch_plan/ties.py
+++ b/lib/stitch_plan/ties.py
@@ -1,26 +1,37 @@
 from copy import deepcopy
 
 from .stitch import Stitch
-from ..utils import cut_path
-from ..stitches import running_stitch
+from ..svg import PIXELS_PER_MM
 
 
 def add_tie(stitches, tie_path):
-    if stitches[-1].no_ties:
+    if len(tie_path) < 2 or stitches[0].no_ties:
         # It's from a manual stitch block, so don't add tie stitches.  The user
         # will add them if they want them.
         return
 
-    tie_path = cut_path(tie_path, 0.6)
-    tie_stitches = running_stitch(tie_path, 0.3)
-    tie_stitches = [Stitch(stitch.x, stitch.y) for stitch in tie_stitches]
+    to_previous = tie_path[1] - tie_path[0]
+    length = to_previous.length()
+    if length > 0.5 * PIXELS_PER_MM:
+        # Travel back one stitch, stopping halfway there.
+        # Then go forward one stitch, stopping halfway between
+        # again.
 
-    stitches.extend(deepcopy(tie_stitches[1:]))
-    stitches.extend(deepcopy(list(reversed(tie_stitches))[1:]))
+        # but travel at most 1.5mm
+        length = min(length, 1.5 * PIXELS_PER_MM)
+
+        direction = to_previous.unit()
+        for delta in (0.5, 1.0, 0.5, 0):
+            stitches.append(Stitch(tie_path[0] + delta * length * direction))
+    else:
+        # Too short to travel part of the way to the previous stitch; ust go
+        # back and forth to it a couple times.
+        for i in (1, 0, 1, 0):
+            stitches.append(deepcopy(tie_path[i]))
 
 
 def add_tie_off(stitches):
-    add_tie(stitches, list(reversed(stitches)))
+    add_tie(stitches, stitches[-1:-3:-1])
 
 
 def add_tie_in(stitches, upcoming_stitches):

--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -80,7 +80,10 @@ def convert_length(length):
 
 @cache
 def get_viewbox(svg):
-    return svg.get('viewBox').strip().replace(',', ' ').split()
+    viewbox = svg.get('viewBox')
+    if viewbox is None:
+        viewbox = "0 0 0 0"
+    return viewbox.strip().replace(',', ' ').split()
 
 
 @cache


### PR DESCRIPTION
* support SVGs without a viewbox defined (even though I think that violates the spec)
  * related to #194 
* use significantly faster algorithm for tie-stitches

For designs with a lot of trims or color changes, Ink/Stitch would take a ridiculously long time to render due to the way the tie-stitch code worked.  This version switches to a much faster algorithm that still does a pretty good job.  An example file is @danielkschneider's [Geneva Simple font](https://github.com/inkstitch/embroidery-fonts/blob/master/geneva/geneva-simple-sans.svg).  Before this fix, it took > 1 minute for Embroider to run.  Now, it takes less than a second.