### PR TITLE
fix manual stitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build/
 locales/
 /inx/
 messages.po
+/DEBUG
+.pydevproject
+.project
+

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -1,9 +1,10 @@
-import sys
 import os
+import sys
 import traceback
 from argparse import ArgumentParser
-from lib.utils import save_stderr, restore_stderr
+
 from lib import extensions
+from lib.utils import save_stderr, restore_stderr
 
 
 parser = ArgumentParser()
@@ -18,8 +19,9 @@ if os.path.exists(os.path.join(os.path.dirname(os.path.realpath(__file__)), "DEB
     #    * follow the "Note:" to enable the debug server menu item
     # 3. Create a file named "DEBUG" next to inkstitch.py in your git clone.
     # 4. Run any extension and PyDev will start debugging.
-    
-    import pydevd; pydevd.settrace()
+
+    import pydevd
+    pydevd.settrace()
 
 extension_name = my_args.extension
 

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import traceback
 from argparse import ArgumentParser
 from lib.utils import save_stderr, restore_stderr
@@ -8,6 +9,17 @@ from lib import extensions
 parser = ArgumentParser()
 parser.add_argument("--extension")
 my_args, remaining_args = parser.parse_known_args()
+
+if os.path.exists(os.path.join(os.path.dirname(os.path.realpath(__file__)), "DEBUG")):
+    # How to debug Ink/Stitch:
+    #
+    # 1. Install LiClipse (liclipse.com) -- no need to install Eclipse first
+    # 2. Start debug server as described here: http://www.pydev.org/manual_adv_remote_debugger.html
+    #    * follow the "Note:" to enable the debug server menu item
+    # 3. Create a file named "DEBUG" next to inkstitch.py in your git clone.
+    # 4. Run any extension and PyDev will start debugging.
+    
+    import pydevd; pydevd.settrace()
 
 extension_name = my_args.extension
 

--- a/lib/stitch_plan/ties.py
+++ b/lib/stitch_plan/ties.py
@@ -5,7 +5,7 @@ from ..svg import PIXELS_PER_MM
 
 
 def add_tie(stitches, tie_path):
-    if len(tie_path) < 2 or stitches[0].no_ties:
+    if len(tie_path) < 2 or tie_path[0].no_ties:
         # It's from a manual stitch block, so don't add tie stitches.  The user
         # will add them if they want them.
         return


### PR DESCRIPTION
Somewhere along the line, Ink/Stitch started adding tie stitches for manual stitch runs when it shouldn't.  This fixes that.

I finally got sick of debugging with print statements and added support for a proper debugger!  Now one can debug Ink/Stitch in the comfort of a glorious GUI in PyDev.  It's gonna make things so much easier.