### PR TITLE
use ugettext() instead of gettext()

### DIFF
--- a/lib/extensions/install.py
+++ b/lib/extensions/install.py
@@ -24,8 +24,8 @@ class InstallerFrame(wx.Frame):
 
         text = (_('Ink/Stitch can install files ("add-ons") that make it easier to use Inkscape to create machine embroidery designs.  '
                   'These add-ons will be installed:') +
-                "\n\n   • " + _("thread manufacturer color palettes") +
-                "\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)"))
+                u"\n\n   • " + _("thread manufacturer color palettes") +
+                u"\n   • " + _("Ink/Stitch visual commands (Object -> Symbols...)"))
 
         static_text = wx.StaticText(panel, label=text)
         font = wx.Font(12, wx.DEFAULT, wx.NORMAL, wx.NORMAL)

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -252,16 +252,16 @@ class ParamsTab(ScrolledPanel):
             description = _("These settings will be applied to %d objects.") % len(self.nodes)
 
         if any(len(param.values) > 1 for param in self.params):
-            description += "\n • " + _("Some settings had different values across objects.  Select a value from the dropdown or enter a new one.")
+            description += u"\n • " + _("Some settings had different values across objects.  Select a value from the dropdown or enter a new one.")
 
         if self.dependent_tabs:
             if len(self.dependent_tabs) == 1:
-                description += "\n • " + _("Disabling this tab will disable the following %d tabs.") % len(self.dependent_tabs)
+                description += u"\n • " + _("Disabling this tab will disable the following %d tabs.") % len(self.dependent_tabs)
             else:
-                description += "\n • " + _("Disabling this tab will disable the following tab.")
+                description += u"\n • " + _("Disabling this tab will disable the following tab.")
 
         if self.paired_tab:
-            description += "\n • " + _("Enabling this tab will disable %s and vice-versa.") % self.paired_tab.name
+            description += u"\n • " + _("Enabling this tab will disable %s and vice-versa.") % self.paired_tab.name
 
         self.description_text = description
 

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -30,7 +30,7 @@ def localize(languages=None):
     global translation, _
 
     translation = gettext.translation("inkstitch", locale_dir, fallback=True)
-    _ = translation.gettext
+    _ = translation.ugettext
 
 
 _set_locale_dir()

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -44,7 +44,7 @@ def iterate_inx_locales():
         # generate menu items for this language in Inkscape's "Extensions"
         # menu.
         magic_string = N_("Generate INX files")
-        translated_magic_string = translation.gettext(magic_string)
+        translated_magic_string = translation.ugettext(magic_string)
 
         if translated_magic_string != magic_string or locale == "en_US":
             current_translation = translation


### PR DESCRIPTION
This should fix #320.  We should be using the `ugettext()` function which returns a proper Unicode string.