### PR TITLE
basic lettering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ dist: distclean locales inx
 	cp -a images/examples dist/inkstitch
 	cp -a palettes dist/inkstitch
 	cp -a symbols dist/inkstitch
+    cp -a fonts dist/inkstitch
 	cp -a icons dist/inkstitch/bin
 	cp -a locales dist/inkstitch/bin
 	cp -a print dist/inkstitch/bin

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dist: distclean locales inx
 	cp -a images/examples dist/inkstitch
 	cp -a palettes dist/inkstitch
 	cp -a symbols dist/inkstitch
-    cp -a fonts dist/inkstitch
+	cp -a fonts dist/inkstitch
 	cp -a icons dist/inkstitch/bin
 	cp -a locales dist/inkstitch/bin
 	cp -a print dist/inkstitch/bin

--- a/fonts/small_font/LICENSE
+++ b/fonts/small_font/LICENSE
@@ -1,0 +1,94 @@
+Copyright (c) 2017, Lex Neva.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+

--- a/fonts/small_font/README_en.md
+++ b/fonts/small_font/README_en.md
@@ -1,0 +1,24 @@
+Small Font
+==========
+
+This is a small font for use in machine embroidery.  It includes capital and lowercase letters, numbers, and the following punctuation: `< > = - + , : ( ) @ . _ ' " “ ”`
+
+Currently one size is available, 0.2 inches, as measured by the width of the capital letter "M".
+
+You may use this font for free in any embroidery project, including in designs that you intend to sell or sew out and sell.  There is no limitation on the number of designs or items you may sell.  For full details, check the LICENSE file in the top directory.
+
+I've taken pains to make this font sew out nicely even though it's tiny.  Every character is properly underlayed using a center-walk stitch.  Even still, your choice of fabric, needle, and stabilizer will definitely affect your end results!  Make sure you test it out before sewing onto a garment or anything else that you really care about.
+
+If you can see areas for improvement, I'd like to know.  Just open a github issue in this repo and we can talk through your ideas.
+
+File Structure
+--------------
+
+This font is designed for Ink/Stitch and uses its standard font folder layout.  The folder contains four files:
+
+* `→.svg` contains glyphs designed for words laid out horizontally and stitched left-to-right 
+* `←.svg` contains glyphs designed for words laid out horizontally and stitched right-to-left
+* `↓.svg` contains glyphs designed for words laid out vertically and stitched top-to-bottom
+* `↑.svg` contains glyphs designed for words laid out vertically and stitched bottom-to-top
+
+The files are named as they are so as to (hopefully) be recognizable to native speakers of multiple languages.

--- a/fonts/small_font/font.json
+++ b/fonts/small_font/font.json
@@ -4,6 +4,7 @@
   "leading": 8,
   "letter_spacing": 1.5,
   "word_spacing": 4.5,
+  "auto_satin": true,
   "kerning_pairs": {
     "wo": -0.3
   }

--- a/fonts/small_font/font.json
+++ b/fonts/small_font/font.json
@@ -5,6 +5,7 @@
   "letter_spacing": 1.5,
   "word_spacing": 4.5,
   "auto_satin": true,
+  "default_glyph": "�",
   "kerning_pairs": {
     "wo": -0.3
   }

--- a/fonts/small_font/font.json
+++ b/fonts/small_font/font.json
@@ -1,0 +1,10 @@
+{
+  "name": "Ink/Stitch Small Font",
+  "description": "A font suited for small characters.  The capital em is 0.2 inches wide.",
+  "leading": 8,
+  "letter_spacing": 1.5,
+  "word_spacing": 4.5,
+  "kerning_pairs": {
+    "wo": -0.3
+  }
+}

--- a/fonts/small_font/←.svg
+++ b/fonts/small_font/←.svg
@@ -1,0 +1,2643 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   id="svg8375"
+   version="1.1"
+   inkscape:version="0.92.3 (unknown)"
+   sodipodi:docname="←.svg">
+  <sodipodi:namedview
+     inkscape:snap-global="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="13.547429"
+     inkscape:cy="17.615371"
+     inkscape:document-units="px"
+     inkscape:current-layer="g36092"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <sodipodi:guide
+       id="guide19919"
+       inkscape:label="baseline"
+       position="0,5"
+       orientation="0.00059113112,0.99999983"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19921"
+       inkscape:label="ascender"
+       position="0,25.67"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19923"
+       inkscape:label="caps"
+       position="19.697974,23.959556"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19925"
+       inkscape:label="xheight"
+       position="0,19.598"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19927"
+       inkscape:label="descender"
+       position="0,0"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <defs
+     id="defs8377">
+    <symbol
+       style="display:inline"
+       id="inkstitch_satin_cut_point">
+      <title
+         id="inkstitch_title9427-675">Satin Column cut point</title>
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.220113,0.07922893 c -1.9e-6,5.10672897 -4.1398241,9.24654997 -9.24655297,9.24654997 -5.10672933,0 -9.24655213,-4.139821 -9.24655403,-9.24654997 1e-7,-2.45233803 0.9741879,-4.80423503 2.7082531,-6.53830103 1.7340653,-1.734065 4.0859624,-2.708252 6.53830093,-2.708252 5.10673007,0 9.24655277,4.139823 9.24655297,9.24655303 0,0 0,0 0,0"
+         id="inkstitch_circle13166-3" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -7.8132269,-1.4510415 c -0.4413094,0.88338563 -0.07931,1.96814513 0.8040823,2.40945763 0.8833854,0.44130937 1.9681488,0.079303 2.4094581,-0.8040818 0.1983467,-0.3970378 0.2270074,-0.8329413 0.1264064,-1.23463743 0,0 1.3053145,0.13034233 1.3053145,0.13034233 0,0 3.29416163,3.58901577 3.29416163,3.58901577 0.2487872,-0.7097192 0.2411124,-0.9255141 -0.09365,-1.4617903 0,0 -1.70824193,-1.97779537 -1.70824193,-1.97779537 0,0 2.61658533,0.2619947 2.61658533,0.2619947 0.60556237,0.1061633 0.82089997,-0.3026842 1.25878787,-0.70526413 0,0 -4.8501007,-0.6859624 -4.8501007,-0.6859624 0,0 -0.9370561,-1.0856429 -0.9370561,-1.0856429 0.4268116,-0.1490142 0.7990019,-0.4558243 1.0156363,-0.8894695 0.4413094,-0.8833854 0.079303,-1.9681487 -0.8040822,-2.4094581 -0.8833921,-0.4413128 -1.9681487,-0.079303 -2.4094581,0.8040822 -0.3590398,0.7187033 -0.1792857,1.5648425 0.373288,2.0951784 0,0 -0.014508,0.00264 -0.014508,0.00264 0,0 1.1504733,1.2533541 1.1504733,1.2533541 0,0 -1.3945129,-0.196367 -1.3945129,-0.196367 -0.8248385,-0.2578481 -1.7446631,0.1079194 -2.1425563,0.9043974 0,0 -2.71e-5,3.4e-6 -2.71e-5,3.4e-6 m 0.6765348,0.337974 c 0.2586549,-0.517759 0.877184,-0.7241797 1.3949495,-0.4655215 0.5177589,0.2586549 0.7241761,0.87719093 0.4655214,1.39494953 -0.2586548,0.5177587 -0.8771906,0.7241758 -1.3949494,0.4655211 -0.5177657,-0.2586579 -0.7241762,-0.8771902 -0.4655215,-1.39494913 0,0 0,0 0,0 m 2.0278432,-4.0592094 c 0.2586548,-0.5177589 0.8771839,-0.7241794 1.3949495,-0.4655213 0.5177588,0.2586548 0.724176,0.8771905 0.4655213,1.3949494 -0.2586548,0.5177588 -0.8771906,0.7241761 -1.3949494,0.4655213 -0.5177656,-0.2586581 -0.7241761,-0.8771906 -0.4655214,-1.3949494 0,0 0,0 0,0"
+         id="path24356" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 4.4798843,-4.3110508 c 0.219827,2.414579 -0.180079,4.01786863 -1.429103,5.5454305 0,0 2.023437,1.0507812 2.023437,1.0507812 1.715964,-1.67359867 1.847271,-3.9809016 1.75755,-6.660665 0,0 -2.351884,0.064453 -2.351884,0.064453 m -2.097072,6.2192586 c -2.10168637,1.4056146 -3.14434337,3.5358281 -3.667017,6.0218201 0,0 2.3918915,0.212651 2.3918915,0.212651 0.3238246,-2.741001 2.2229845,-4.191785 3.3298135,-5.1368148 0,0 -2.054688,-1.0976563 -2.054688,-1.0976563"
+         id="path24362" />
+    </symbol>
+  </defs>
+  <metadata
+     id="metadata8380">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1" />
+  <g
+     id="g20096"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-A">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7548-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="path7570-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7550-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-B"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20473">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9052"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_running_stitch_length_mm="1.5"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_repeats=""
+       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9054"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7385"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-C"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20573">
+    <path
+       sodipodi:nodetypes="ccscccsccccscccscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7387"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20639"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-D">
+    <path
+       id="path13248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path7389"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-E"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20732">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019"
+       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 8.9392548,6.7571256 V 13.467283 M 11.565268,6.8071156 v 6.6643754"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015"
+       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 8.9392548,13.467283 V 24.494025 M 11.565268,13.471491 v 10.938244"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path38776"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14011"
+       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20851"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-F">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019-6"
+       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.77006,6.69201 v 6.55232 M 13.39607,6.742 v 6.507875"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391-0"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015-0"
+       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.77006,13.24433 V 24.96227 M 13.39607,13.249875 V 24.87798"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39823"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-G"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21249">
+    <path
+       sodipodi:nodetypes="ccccscscscccsscscscccccc"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14890"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14866"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14868"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-H"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21438">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18656"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18640"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18642"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21538"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-I">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21746"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-J">
+    <path
+       id="path7401-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscccscsc" />
+  </g>
+  <g
+     id="g22082"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-K">
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22148"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7403"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-L"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22205">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path24793" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7405" />
+  </g>
+  <g
+     id="g22344"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-M">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26119"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26117"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26115"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7407"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-N"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22488">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7409" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27049" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27051" />
+  </g>
+  <g
+     id="g14481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-O">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7411"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g14770"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-P">
+    <path
+       sodipodi:nodetypes="cscccsccsccssc"
+       inkscape:connector-curvature="0"
+       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29322"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29324" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Q"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15502">
+    <path
+       sodipodi:nodetypes="cccscscscccscscscscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 23.686134,15.673101 c 0,0 -0.0781,1.491279 -0.0781,1.491279 0,0 -0.25594,1.507186 -0.25594,1.507186 0,0 -0.426563,1.385313 -0.426563,1.385313 0,0 -0.597183,1.263441 -0.597183,1.263441 0,0 -0.709765,1.069489 -0.709765,1.069489 0,0 -0.847135,0.927731 -0.847135,0.927731 m 0.146817,-7.711411 c 0,0 -0.197167,2.295775 -0.197167,2.295775 0,0 -0.60975,1.994776 -0.60975,1.994776 0,0 -1.0577,1.67288 -1.0577,1.67288 m 3.283115,-0.243837 c 0,0 -2.23383,-1.434446 -2.23383,-1.434446"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40905" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30718" />
+    <path
+       sodipodi:nodetypes="cccscscscccscscscscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.74008,24.7112 c 0,0 -2.045494,0.65993 -2.045494,0.65993 0,0 -1.971236,0.22619 -1.971236,0.22619 0,0 -1.945125,-0.170625 -1.945125,-0.170625 0,0 -1.740375,-0.511875 -1.740375,-0.511875 0,0 -1.535625,-0.853125 -1.535625,-0.853125 0,0 -1.330875,-1.194375 -1.330875,-1.194375 0,0 -1.0692486,-1.486877 -1.0692486,-1.486877 0,0 -0.7637502,-1.717626 -0.7637502,-1.717626 0,0 -0.4582507,-1.948374 -0.4582507,-1.948374 0,0 -0.1527505,-2.179123 -0.1527505,-2.179123 0,0 0.1527505,-2.184 0.1527505,-2.184 0,0 0.4582507,-1.95 0.4582507,-1.95 0,0 0.7637502,-1.716 0.7637502,-1.716 0,0 1.0692486,-1.482 1.0692486,-1.482 0,0 1.330875,-1.2000639 1.330875,-1.2000639 0,0 1.535625,-0.8571873 1.535625,-0.8571873 0,0 1.740375,-0.5143118 1.740375,-0.5143118 0,0 1.945125,-0.171437 1.945125,-0.171437 0,0 1.938624,0.171437 1.938624,0.171437 0,0 1.733876,0.5143118 1.733876,0.5143118 0,0 1.529126,0.8571873 1.529126,0.8571873 0,0 1.324374,1.2000639 1.324374,1.2000639 0,0 1.069249,1.482 1.069249,1.482 0,0 0.76375,1.716 0.76375,1.716 0,0 0.458251,1.95 0.458251,1.95 0,0 0.15275,2.184 0.15275,2.184 0,0 -0.0072,0.137781 -0.0072,0.137781 m -6.56754,7.333759 c 0,0 -1.13334,0.343831 -1.13334,0.343831 0,0 -1.26192,0.114609 -1.26192,0.114609 0,0 -1.356877,-0.13325 -1.356877,-0.13325 0,0 -1.210627,-0.399751 -1.210627,-0.399751 0,0 -1.064374,-0.66625 -1.064374,-0.66625 0,0 -0.918122,-0.932749 -0.918122,-0.932749 0,0 -0.7336875,-1.161878 -0.7336875,-1.161878 0,0 -0.5240625,-1.353625 -0.5240625,-1.353625 0,0 -0.3144375,-1.545373 -0.3144375,-1.545373 0,0 -0.1048125,-1.737124 -0.1048125,-1.737124 0,0 0.1048125,-1.742814 0.1048125,-1.742814 0,0 0.3144375,-1.549439 0.3144375,-1.549439 0,0 0.5240625,-1.356061 0.5240625,-1.356061 0,0 0.7336875,-1.162686 0.7336875,-1.162686 0,0 0.918122,-0.9327528 0.918122,-0.9327528 0,0 1.064374,-0.6662497 1.064374,-0.6662497 0,0 1.210627,-0.3997484 1.210627,-0.3997484 0,0 1.356877,-0.1332491 1.356877,-0.1332491 0,0 1.35525,0.1332491 1.35525,0.1332491 0,0 1.205749,0.3997484 1.205749,0.3997484 0,0 1.056249,0.6662497 1.056249,0.6662497 0,0 0.906752,0.9327528 0.906752,0.9327528 0,0 0.733683,1.162686 0.733683,1.162686 0,0 0.524063,1.356061 0.524063,1.356061 0,0 0.31444,1.549439 0.31444,1.549439 0,0 0.104814,1.742814 0.104814,1.742814 0,0 -0.0061,0.07083 -0.0061,0.07083 m -6.1949,10.00119 c 0,0 0,-2.15202 0,-2.15202 M 8.1634123,22.873402 c 0,0 2.0178757,-1.546184 2.0178757,-1.546184 M 5.71735,15.53532 c 0,0 2.789,-2e-5 2.789,-2e-5 M 8.1633873,8.1972705 c 0,0 2.0179257,1.533079 2.0179257,1.533079 M 14.72335,5.45032 c 0,0 0,2.15198 0,2.15198 m 6.533963,0.5949705 c 0,0 -2.017926,1.533079 -2.017926,1.533079 M 23.70335,15.53532 c 0,0 -2.789,-2e-5 -2.789,-2e-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30716" />
+  </g>
+  <g
+     id="g15673"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-R">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7417"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccccsccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32125"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-S"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15839">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7419" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-T"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16335">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31333"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7421"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path34968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g16687"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-U">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7423"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscscsccscscsc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-V"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16861">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800" />
+  </g>
+  <g
+     id="g17062"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-W">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39256"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39252"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39250"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7427"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-X"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17279">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40770"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40754" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40760" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40772"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g17493"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Y">
+    <path
+       id="path42255"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.54868,25.00103 v -8.95889 l 1.24202,-2.184 5.343,-7.76103 m -3.94602,18.90392 v -8.95889 l 6.864,-9.94503 M 12.92754,19.32583 h 4.07293"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       id="path7431"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Z"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17715">
+    <path
+       inkscape:connector-curvature="0"
+       id="path43759"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.62245,8.53258 c 0,0 14.93072,0 14.93072,0 M 7.62245,5.83771 c 0,0 15.24899,0 15.24899,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43761"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.59544,8.53258 c 0,0 -12.272,14.22726 -12.272,14.22726 m 15.548,-14.43526 c 0,0 -12.272,14.22726 -12.272,14.22726"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43765"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.32344,25.24671 c 0,0 15.847,0 15.847,0 M 7.39928,22.55184 c 0,0 15.77116,0 15.77116,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17946"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-a">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4609"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccscccc" />
+    <path
+       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path847"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-b"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18617">
+    <path
+       id="path13834"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.543215,22.122558 1.53398,2.98178 m -7.487063,-9.949696 c 0.219817,-0.472451 0.798071,-1.186277 1.066153,-1.556484 0.727998,-0.996667 1.724667,-1.495001 2.99,-1.495001 1.26533,0 2.261998,0.498334 2.989997,1.495001 0.719336,1.005332 1.079002,2.387666 1.079002,4.147 0,1.759334 -0.359666,3.137334 -1.079002,4.133998 -0.727999,1.005335 -1.724667,1.508003 -2.989997,1.508003 -1.265333,0 -2.309552,-0.454787 -3.038749,-1.45925 -0.297301,-0.409532 -0.768484,-1.125174 -0.99504,-1.467049 m -0.04822,-8.384717 c 1.213352,-1.708275 2.873841,-1.961664 4.666998,-1.974985 1.759334,0 3.193667,0.702 4.303,2.106 1.100667,1.404 1.651001,3.249999 1.651004,5.538 4e-6,2.287999 -0.550329,4.133998 -1.650996,5.537998 -1.109334,1.404 -2.543666,2.106002 -4.303,2.106002 -2.022659,-0.0012 -3.640858,-0.657066 -4.666998,-2.009457 m 5.1909,-10.766297 1.023752,-2.827501"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       inkscape:connector-curvature="0"
+       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13821"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     id="g18852"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-c">
+    <path
+       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9367"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-d"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19099">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9395-2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.6495,12.076147 c -1.21335,-1.708275 -2.87384,-1.961664 -4.667,-1.974985 -1.75933,0 -3.19366,0.702 -4.303,2.106 -1.10066,1.404 -1.651,3.249999 -1.651,5.538 0,2.287999 0.55034,4.133998 1.651,5.537998 1.10934,1.404 2.54367,2.106002 4.303,2.106002 2.02266,-0.0012 3.64086,-0.657066 4.667,-2.009457 m -0.0108,-7.606268 c -0.17604,-0.856546 -0.65135,-1.581636 -1.08123,-2.175275 -0.728,-0.996667 -1.72466,-1.495001 -2.99,-1.495001 -1.26533,0 -2.262,0.498334 -2.98999,1.495001 -0.71934,1.005332 -1.07901,2.387666 -1.07901,4.147 0,1.759334 0.35967,3.137334 1.07901,4.133998 0.72799,1.005335 1.72466,1.508003 2.98999,1.508003 1.26534,0 2.262,-0.502668 2.99,-1.508003 0.42152,-0.577075 0.89336,-1.281992 1.07082,-2.114749 m -7.7085,-1.739755 c 0,0 -3.46125,-0.04875 -3.46125,-0.04875 m 7.90905,-5.177876 c 0,0 -0.10341,-3.274787 -0.10341,-3.274787 m 0.27576,12.892325 c 0,0 -0.0345,3.171371 -0.0345,3.171371"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13733-0" />
+  </g>
+  <g
+     id="g19346"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-e">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path6501"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscscsccccsccccscccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9371"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-f"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20089">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4599" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9759" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path4595"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20354"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-g">
+    <path
+       sodipodi:nodetypes="ccscccccscsccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6095"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9375"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-h"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20629">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6452" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6479" />
+  </g>
+  <g
+     id="g20904"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-i">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6852"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9379"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-j"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21185">
+    <path
+       inkscape:connector-curvature="0"
+       id="path7095"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9381"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-k">
+    <path
+       id="path9383"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path7639"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-l"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21769">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path9385"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161" />
+  </g>
+  <g
+     id="g22083"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-m">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9331"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9327"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9321"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-n"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22392">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9327-6" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9321-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     id="g22701"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-o">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9391"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-p"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15223">
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g15551"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-q">
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144-6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180-3"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-r"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16497">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22967"
+       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path22973"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g16825"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-s">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9399"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-t"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17173">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path55570"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path26331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26335" />
+  </g>
+  <g
+     id="g17518"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-u">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path28174"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9403"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-v"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17883">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800-7" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425-5" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-w"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18646">
+    <path
+       id="path9407"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18115"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18117"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18119"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g19389"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-x">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30901"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30893"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9409"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-y"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19767">
+    <path
+       inkscape:connector-curvature="0"
+       id="path31668"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path31664"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20153"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-z">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9413"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3140"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3142"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-0"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20540">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path49864"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488" />
+  </g>
+  <g
+     id="g20941"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-1">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53129"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53135"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53139"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-2"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21342">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path54384" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49868" />
+  </g>
+  <g
+     id="g21752"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-3">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path55631"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49870"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-4"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22181">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58735" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58727" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58741" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49872" />
+  </g>
+  <g
+     id="g23013"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-5">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49874"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path74136"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g24259"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-6">
+    <path
+       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path77434" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-7"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g24692">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1140"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g25126"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-8">
+    <path
+       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc"
+       id="path49880"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-9"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g25564">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-@"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g27314">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3259"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3287"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g27781"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&lt;">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60030"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60034"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&gt;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g28228">
+    <path
+       inkscape:connector-curvature="0"
+       id="path60030-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path60034-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g28695"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-:">
+    <path
+       id="path64532"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path49890"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-,"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g29163">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g29625"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-'">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&quot;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g30411">
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-23"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g34046"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-“">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-”"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g34542">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-2"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g35054"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-.">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49894"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g36092"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-+">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70206" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70194" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70200"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer--"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g36598">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155" />
+  </g>
+  <g
+     id="g37137"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-=">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72806"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72814"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-("
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g37653">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path11049"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g38173"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-)">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path11049-4"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-_"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g38697">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-/"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21638">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/fonts/small_font/←.svg
+++ b/fonts/small_font/←.svg
@@ -25,10 +25,10 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="22.4"
-     inkscape:cx="13.547429"
+     inkscape:cx="-5.3364996"
      inkscape:cy="17.615371"
      inkscape:document-units="px"
-     inkscape:current-layer="g36092"
+     inkscape:current-layer="layer6"
      showgrid="false"
      units="px"
      inkscape:window-width="1366"
@@ -2639,5 +2639,20 @@
        d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer6"
+     inkscape:label="GlyphLayer-�"
+     style="display:none">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.37795275;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1"
+       embroider_satin_column="true"
+       d="m 14.773481,8.5147102 h 0.789182 4.754671 V 22.524457 H 9.8106215 V 8.5147102 h 4.9628595 m 0,-2.4944882 h 0.789182 7.249159 V 25.018945 H 7.3161333 V 6.020222 h 7.4573477 m 3.700266,2.7708704 V 5.649138 m 1.219965,15.411788 h 3.394492 m -11.621622,0.839909 v 3.741732 M 10.181706,10.372833 H 6.8819148 M 10.16466,21.00333 6.8185297,21.0349 m 11.7114563,0.66291 v 3.756505 m 1.199556,-15.02602 h 3.377697 M 11.332649,8.9762007 V 5.7247722"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="0.90" />
   </g>
 </svg>

--- a/fonts/small_font/↑.svg
+++ b/fonts/small_font/↑.svg
@@ -15,7 +15,7 @@
    id="svg8375"
    version="1.1"
    inkscape:version="0.92.3 (unknown)"
-   sodipodi:docname="small_font.svg">
+   sodipodi:docname="↑.svg">
   <sodipodi:namedview
      inkscape:snap-global="false"
      id="base"
@@ -24,11 +24,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="44.8"
-     inkscape:cx="16.674264"
-     inkscape:cy="14.334539"
+     inkscape:zoom="15.839192"
+     inkscape:cx="14.162991"
+     inkscape:cy="12.629907"
      inkscape:document-units="px"
-     inkscape:current-layer="g17173"
+     inkscape:current-layer="layer4"
      showgrid="false"
      units="px"
      inkscape:window-width="1366"
@@ -2598,5 +2598,20 @@
        d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="GlyphLayer-�"
+     style="display:none">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.37795275;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1"
+       embroider_satin_column="true"
+       d="m 14.773481,8.5147102 h 0.789182 4.754671 V 22.524457 H 9.8106215 V 8.5147102 h 4.9628595 m 0,-2.4944882 h 0.789182 7.249159 V 25.018945 H 7.3161333 V 6.020222 h 7.4573477 m 3.700266,2.7708704 V 5.649138 m 1.219965,15.411788 h 3.394492 m -11.621622,0.839909 v 3.741732 M 10.181706,10.372833 H 6.8819148 M 10.16466,21.00333 6.8185297,21.0349 m 11.7114563,0.66291 v 3.756505 m 1.199556,-15.02602 h 3.377697 M 11.332649,8.9762007 V 5.7247722"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="0.90" />
   </g>
 </svg>

--- a/fonts/small_font/↑.svg
+++ b/fonts/small_font/↑.svg
@@ -1,0 +1,2602 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   id="svg8375"
+   version="1.1"
+   inkscape:version="0.92.3 (unknown)"
+   sodipodi:docname="small_font.svg">
+  <sodipodi:namedview
+     inkscape:snap-global="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="16.674264"
+     inkscape:cy="14.334539"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17173"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <sodipodi:guide
+       id="guide19919"
+       inkscape:label="baseline"
+       position="0,5"
+       orientation="0.00059113112,0.99999983"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19921"
+       inkscape:label="ascender"
+       position="0,25.67"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19923"
+       inkscape:label="caps"
+       position="19.697974,23.959556"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19925"
+       inkscape:label="xheight"
+       position="0,19.598"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19927"
+       inkscape:label="descender"
+       position="0,0"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <defs
+     id="defs8377">
+    <symbol
+       style="display:inline"
+       id="inkstitch_satin_cut_point">
+      <title
+         id="inkstitch_title9427-675">Satin Column cut point</title>
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.220113,0.07922893 c -1.9e-6,5.10672897 -4.1398241,9.24654997 -9.24655297,9.24654997 -5.10672933,0 -9.24655213,-4.139821 -9.24655403,-9.24654997 1e-7,-2.45233803 0.9741879,-4.80423503 2.7082531,-6.53830103 1.7340653,-1.734065 4.0859624,-2.708252 6.53830093,-2.708252 5.10673007,0 9.24655277,4.139823 9.24655297,9.24655303 0,0 0,0 0,0"
+         id="inkstitch_circle13166-3" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -7.8132269,-1.4510415 c -0.4413094,0.88338563 -0.07931,1.96814513 0.8040823,2.40945763 0.8833854,0.44130937 1.9681488,0.079303 2.4094581,-0.8040818 0.1983467,-0.3970378 0.2270074,-0.8329413 0.1264064,-1.23463743 0,0 1.3053145,0.13034233 1.3053145,0.13034233 0,0 3.29416163,3.58901577 3.29416163,3.58901577 0.2487872,-0.7097192 0.2411124,-0.9255141 -0.09365,-1.4617903 0,0 -1.70824193,-1.97779537 -1.70824193,-1.97779537 0,0 2.61658533,0.2619947 2.61658533,0.2619947 0.60556237,0.1061633 0.82089997,-0.3026842 1.25878787,-0.70526413 0,0 -4.8501007,-0.6859624 -4.8501007,-0.6859624 0,0 -0.9370561,-1.0856429 -0.9370561,-1.0856429 0.4268116,-0.1490142 0.7990019,-0.4558243 1.0156363,-0.8894695 0.4413094,-0.8833854 0.079303,-1.9681487 -0.8040822,-2.4094581 -0.8833921,-0.4413128 -1.9681487,-0.079303 -2.4094581,0.8040822 -0.3590398,0.7187033 -0.1792857,1.5648425 0.373288,2.0951784 0,0 -0.014508,0.00264 -0.014508,0.00264 0,0 1.1504733,1.2533541 1.1504733,1.2533541 0,0 -1.3945129,-0.196367 -1.3945129,-0.196367 -0.8248385,-0.2578481 -1.7446631,0.1079194 -2.1425563,0.9043974 0,0 -2.71e-5,3.4e-6 -2.71e-5,3.4e-6 m 0.6765348,0.337974 c 0.2586549,-0.517759 0.877184,-0.7241797 1.3949495,-0.4655215 0.5177589,0.2586549 0.7241761,0.87719093 0.4655214,1.39494953 -0.2586548,0.5177587 -0.8771906,0.7241758 -1.3949494,0.4655211 -0.5177657,-0.2586579 -0.7241762,-0.8771902 -0.4655215,-1.39494913 0,0 0,0 0,0 m 2.0278432,-4.0592094 c 0.2586548,-0.5177589 0.8771839,-0.7241794 1.3949495,-0.4655213 0.5177588,0.2586548 0.724176,0.8771905 0.4655213,1.3949494 -0.2586548,0.5177588 -0.8771906,0.7241761 -1.3949494,0.4655213 -0.5177656,-0.2586581 -0.7241761,-0.8771906 -0.4655214,-1.3949494 0,0 0,0 0,0"
+         id="path24356" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 4.4798843,-4.3110508 c 0.219827,2.414579 -0.180079,4.01786863 -1.429103,5.5454305 0,0 2.023437,1.0507812 2.023437,1.0507812 1.715964,-1.67359867 1.847271,-3.9809016 1.75755,-6.660665 0,0 -2.351884,0.064453 -2.351884,0.064453 m -2.097072,6.2192586 c -2.10168637,1.4056146 -3.14434337,3.5358281 -3.667017,6.0218201 0,0 2.3918915,0.212651 2.3918915,0.212651 0.3238246,-2.741001 2.2229845,-4.191785 3.3298135,-5.1368148 0,0 -2.054688,-1.0976563 -2.054688,-1.0976563"
+         id="path24362" />
+    </symbol>
+  </defs>
+  <metadata
+     id="metadata8380">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1" />
+  <g
+     id="g20096"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-A">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7548-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7550-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="path7570-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-B"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20473">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7385"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_running_stitch_length_mm="1.5"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_repeats=""
+       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9054"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9052"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-C"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20573">
+    <path
+       sodipodi:nodetypes="ccscccsccccscccscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7387"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20639"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-D">
+    <path
+       id="path7389"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path13248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-E"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20732">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019"
+       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015"
+       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.9392548,6.7571256 c 0,0 0,17.7368994 0,17.7368994 M 11.565268,6.8071156 c 0,0 0,17.6026194 0,17.6026194"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14011"
+       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20851"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-F">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015-0"
+       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.77006,6.69201 c 0,0 0,18.27026 0,18.27026 M 13.39607,6.742 c 0,0 0,18.13598 0,18.13598"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391-0"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019-6"
+       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-G"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21249">
+    <path
+       sodipodi:nodetypes="ccccscscscccsscscscccccc"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14890"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14866"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14868"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-H"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21438">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18656"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18640"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18642"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21538"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-I">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21746"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-J">
+    <path
+       id="path7401-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscccscsc" />
+  </g>
+  <g
+     id="g22082"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-K">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7403"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22148"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-L"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22205">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7405" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path24793" />
+  </g>
+  <g
+     id="g22344"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-M">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7407"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26115"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26117"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26119"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-N"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22488">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27051" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27049" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7409" />
+  </g>
+  <g
+     id="g14481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-O">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7411"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g14770"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-P">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29324" />
+    <path
+       sodipodi:nodetypes="cscccsccsccssc"
+       inkscape:connector-curvature="0"
+       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29322"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Q"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15502">
+    <path
+       sodipodi:nodetypes="cccscscscccscscscscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.74008,24.7112 c -1.28002,0.60999 -2.83572,0.85445 -4.01673,0.88612 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82867 -2.444,-4.27267 -2.444,-7.332 0,-3.068 0.81467,-5.512 2.444,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72133,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332 0,2.25333 -0.45501,4.18166 -1.365,5.785 -0.42739,0.76024 -0.94635,1.42599 -1.5569,1.99722 m -3.65284,-0.31068 c -0.7127,0.30563 -1.51112,0.45844 -2.39526,0.45844 -1.90667,0 -3.42334,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12666,-1.42134 2.64333,-2.132 4.55,-2.132 1.90667,0 3.41466,0.71066 4.524,2.132 1.11799,1.42133 1.677,3.35833 1.677,5.811 0,1.70168 -0.271,3.15547 -0.813,4.36138 -0.30413,0.65637 -0.65817,1.1707 -1.0577,1.67288"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30716" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30718" />
+  </g>
+  <g
+     id="g15673"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-R">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32125"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7417"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccccsccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-S"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15839">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7419" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-T"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16335">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path34968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7421"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31333"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g16687"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-U">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7423"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscscsccscscsc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-V"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16861">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425" />
+  </g>
+  <g
+     id="g17062"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-W">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7427"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39250"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39252"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39256"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-X"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17279">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40772"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40754" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40770"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40760" />
+  </g>
+  <g
+     id="g17493"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Y">
+    <path
+       id="path7431"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path42255"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.54868,25.00103 v -8.95889 l 1.24202,-2.184 5.343,-7.76103 m -3.94602,18.90392 v -8.95889 l 6.864,-9.94503 M 12.92754,19.32583 h 4.07293"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Z"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17715">
+    <path
+       inkscape:connector-curvature="0"
+       id="path43759"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.62245,8.53258 c 0,0 14.93072,0 14.93072,0 M 7.62245,5.83771 c 0,0 15.24899,0 15.24899,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43761"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.59544,8.53258 c 0,0 -12.272,14.22726 -12.272,14.22726 m 15.548,-14.43526 c 0,0 -12.272,14.22726 -12.272,14.22726"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43765"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.32344,25.24671 c 0,0 15.847,0 15.847,0 M 7.39928,22.55184 c 0,0 15.77116,0 15.77116,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17946"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-a">
+    <path
+       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path847"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4609"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccscccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-b"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18617">
+    <path
+       inkscape:connector-curvature="0"
+       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13821"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path13834"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.543215,22.122558 1.53398,2.98178 m -7.487063,-9.949696 c 0.219817,-0.472451 0.798071,-1.186277 1.066153,-1.556484 0.727998,-0.996667 1.724667,-1.495001 2.99,-1.495001 1.26533,0 2.261998,0.498334 2.989997,1.495001 0.719336,1.005332 1.079002,2.387666 1.079002,4.147 0,1.759334 -0.359666,3.137334 -1.079002,4.133998 -0.727999,1.005335 -1.724667,1.508003 -2.989997,1.508003 -1.265333,0 -2.309552,-0.454787 -3.038749,-1.45925 -0.297301,-0.409532 -0.768484,-1.125174 -0.99504,-1.467049 m -0.04822,-8.384717 c 1.213352,-1.708275 2.873841,-1.961664 4.666998,-1.974985 1.759334,0 3.193667,0.702 4.303,2.106 1.100667,1.404 1.651001,3.249999 1.651004,5.538 4e-6,2.287999 -0.550329,4.133998 -1.650996,5.537998 -1.109334,1.404 -2.543666,2.106002 -4.303,2.106002 -2.022659,-0.0012 -3.640858,-0.657066 -4.666998,-2.009457 m 5.1909,-10.766297 1.023752,-2.827501"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g18852"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-c">
+    <path
+       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9367"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-d"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19099">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.6495,12.076147 c -1.21335,-1.708275 -2.87384,-1.961664 -4.667,-1.974985 -1.75933,0 -3.19366,0.702 -4.303,2.106 -1.10066,1.404 -1.651,3.249999 -1.651,5.538 0,2.287999 0.55034,4.133998 1.651,5.537998 1.10934,1.404 2.54367,2.106002 4.303,2.106002 2.02266,-0.0012 3.64086,-0.657066 4.667,-2.009457 m -0.0108,-7.606268 c -0.17604,-0.856546 -0.65135,-1.581636 -1.08123,-2.175275 -0.728,-0.996667 -1.72466,-1.495001 -2.99,-1.495001 -1.26533,0 -2.262,0.498334 -2.98999,1.495001 -0.71934,1.005332 -1.07901,2.387666 -1.07901,4.147 0,1.759334 0.35967,3.137334 1.07901,4.133998 0.72799,1.005335 1.72466,1.508003 2.98999,1.508003 1.26534,0 2.262,-0.502668 2.99,-1.508003 0.42152,-0.577075 0.89336,-1.281992 1.07082,-2.114749 m -7.7085,-1.739755 c 0,0 -3.46125,-0.04875 -3.46125,-0.04875 m 7.90905,-5.177876 c 0,0 -0.10341,-3.274787 -0.10341,-3.274787 m 0.27576,12.892325 c 0,0 -0.0345,3.171371 -0.0345,3.171371"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13733-0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9395-2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g19346"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-e">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path6501"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscscsccccsccccscccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9371"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-f"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20089">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4599" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9759" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path4595"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20354"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-g">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9375"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscccccscsccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6095"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-h"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20629">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6479" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6452" />
+  </g>
+  <g
+     id="g20904"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-i">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6852"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9379"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-j"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21185">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9381"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7095"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-k">
+    <path
+       id="path7639"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9383"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-l"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21769">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path9385"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161" />
+  </g>
+  <g
+     id="g22083"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-m">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9321"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9327"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9331"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-n"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22392">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9321-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9327-6" />
+  </g>
+  <g
+     id="g22701"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-o">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9391"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-p"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15223">
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g15551"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-q">
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180-3"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144-6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-r"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16497">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path22973"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22967"
+       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     id="g16825"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-s">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9399"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-t"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17173">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26335" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path55570"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path26331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g17518"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-u">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9403"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path28174"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-v"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17883">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425-5" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-w"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18646">
+    <path
+       id="path18119"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18117"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18115"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path9407"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g19389"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-x">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30893"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30901"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9409"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-y"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19767">
+    <path
+       inkscape:connector-curvature="0"
+       id="path31664"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path31668"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20153"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-z">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9413"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3140"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3142"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-0"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20540">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path49864"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488" />
+  </g>
+  <g
+     id="g20941"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-1">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53139"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53135"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53129"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-2"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21342">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49868" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path54384" />
+  </g>
+  <g
+     id="g21752"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-3">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path55631"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49870"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-4"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22181">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49872" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58727" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58735" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58741" />
+  </g>
+  <g
+     id="g23013"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-5">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49874"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path74136"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g24259"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-6">
+    <path
+       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path77434" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-7"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g24692">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1140"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g25126"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-8">
+    <path
+       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc"
+       id="path49880"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-9"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g25564">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-@"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g27314">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3259"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3287"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g27781"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&lt;">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60030"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60034"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&gt;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g28228">
+    <path
+       inkscape:connector-curvature="0"
+       id="path60030-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path60034-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g28695"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-:">
+    <path
+       id="path64532"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path49890"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-,"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g29163">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g29625"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-'">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&quot;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g30411">
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-23"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g34046"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-“">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-”"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g34542">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-9"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-2"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g35054"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-.">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49894"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g36092"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-+">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70194" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70206" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70200"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer--"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g36598">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155" />
+  </g>
+  <g
+     id="g37137"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-=">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72806"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72814"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-("
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g37653">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path11049"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g38173"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-)">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path11049-4"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-_"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g38697">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-/"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21638">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/fonts/small_font/→.svg
+++ b/fonts/small_font/→.svg
@@ -9,93 +9,93 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="30"
-   height="30"
-   viewBox="0 0 30 30"
-   id="svg8375"
-   version="1.1"
+   sodipodi:docname="→.svg"
    inkscape:version="0.92.3 (unknown)"
-   sodipodi:docname="→.svg">
+   version="1.1"
+   id="svg8375"
+   viewBox="0 0 30 30"
+   height="30"
+   width="30">
   <sodipodi:namedview
-     inkscape:snap-global="false"
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="44.8"
-     inkscape:cx="7.2322999"
-     inkscape:cy="20.584539"
-     inkscape:document-units="px"
-     inkscape:current-layer="g34046"
-     showgrid="false"
-     units="px"
-     inkscape:window-width="1366"
-     inkscape:window-height="705"
-     inkscape:window-x="-4"
-     inkscape:window-y="-4"
+     inkscape:measure-end="19.2857,16.6964"
+     inkscape:measure-start="16.3839,16.6964"
      inkscape:window-maximized="1"
-     inkscape:measure-start="0,0"
-     inkscape:measure-end="0,0">
+     inkscape:window-y="-4"
+     inkscape:window-x="-4"
+     inkscape:window-height="705"
+     inkscape:window-width="1366"
+     units="px"
+     showgrid="false"
+     inkscape:current-layer="g21881"
+     inkscape:document-units="px"
+     inkscape:cy="15.884593"
+     inkscape:cx="14.324"
+     inkscape:zoom="31.678384"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:snap-global="false">
     <sodipodi:guide
-       id="guide19919"
-       inkscape:label="baseline"
-       position="0,5"
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false"
        orientation="0.00059113112,0.99999983"
-       inkscape:locked="false"
-       inkscape:color="rgb(0,0,255)" />
+       position="0,5"
+       inkscape:label="baseline"
+       id="guide19919" />
     <sodipodi:guide
-       id="guide19921"
-       inkscape:label="ascender"
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false"
+       orientation="0,1"
        position="0,25.67"
-       orientation="0,1"
-       inkscape:locked="false"
-       inkscape:color="rgb(0,0,255)" />
+       inkscape:label="ascender"
+       id="guide19921" />
     <sodipodi:guide
-       id="guide19923"
-       inkscape:label="caps"
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false"
+       orientation="0,1"
        position="19.697974,23.959556"
-       orientation="0,1"
-       inkscape:locked="false"
-       inkscape:color="rgb(0,0,255)" />
+       inkscape:label="caps"
+       id="guide19923" />
     <sodipodi:guide
-       id="guide19925"
-       inkscape:label="xheight"
+       inkscape:color="rgb(0,0,255)"
+       inkscape:locked="false"
+       orientation="0,1"
        position="0,19.598"
-       orientation="0,1"
-       inkscape:locked="false"
-       inkscape:color="rgb(0,0,255)" />
+       inkscape:label="xheight"
+       id="guide19925" />
     <sodipodi:guide
-       id="guide19927"
-       inkscape:label="descender"
-       position="0,0"
-       orientation="0,1"
+       inkscape:color="rgb(0,0,255)"
        inkscape:locked="false"
-       inkscape:color="rgb(0,0,255)" />
+       orientation="0,1"
+       position="0,0"
+       inkscape:label="descender"
+       id="guide19927" />
   </sodipodi:namedview>
   <defs
      id="defs8377">
     <symbol
-       style="display:inline"
-       id="inkstitch_satin_cut_point">
+       id="inkstitch_satin_cut_point"
+       style="display:inline">
       <title
          id="inkstitch_title9427-675">Satin Column cut point</title>
       <path
-         inkscape:connector-curvature="0"
-         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         id="inkstitch_circle13166-3"
          d="m 9.220113,0.07922893 c -1.9e-6,5.10672897 -4.1398241,9.24654997 -9.24655297,9.24654997 -5.10672933,0 -9.24655213,-4.139821 -9.24655403,-9.24654997 1e-7,-2.45233803 0.9741879,-4.80423503 2.7082531,-6.53830103 1.7340653,-1.734065 4.0859624,-2.708252 6.53830093,-2.708252 5.10673007,0 9.24655277,4.139823 9.24655297,9.24655303 0,0 0,0 0,0"
-         id="inkstitch_circle13166-3" />
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         id="path24356"
          d="m -7.8132269,-1.4510415 c -0.4413094,0.88338563 -0.07931,1.96814513 0.8040823,2.40945763 0.8833854,0.44130937 1.9681488,0.079303 2.4094581,-0.8040818 0.1983467,-0.3970378 0.2270074,-0.8329413 0.1264064,-1.23463743 0,0 1.3053145,0.13034233 1.3053145,0.13034233 0,0 3.29416163,3.58901577 3.29416163,3.58901577 0.2487872,-0.7097192 0.2411124,-0.9255141 -0.09365,-1.4617903 0,0 -1.70824193,-1.97779537 -1.70824193,-1.97779537 0,0 2.61658533,0.2619947 2.61658533,0.2619947 0.60556237,0.1061633 0.82089997,-0.3026842 1.25878787,-0.70526413 0,0 -4.8501007,-0.6859624 -4.8501007,-0.6859624 0,0 -0.9370561,-1.0856429 -0.9370561,-1.0856429 0.4268116,-0.1490142 0.7990019,-0.4558243 1.0156363,-0.8894695 0.4413094,-0.8833854 0.079303,-1.9681487 -0.8040822,-2.4094581 -0.8833921,-0.4413128 -1.9681487,-0.079303 -2.4094581,0.8040822 -0.3590398,0.7187033 -0.1792857,1.5648425 0.373288,2.0951784 0,0 -0.014508,0.00264 -0.014508,0.00264 0,0 1.1504733,1.2533541 1.1504733,1.2533541 0,0 -1.3945129,-0.196367 -1.3945129,-0.196367 -0.8248385,-0.2578481 -1.7446631,0.1079194 -2.1425563,0.9043974 0,0 -2.71e-5,3.4e-6 -2.71e-5,3.4e-6 m 0.6765348,0.337974 c 0.2586549,-0.517759 0.877184,-0.7241797 1.3949495,-0.4655215 0.5177589,0.2586549 0.7241761,0.87719093 0.4655214,1.39494953 -0.2586548,0.5177587 -0.8771906,0.7241758 -1.3949494,0.4655211 -0.5177657,-0.2586579 -0.7241762,-0.8771902 -0.4655215,-1.39494913 0,0 0,0 0,0 m 2.0278432,-4.0592094 c 0.2586548,-0.5177589 0.8771839,-0.7241794 1.3949495,-0.4655213 0.5177588,0.2586548 0.724176,0.8771905 0.4655213,1.3949494 -0.2586548,0.5177588 -0.8771906,0.7241761 -1.3949494,0.4655213 -0.5177656,-0.2586581 -0.7241761,-0.8771906 -0.4655214,-1.3949494 0,0 0,0 0,0"
-         id="path24356" />
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         inkscape:connector-curvature="0" />
       <path
-         inkscape:connector-curvature="0"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="path24362"
          d="m 4.4798843,-4.3110508 c 0.219827,2.414579 -0.180079,4.01786863 -1.429103,5.5454305 0,0 2.023437,1.0507812 2.023437,1.0507812 1.715964,-1.67359867 1.847271,-3.9809016 1.75755,-6.660665 0,0 -2.351884,0.064453 -2.351884,0.064453 m -2.097072,6.2192586 c -2.10168637,1.4056146 -3.14434337,3.5358281 -3.667017,6.0218201 0,0 2.3918915,0.212651 2.3918915,0.212651 0.3238246,-2.741001 2.2229845,-4.191785 3.3298135,-5.1368148 0,0 -2.054688,-1.0976563 -2.054688,-1.0976563"
-         id="path24362" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
     </symbol>
   </defs>
   <metadata
@@ -111,15 +111,693 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
+     inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     inkscape:label="Layer 1" />
+     id="layer1" />
   <g
-     id="g20096"
+     inkscape:label="GlyphLayer-A"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20096">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7548-7"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7550-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7570-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+  <g
+     id="g20473"
      style="display:none"
      inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-A">
+     inkscape:label="GlyphLayer-B">
     <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7385"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       id="path9054"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
+       embroider_repeats=""
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_running_stitch_length_mm="1.5"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9052"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g20573"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-C">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       id="path7387"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscccsccccscccscc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-D"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20639">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7389" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13248" />
+  </g>
+  <g
+     id="g20732"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-E">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
+       id="path14019"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
+       id="path14015"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       id="path7391"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.9392548,6.7571256 c 0,0 0,17.7368994 0,17.7368994 M 11.565268,6.8071156 c 0,0 0,17.6026194 0,17.6026194"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
+       id="path14011"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-F"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20851">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
+       id="path14015-0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       id="path7391-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.77006,6.69201 c 0,0 0,18.27026 0,18.27026 M 13.39607,6.742 c 0,0 0,18.13598 0,18.13598"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
+       id="path14019-6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21249"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-G">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14890"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       sodipodi:nodetypes="ccccscscscccsscscscccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14866"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       id="path14868"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g21438"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-H">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path18656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path18640"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path18642"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-I"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21538">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7399"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-J"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21746">
+    <path
+       sodipodi:nodetypes="ccscscccscsc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7401-1" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-K"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22082">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7403"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path22148"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+  <g
+     id="g22205"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-L">
+    <path
+       id="path7405"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path24793"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-M"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22344">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path7407"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path26115"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path26117"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path26119"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g22488"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-N">
+    <path
+       id="path27051"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       id="path27049"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       id="path7409"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-O"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g14481">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7411"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-P"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g14770">
+    <path
+       id="path29324"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path29322"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccsccsccssc" />
+  </g>
+  <g
+     id="g15502"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Q">
+    <path
+       id="path30716"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.74008,24.7112 c -1.28002,0.60999 -2.83572,0.85445 -4.01673,0.88612 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82867 -2.444,-4.27267 -2.444,-7.332 0,-3.068 0.81467,-5.512 2.444,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72133,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332 0,2.25333 -0.45501,4.18166 -1.365,5.785 -0.42739,0.76024 -0.94635,1.42599 -1.5569,1.99722 m -3.65284,-0.31068 c -0.7127,0.30563 -1.51112,0.45844 -2.39526,0.45844 -1.90667,0 -3.42334,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12666,-1.42134 2.64333,-2.132 4.55,-2.132 1.90667,0 3.41466,0.71066 4.524,2.132 1.11799,1.42133 1.677,3.35833 1.677,5.811 0,1.70168 -0.271,3.15547 -0.813,4.36138 -0.30413,0.65637 -0.65817,1.1707 -1.0577,1.67288"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccscscscccscscscscc" />
+    <path
+       id="path30718"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-R"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15673">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path32125"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7417"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="csccccccsccccc"
+       inkscape:connector-curvature="0"
+       id="path32150"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g15839"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-S">
+    <path
+       id="path7419"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g16335"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-T">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path34968"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
        embroider_zigzag_underlay="False"
        embroider_contour_underlay="False"
@@ -127,317 +805,211 @@
        embroider_pull_compensation_mm="0.2"
        embroider_satin_column="True"
        embroider_zigzag_spacing_mm="0.4"
-       id="path7548-7"
+       id="path7421"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path31333"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-U"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16687">
+    <path
+       sodipodi:nodetypes="cscscsccscscsc"
+       inkscape:connector-curvature="0"
+       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7423"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g16861"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-V">
+    <path
+       id="path37800"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       id="path7425"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-W"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17062">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path7427"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="path39250"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="path39252"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path39256"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17279"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-X">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path40772"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path40754"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path40770"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path40760"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Y"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17493">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7431" />
     <path
        sodipodi:nodetypes="ccccccccc"
        inkscape:connector-curvature="0"
-       id="path7550-3"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       sodipodi:nodetypes="ccccccc"
-       inkscape:connector-curvature="0"
-       id="path7570-6"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-B"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20473">
-    <path
-       inkscape:connector-curvature="0"
-       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7385"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_running_stitch_length_mm="1.5"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_repeats=""
-       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9054"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path9052"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-C"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20573">
-    <path
-       sodipodi:nodetypes="ccscccsccccscccscc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7387"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     id="g20639"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-D">
-    <path
-       id="path7389"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path13248"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-E"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20732">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path14019"
-       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path14015"
-       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.9392548,6.7571256 c 0,0 0,17.7368994 0,17.7368994 M 11.565268,6.8071156 c 0,0 0,17.6026194 0,17.6026194"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7391"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path14011"
-       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     id="g20851"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-F">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path14015-0"
-       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.77006,6.69201 c 0,0 0,18.27026 0,18.27026 M 13.39607,6.742 c 0,0 0,18.13598 0,18.13598"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7391-0"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path14019-6"
-       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-G"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21249">
-    <path
-       sodipodi:nodetypes="ccccscscscccsscscscccccc"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       inkscape:connector-curvature="0"
-       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path14890"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path14866"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path14868"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-H"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21438">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path18656"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path18640"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path18642"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-  </g>
-  <g
-     id="g21538"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-I">
-    <path
        embroider_zigzag_underlay="False"
        embroider_contour_underlay="False"
        embroider_center_walk_underlay_stitch_length_mm="1.2"
@@ -445,2158 +1017,1601 @@
        embroider_pull_compensation_mm="0.2"
        embroider_satin_column="True"
        embroider_zigzag_spacing_mm="0.4"
-       id="path7399"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-  </g>
-  <g
-     id="g21746"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-J">
-    <path
-       id="path7401-1"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccscscccscsc" />
-  </g>
-  <g
-     id="g22082"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-K">
-    <path
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path7403"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path22148"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-L"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g22205">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7405" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path24793" />
-  </g>
-  <g
-     id="g22344"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-M">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7407"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path26115"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path26117"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path26119"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-N"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g22488">
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path27051" />
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path27049" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7409" />
-  </g>
-  <g
-     id="g14481"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-O">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path7411"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g14770"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-P">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path29324" />
-    <path
-       sodipodi:nodetypes="cscccsccsccssc"
-       inkscape:connector-curvature="0"
-       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path29322"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-Q"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g15502">
-    <path
-       sodipodi:nodetypes="cccscscscccscscscscc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 18.74008,24.7112 c -1.28002,0.60999 -2.83572,0.85445 -4.01673,0.88612 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82867 -2.444,-4.27267 -2.444,-7.332 0,-3.068 0.81467,-5.512 2.444,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72133,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332 0,2.25333 -0.45501,4.18166 -1.365,5.785 -0.42739,0.76024 -0.94635,1.42599 -1.5569,1.99722 m -3.65284,-0.31068 c -0.7127,0.30563 -1.51112,0.45844 -2.39526,0.45844 -1.90667,0 -3.42334,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12666,-1.42134 2.64333,-2.132 4.55,-2.132 1.90667,0 3.41466,0.71066 4.524,2.132 1.11799,1.42133 1.677,3.35833 1.677,5.811 0,1.70168 -0.271,3.15547 -0.813,4.36138 -0.30413,0.65637 -0.65817,1.1707 -1.0577,1.67288"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path30716" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path30718" />
-  </g>
-  <g
-     id="g15673"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-R">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path32125"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7417"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path32150"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csccccccsccccc" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-S"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g15839">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7419" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-T"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g16335">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path34968"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7421"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path31333"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-  </g>
-  <g
-     id="g16687"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-U">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path7423"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cscscsccscscsc" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-V"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g16861">
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path37800" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7425" />
-  </g>
-  <g
-     id="g17062"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-W">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7427"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path39250"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path39252"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path39256"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-X"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g17279">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path40772"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path40754" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path40770"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path40760" />
-  </g>
-  <g
-     id="g17493"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-Y">
-    <path
-       id="path7431"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       id="path42255"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 13.54868,25.00103 v -8.95889 l 1.24202,-2.184 5.343,-7.76103 m -3.94602,18.90392 v -8.95889 l 6.864,-9.94503 M 12.92754,19.32583 h 4.07293"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccc" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path42255" />
   </g>
   <g
-     inkscape:label="GlyphLayer-Z"
-     inkscape:groupmode="layer"
+     id="g17715"
      style="display:none"
-     id="g17715">
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Z">
     <path
-       inkscape:connector-curvature="0"
-       id="path43759"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        d="m 7.62245,8.53258 c 0,0 14.93072,0 14.93072,0 M 7.62245,5.83771 c 0,0 15.24899,0 15.24899,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path43761"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path43759"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        d="m 19.59544,8.53258 c 0,0 -12.272,14.22726 -12.272,14.22726 m 15.548,-14.43526 c 0,0 -12.272,14.22726 -12.272,14.22726"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path43765"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path43761"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        d="m 7.32344,25.24671 c 0,0 15.847,0 15.847,0 M 7.39928,22.55184 c 0,0 15.77116,0 15.77116,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path43765"
+       inkscape:connector-curvature="0" />
   </g>
   <g
-     id="g17946"
-     style="display:none"
+     inkscape:label="GlyphLayer-a"
      inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-a">
+     style="display:none"
+     id="g17946">
     <path
-       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        id="path847"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626" />
+    <path
+       sodipodi:nodetypes="ccsscccscccc"
+       inkscape:connector-curvature="0"
        id="path4609"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccsscccscccc" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
   </g>
   <g
-     inkscape:label="GlyphLayer-b"
-     inkscape:groupmode="layer"
+     id="g18617"
      style="display:none"
-     id="g18617">
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-b">
     <path
-       inkscape:connector-curvature="0"
-       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        id="path13821"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       sodipodi:nodetypes="cccccc" />
-    <path
-       id="path13834"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
        d="m 18.543215,22.122558 1.53398,2.98178 m -7.487063,-9.949696 c 0.219817,-0.472451 0.798071,-1.186277 1.066153,-1.556484 0.727998,-0.996667 1.724667,-1.495001 2.99,-1.495001 1.26533,0 2.261998,0.498334 2.989997,1.495001 0.719336,1.005332 1.079002,2.387666 1.079002,4.147 0,1.759334 -0.359666,3.137334 -1.079002,4.133998 -0.727999,1.005335 -1.724667,1.508003 -2.989997,1.508003 -1.265333,0 -2.309552,-0.454787 -3.038749,-1.45925 -0.297301,-0.409532 -0.768484,-1.125174 -0.99504,-1.467049 m -0.04822,-8.384717 c 1.213352,-1.708275 2.873841,-1.961664 4.666998,-1.974985 1.759334,0 3.193667,0.702 4.303,2.106 1.100667,1.404 1.651001,3.249999 1.651004,5.538 4e-6,2.287999 -0.550329,4.133998 -1.650996,5.537998 -1.109334,1.404 -2.543666,2.106002 -4.303,2.106002 -2.022659,-0.0012 -3.640858,-0.657066 -4.666998,-2.009457 m 5.1909,-10.766297 1.023752,-2.827501"
-       inkscape:connector-curvature="0"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_zigzag_spacing_mm="0.4" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13834" />
   </g>
   <g
-     id="g18852"
-     style="display:none"
+     inkscape:label="GlyphLayer-c"
      inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-c">
+     style="display:none"
+     id="g18852">
     <path
-       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        id="path9367"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845" />
   </g>
   <g
-     inkscape:label="GlyphLayer-d"
-     inkscape:groupmode="layer"
+     id="g19099"
      style="display:none"
-     id="g19099">
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-d">
     <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
+       id="path13733-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 19.6495,12.076147 c -1.21335,-1.708275 -2.87384,-1.961664 -4.667,-1.974985 -1.75933,0 -3.19366,0.702 -4.303,2.106 -1.10066,1.404 -1.651,3.249999 -1.651,5.538 0,2.287999 0.55034,4.133998 1.651,5.537998 1.10934,1.404 2.54367,2.106002 4.303,2.106002 2.02266,-0.0012 3.64086,-0.657066 4.667,-2.009457 m -0.0108,-7.606268 c -0.17604,-0.856546 -0.65135,-1.581636 -1.08123,-2.175275 -0.728,-0.996667 -1.72466,-1.495001 -2.99,-1.495001 -1.26533,0 -2.262,0.498334 -2.98999,1.495001 -0.71934,1.005332 -1.07901,2.387666 -1.07901,4.147 0,1.759334 0.35967,3.137334 1.07901,4.133998 0.72799,1.005335 1.72466,1.508003 2.98999,1.508003 1.26534,0 2.262,-0.502668 2.99,-1.508003 0.42152,-0.577075 0.89336,-1.281992 1.07082,-2.114749 m -7.7085,-1.739755 c 0,0 -3.46125,-0.04875 -3.46125,-0.04875 m 7.90905,-5.177876 c 0,0 -0.10341,-3.274787 -0.10341,-3.274787 m 0.27576,12.892325 c 0,0 -0.0345,3.171371 -0.0345,3.171371"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path13733-0" />
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
        id="path9395-2"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g19346"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-e">
-    <path
-       sodipodi:nodetypes="cccc"
-       id="path6501"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="ccscscsccccsccccscccccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9371"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-f"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20089">
-    <path
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       inkscape:connector-curvature="0"
-       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path4599" />
-    <path
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       inkscape:connector-curvature="0"
-       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9759" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       id="path4595"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g20354"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-g">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9375"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="ccscccccscsccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path6095"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-h"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20629">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path6479" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path6452" />
-  </g>
-  <g
-     id="g20904"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-i">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path6852"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path9379"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-j"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21185">
-    <path
-       inkscape:connector-curvature="0"
-       id="path9381"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path7095"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g21481"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-k">
-    <path
-       id="path7639"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccc" />
-    <path
-       id="path9383"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-l"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21769">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path9385"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161" />
-  </g>
-  <g
-     id="g22083"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-m">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9321"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccc" />
-    <path
-       id="path9327"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccc" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9331"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-n"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g22392">
-    <path
-       inkscape:connector-curvature="0"
-       id="path9321-7"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       sodipodi:nodetypes="cccccc" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9327-6" />
-  </g>
-  <g
-     id="g22701"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-o">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9391"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-p"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g15223">
-    <path
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path17144"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       sodipodi:nodetypes="cccscccccscscssccccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       inkscape:connector-curvature="0"
-       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path17180"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     id="g15551"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-q">
-    <path
-       sodipodi:nodetypes="cccscccccscscssccccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay="True"
-       inkscape:connector-curvature="0"
-       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path17180-3"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path17144-6"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-r"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g16497">
-    <path
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path22973"
-       embroider_center_walk_underlay="True"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path22967"
-       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  </g>
-  <g
-     id="g16825"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-s">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9399"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-t"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g17173">
-    <path
-       embroider_pull_compensation_mm="0.2"
-       id="path55570"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
-       inkscape:connector-curvature="0"
-       embroider_satin_column="True"
-       embroider_center_walk_underlay="True"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       embroider_pull_compensation_mm="0.2"
-       id="path26331"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
-       inkscape:connector-curvature="0"
-       embroider_satin_column="True"
-       embroider_center_walk_underlay="True"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path26335" />
-  </g>
-  <g
-     id="g17518"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-u">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9403"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path28174"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-v"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g17883">
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path7425-5" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path37800-7" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-w"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g18646">
-    <path
-       id="path18119"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccc"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_zigzag_spacing_mm="0.4" />
-    <path
-       id="path18117"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_zigzag_spacing_mm="0.4" />
-    <path
-       id="path18115"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_zigzag_spacing_mm="0.4" />
-    <path
-       id="path9407"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_zigzag_spacing_mm="0.4" />
-  </g>
-  <g
-     id="g19389"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-x">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path30893"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path30901"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9409"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-y"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g19767">
-    <path
-       inkscape:connector-curvature="0"
-       id="path31664"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path31668"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g20153"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-z">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path9413"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3140"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3142"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-0"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g20540">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path49864"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488" />
-  </g>
-  <g
-     id="g20941"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-1">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path53139"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path53135"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path53129"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-2"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21342">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49868" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path54384" />
-  </g>
-  <g
-     id="g21752"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-3">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path55631"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49870"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-4"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g22181">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49872" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path58727" />
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path58735" />
-    <path
-       sodipodi:nodetypes="cccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path58741" />
-  </g>
-  <g
-     id="g23013"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-5">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49874"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path74136"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g24259"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-6">
-    <path
-       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path77434" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-7"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g24692">
-    <path
-       inkscape:connector-curvature="0"
-       id="path1140"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path1142"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g25126"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-8">
-    <path
-       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc"
-       id="path49880"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-9"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g25564">
-    <path
-       inkscape:connector-curvature="0"
-       id="path3771"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-@"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g27314">
-    <path
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_center_walk_underlay="True"
-       inkscape:connector-curvature="0"
-       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3259"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-    <path
-       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3287"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g27781"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-&lt;">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path60030"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path60034"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-&gt;"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g28228">
-    <path
-       inkscape:connector-curvature="0"
-       id="path60030-7"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path60034-0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g28695"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-:">
-    <path
-       id="path64532"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path49890"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-,"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g29163">
-    <path
-       inkscape:connector-curvature="0"
-       id="path49892"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g29625"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-'">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-&quot;"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g30411">
-    <path
-       sodipodi:nodetypes="cccccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-62-1-23"
-       inkscape:connector-curvature="0" />
-    <path
-       sodipodi:nodetypes="cccccc"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-6-6-0"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g34046"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-“">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-62-1"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-6-6"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-”"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g34542">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-6-6-9"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49892-9-62-1-2"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g35054"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-.">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path49894"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     id="g36092"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-+">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path70194" />
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path70206" />
-    <path
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path70200"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_center_walk_underlay_stitch_length_mm="1.2" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer--"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g36598">
-    <path
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path72155" />
-  </g>
-  <g
-     id="g37137"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-=">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path72806"
-       inkscape:connector-curvature="0" />
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path72814"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-("
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g37653">
-    <path
-       inkscape:connector-curvature="0"
-       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path11049"
-       embroider_zigzag_spacing_mm="0.4"
-       embroider_satin_column="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_center_walk_underlay="True"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_contour_underlay="False"
-       embroider_zigzag_underlay="False" />
-  </g>
-  <g
-     id="g38173"
-     style="display:none"
-     inkscape:groupmode="layer"
-     inkscape:label="GlyphLayer-)">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path11049-4"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-_"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g38697">
-    <path
-       sodipodi:nodetypes="cccc"
-       inkscape:connector-curvature="0"
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path72155-7" />
-  </g>
-  <g
-     inkscape:label="GlyphLayer-/"
-     inkscape:groupmode="layer"
-     style="display:none"
-     id="g21638">
-    <path
-       embroider_zigzag_underlay="False"
-       embroider_contour_underlay="False"
-       embroider_center_walk_underlay_stitch_length_mm="1.2"
-       embroider_center_walk_underlay="True"
-       embroider_pull_compensation_mm="0.2"
-       embroider_satin_column="True"
-       embroider_zigzag_spacing_mm="0.4"
-       id="path7399-5"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-e"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19346">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6501"
+       sodipodi:nodetypes="cccc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9371"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="ccscscsccccsccccscccccc" />
+  </g>
+  <g
+     id="g20089"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-f">
+    <path
+       id="path4599"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       id="path9759"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4595"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-g"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20354">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9375"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path6095"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="ccscccccscsccc" />
+  </g>
+  <g
+     id="g20629"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-h">
+    <path
+       id="path6479"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path6452"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-i"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20904">
+    <path
+       inkscape:connector-curvature="0"
+       id="path6852"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9379" />
+  </g>
+  <g
+     id="g21185"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-j">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9381"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7095"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-k"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21481">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7639" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9383" />
+  </g>
+  <g
+     id="g21769"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-l">
+    <path
+       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9385"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-m"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22083">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="path9321"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9327" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g22392"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-n">
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9321-7"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9327-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-o"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22701">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9391"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g15223"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-p">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path17144"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       id="path17180"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccscccccscscssccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-q"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15551">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       id="path17180-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccscccccscscssccccc" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path17144-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True" />
+  </g>
+  <g
+     id="g16497"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-r">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay="True"
+       id="path22973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
+       id="path22967"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-s"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16825">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9399"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17173"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-t">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay="True"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path55570"
+       embroider_pull_compensation_mm="0.2" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay="True"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26331"
+       embroider_pull_compensation_mm="0.2" />
+    <path
+       id="path26335"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-u"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17518">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9403"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path28174"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17883"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-v">
+    <path
+       id="path7425-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       id="path37800-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     id="g18646"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-w">
+    <path
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18119" />
+    <path
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18117" />
+    <path
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18115" />
+    <path
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9407" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-x"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19389">
+    <path
+       inkscape:connector-curvature="0"
+       id="path30893"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path30901"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9409"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g19767"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-y">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31664"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31668"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-z"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20153">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9413"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3140"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20540"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-0">
+    <path
+       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49864"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-1"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20941">
+    <path
+       inkscape:connector-curvature="0"
+       id="path53139"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path53135"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path53129"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21342"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-2">
+    <path
+       id="path49868"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54384"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-3"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21752">
+    <path
+       inkscape:connector-curvature="0"
+       id="path55631"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path49870"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g22181"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-4">
+    <path
+       id="path49872"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path58727"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path58735"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path58741"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-5"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g23013">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49874"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path74136" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-6"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g24259">
+    <path
+       id="path77434"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc" />
+  </g>
+  <g
+     id="g24692"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-7">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1140"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path1142"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-8"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g25126">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49880"
+       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc" />
+  </g>
+  <g
+     id="g25564"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-9">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3771"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g27314"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-@">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path3259"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay="True"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path3287"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&lt;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g27781">
+    <path
+       inkscape:connector-curvature="0"
+       id="path60030"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path60034"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g28228"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&gt;">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60030-7"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60034-0"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-:"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g28695">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path64532" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49890" />
+  </g>
+  <g
+     id="g29163"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-,">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-'"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g29625">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g30411"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&quot;">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-62-1-23"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-6-6-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-“"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g34046">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-62-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-6-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g34542"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-”">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-6-6-9"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892-9-62-1-2"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-."
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g35054">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49894"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-+"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g36092">
+    <path
+       id="path70194"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path70206"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path70200"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True" />
+  </g>
+  <g
+     id="g36598"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer--">
+    <path
+       id="path72155"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-="
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g37137">
+    <path
+       inkscape:connector-curvature="0"
+       id="path72806"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path72814"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g37653"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-(">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path11049"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-)"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g38173">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path11049-4"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g38697"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-_">
+    <path
+       id="path72155-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21638"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-/">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7399-5"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21881"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-�">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.37795275;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1"
+       embroider_satin_column="true"
+       d="m 14.773481,8.5147097 h 0.789182 4.754671 V 22.524456 H 9.8106215 V 8.5147097 h 4.9628595 m 0,-2.4944882 h 0.789182 7.249159 V 25.018944 H 7.3161333 V 6.0202215 h 7.4573477 m 3.700266,2.7708704 V 5.6491375 m 1.219965,15.4117875 h 3.394492 m -11.621622,0.839909 v 3.741732 M 10.181706,10.372832 H 6.8819148 m 3.2827452,10.630497 -3.3461303,0.03157 m 11.7114563,0.66291 v 3.756505 m 1.199556,-15.02602 h 3.377697 M 11.332649,8.9762002 V 5.7247717"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="0.90" />
   </g>
 </svg>

--- a/fonts/small_font/→.svg
+++ b/fonts/small_font/→.svg
@@ -1,0 +1,2602 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   id="svg8375"
+   version="1.1"
+   inkscape:version="0.92.3 (unknown)"
+   sodipodi:docname="→.svg">
+  <sodipodi:namedview
+     inkscape:snap-global="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="7.2322999"
+     inkscape:cy="20.584539"
+     inkscape:document-units="px"
+     inkscape:current-layer="g34046"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <sodipodi:guide
+       id="guide19919"
+       inkscape:label="baseline"
+       position="0,5"
+       orientation="0.00059113112,0.99999983"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19921"
+       inkscape:label="ascender"
+       position="0,25.67"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19923"
+       inkscape:label="caps"
+       position="19.697974,23.959556"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19925"
+       inkscape:label="xheight"
+       position="0,19.598"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19927"
+       inkscape:label="descender"
+       position="0,0"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <defs
+     id="defs8377">
+    <symbol
+       style="display:inline"
+       id="inkstitch_satin_cut_point">
+      <title
+         id="inkstitch_title9427-675">Satin Column cut point</title>
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.220113,0.07922893 c -1.9e-6,5.10672897 -4.1398241,9.24654997 -9.24655297,9.24654997 -5.10672933,0 -9.24655213,-4.139821 -9.24655403,-9.24654997 1e-7,-2.45233803 0.9741879,-4.80423503 2.7082531,-6.53830103 1.7340653,-1.734065 4.0859624,-2.708252 6.53830093,-2.708252 5.10673007,0 9.24655277,4.139823 9.24655297,9.24655303 0,0 0,0 0,0"
+         id="inkstitch_circle13166-3" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -7.8132269,-1.4510415 c -0.4413094,0.88338563 -0.07931,1.96814513 0.8040823,2.40945763 0.8833854,0.44130937 1.9681488,0.079303 2.4094581,-0.8040818 0.1983467,-0.3970378 0.2270074,-0.8329413 0.1264064,-1.23463743 0,0 1.3053145,0.13034233 1.3053145,0.13034233 0,0 3.29416163,3.58901577 3.29416163,3.58901577 0.2487872,-0.7097192 0.2411124,-0.9255141 -0.09365,-1.4617903 0,0 -1.70824193,-1.97779537 -1.70824193,-1.97779537 0,0 2.61658533,0.2619947 2.61658533,0.2619947 0.60556237,0.1061633 0.82089997,-0.3026842 1.25878787,-0.70526413 0,0 -4.8501007,-0.6859624 -4.8501007,-0.6859624 0,0 -0.9370561,-1.0856429 -0.9370561,-1.0856429 0.4268116,-0.1490142 0.7990019,-0.4558243 1.0156363,-0.8894695 0.4413094,-0.8833854 0.079303,-1.9681487 -0.8040822,-2.4094581 -0.8833921,-0.4413128 -1.9681487,-0.079303 -2.4094581,0.8040822 -0.3590398,0.7187033 -0.1792857,1.5648425 0.373288,2.0951784 0,0 -0.014508,0.00264 -0.014508,0.00264 0,0 1.1504733,1.2533541 1.1504733,1.2533541 0,0 -1.3945129,-0.196367 -1.3945129,-0.196367 -0.8248385,-0.2578481 -1.7446631,0.1079194 -2.1425563,0.9043974 0,0 -2.71e-5,3.4e-6 -2.71e-5,3.4e-6 m 0.6765348,0.337974 c 0.2586549,-0.517759 0.877184,-0.7241797 1.3949495,-0.4655215 0.5177589,0.2586549 0.7241761,0.87719093 0.4655214,1.39494953 -0.2586548,0.5177587 -0.8771906,0.7241758 -1.3949494,0.4655211 -0.5177657,-0.2586579 -0.7241762,-0.8771902 -0.4655215,-1.39494913 0,0 0,0 0,0 m 2.0278432,-4.0592094 c 0.2586548,-0.5177589 0.8771839,-0.7241794 1.3949495,-0.4655213 0.5177588,0.2586548 0.724176,0.8771905 0.4655213,1.3949494 -0.2586548,0.5177588 -0.8771906,0.7241761 -1.3949494,0.4655213 -0.5177656,-0.2586581 -0.7241761,-0.8771906 -0.4655214,-1.3949494 0,0 0,0 0,0"
+         id="path24356" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 4.4798843,-4.3110508 c 0.219827,2.414579 -0.180079,4.01786863 -1.429103,5.5454305 0,0 2.023437,1.0507812 2.023437,1.0507812 1.715964,-1.67359867 1.847271,-3.9809016 1.75755,-6.660665 0,0 -2.351884,0.064453 -2.351884,0.064453 m -2.097072,6.2192586 c -2.10168637,1.4056146 -3.14434337,3.5358281 -3.667017,6.0218201 0,0 2.3918915,0.212651 2.3918915,0.212651 0.3238246,-2.741001 2.2229845,-4.191785 3.3298135,-5.1368148 0,0 -2.054688,-1.0976563 -2.054688,-1.0976563"
+         id="path24362" />
+    </symbol>
+  </defs>
+  <metadata
+     id="metadata8380">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1" />
+  <g
+     id="g20096"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-A">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7548-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7550-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="path7570-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-B"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20473">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7385"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_running_stitch_length_mm="1.5"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_repeats=""
+       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9054"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9052"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-C"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20573">
+    <path
+       sodipodi:nodetypes="ccscccsccccscccscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7387"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20639"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-D">
+    <path
+       id="path7389"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path13248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-E"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20732">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019"
+       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015"
+       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.9392548,6.7571256 c 0,0 0,17.7368994 0,17.7368994 M 11.565268,6.8071156 c 0,0 0,17.6026194 0,17.6026194"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14011"
+       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20851"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-F">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015-0"
+       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.77006,6.69201 c 0,0 0,18.27026 0,18.27026 M 13.39607,6.742 c 0,0 0,18.13598 0,18.13598"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391-0"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019-6"
+       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-G"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21249">
+    <path
+       sodipodi:nodetypes="ccccscscscccsscscscccccc"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14890"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14866"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14868"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-H"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21438">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18656"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18640"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18642"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21538"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-I">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21746"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-J">
+    <path
+       id="path7401-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscccscsc" />
+  </g>
+  <g
+     id="g22082"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-K">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7403"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22148"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-L"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22205">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7405" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path24793" />
+  </g>
+  <g
+     id="g22344"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-M">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7407"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26115"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26117"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26119"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-N"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22488">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27051" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27049" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7409" />
+  </g>
+  <g
+     id="g14481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-O">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7411"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g14770"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-P">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29324" />
+    <path
+       sodipodi:nodetypes="cscccsccsccssc"
+       inkscape:connector-curvature="0"
+       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29322"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Q"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15502">
+    <path
+       sodipodi:nodetypes="cccscscscccscscscscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.74008,24.7112 c -1.28002,0.60999 -2.83572,0.85445 -4.01673,0.88612 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82867 -2.444,-4.27267 -2.444,-7.332 0,-3.068 0.81467,-5.512 2.444,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72133,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332 0,2.25333 -0.45501,4.18166 -1.365,5.785 -0.42739,0.76024 -0.94635,1.42599 -1.5569,1.99722 m -3.65284,-0.31068 c -0.7127,0.30563 -1.51112,0.45844 -2.39526,0.45844 -1.90667,0 -3.42334,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12666,-1.42134 2.64333,-2.132 4.55,-2.132 1.90667,0 3.41466,0.71066 4.524,2.132 1.11799,1.42133 1.677,3.35833 1.677,5.811 0,1.70168 -0.271,3.15547 -0.813,4.36138 -0.30413,0.65637 -0.65817,1.1707 -1.0577,1.67288"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30716" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30718" />
+  </g>
+  <g
+     id="g15673"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-R">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32125"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7417"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccccsccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-S"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15839">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7419" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-T"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16335">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path34968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7421"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31333"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g16687"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-U">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7423"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscscsccscscsc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-V"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16861">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425" />
+  </g>
+  <g
+     id="g17062"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-W">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7427"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39250"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39252"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39256"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-X"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17279">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40772"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40754" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40770"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40760" />
+  </g>
+  <g
+     id="g17493"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Y">
+    <path
+       id="path7431"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path42255"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.54868,25.00103 v -8.95889 l 1.24202,-2.184 5.343,-7.76103 m -3.94602,18.90392 v -8.95889 l 6.864,-9.94503 M 12.92754,19.32583 h 4.07293"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Z"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17715">
+    <path
+       inkscape:connector-curvature="0"
+       id="path43759"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.62245,8.53258 c 0,0 14.93072,0 14.93072,0 M 7.62245,5.83771 c 0,0 15.24899,0 15.24899,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43761"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.59544,8.53258 c 0,0 -12.272,14.22726 -12.272,14.22726 m 15.548,-14.43526 c 0,0 -12.272,14.22726 -12.272,14.22726"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43765"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.32344,25.24671 c 0,0 15.847,0 15.847,0 M 7.39928,22.55184 c 0,0 15.77116,0 15.77116,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17946"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-a">
+    <path
+       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path847"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4609"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccscccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-b"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18617">
+    <path
+       inkscape:connector-curvature="0"
+       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13821"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path13834"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.543215,22.122558 1.53398,2.98178 m -7.487063,-9.949696 c 0.219817,-0.472451 0.798071,-1.186277 1.066153,-1.556484 0.727998,-0.996667 1.724667,-1.495001 2.99,-1.495001 1.26533,0 2.261998,0.498334 2.989997,1.495001 0.719336,1.005332 1.079002,2.387666 1.079002,4.147 0,1.759334 -0.359666,3.137334 -1.079002,4.133998 -0.727999,1.005335 -1.724667,1.508003 -2.989997,1.508003 -1.265333,0 -2.309552,-0.454787 -3.038749,-1.45925 -0.297301,-0.409532 -0.768484,-1.125174 -0.99504,-1.467049 m -0.04822,-8.384717 c 1.213352,-1.708275 2.873841,-1.961664 4.666998,-1.974985 1.759334,0 3.193667,0.702 4.303,2.106 1.100667,1.404 1.651001,3.249999 1.651004,5.538 4e-6,2.287999 -0.550329,4.133998 -1.650996,5.537998 -1.109334,1.404 -2.543666,2.106002 -4.303,2.106002 -2.022659,-0.0012 -3.640858,-0.657066 -4.666998,-2.009457 m 5.1909,-10.766297 1.023752,-2.827501"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g18852"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-c">
+    <path
+       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9367"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-d"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19099">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.6495,12.076147 c -1.21335,-1.708275 -2.87384,-1.961664 -4.667,-1.974985 -1.75933,0 -3.19366,0.702 -4.303,2.106 -1.10066,1.404 -1.651,3.249999 -1.651,5.538 0,2.287999 0.55034,4.133998 1.651,5.537998 1.10934,1.404 2.54367,2.106002 4.303,2.106002 2.02266,-0.0012 3.64086,-0.657066 4.667,-2.009457 m -0.0108,-7.606268 c -0.17604,-0.856546 -0.65135,-1.581636 -1.08123,-2.175275 -0.728,-0.996667 -1.72466,-1.495001 -2.99,-1.495001 -1.26533,0 -2.262,0.498334 -2.98999,1.495001 -0.71934,1.005332 -1.07901,2.387666 -1.07901,4.147 0,1.759334 0.35967,3.137334 1.07901,4.133998 0.72799,1.005335 1.72466,1.508003 2.98999,1.508003 1.26534,0 2.262,-0.502668 2.99,-1.508003 0.42152,-0.577075 0.89336,-1.281992 1.07082,-2.114749 m -7.7085,-1.739755 c 0,0 -3.46125,-0.04875 -3.46125,-0.04875 m 7.90905,-5.177876 c 0,0 -0.10341,-3.274787 -0.10341,-3.274787 m 0.27576,12.892325 c 0,0 -0.0345,3.171371 -0.0345,3.171371"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13733-0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9395-2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g19346"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-e">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path6501"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscscsccccsccccscccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9371"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-f"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20089">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4599" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9759" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path4595"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20354"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-g">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9375"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscccccscsccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6095"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-h"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20629">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6479" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6452" />
+  </g>
+  <g
+     id="g20904"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-i">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6852"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9379"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-j"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21185">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9381"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7095"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-k">
+    <path
+       id="path7639"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9383"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-l"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21769">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path9385"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161" />
+  </g>
+  <g
+     id="g22083"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-m">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9321"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9327"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9331"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-n"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22392">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9321-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9327-6" />
+  </g>
+  <g
+     id="g22701"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-o">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9391"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-p"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15223">
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g15551"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-q">
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180-3"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144-6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-r"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16497">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path22973"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22967"
+       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     id="g16825"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-s">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9399"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-t"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17173">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path55570"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path26331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26335" />
+  </g>
+  <g
+     id="g17518"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-u">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9403"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path28174"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-v"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17883">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425-5" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-w"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18646">
+    <path
+       id="path18119"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18117"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18115"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path9407"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g19389"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-x">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30893"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30901"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9409"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-y"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19767">
+    <path
+       inkscape:connector-curvature="0"
+       id="path31664"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path31668"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20153"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-z">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9413"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3140"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3142"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-0"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20540">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path49864"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488" />
+  </g>
+  <g
+     id="g20941"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-1">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53139"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53135"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53129"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-2"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21342">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49868" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path54384" />
+  </g>
+  <g
+     id="g21752"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-3">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path55631"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49870"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-4"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22181">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49872" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58727" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58735" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58741" />
+  </g>
+  <g
+     id="g23013"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-5">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49874"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path74136"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g24259"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-6">
+    <path
+       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path77434" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-7"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g24692">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1140"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g25126"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-8">
+    <path
+       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc"
+       id="path49880"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-9"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g25564">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-@"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g27314">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3259"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3287"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g27781"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&lt;">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60030"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60034"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&gt;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g28228">
+    <path
+       inkscape:connector-curvature="0"
+       id="path60030-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path60034-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g28695"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-:">
+    <path
+       id="path64532"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path49890"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-,"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g29163">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g29625"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-'">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&quot;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g30411">
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-23"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-0"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g34046"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-“">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-”"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g34542">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-9"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-2"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g35054"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-.">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49894"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g36092"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-+">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70194" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70206" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70200"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer--"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g36598">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155" />
+  </g>
+  <g
+     id="g37137"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-=">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72806"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72814"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-("
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g37653">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path11049"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g38173"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-)">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path11049-4"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-_"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g38697">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-/"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21638">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/fonts/small_font/↓.svg
+++ b/fonts/small_font/↓.svg
@@ -15,7 +15,7 @@
    id="svg8375"
    version="1.1"
    inkscape:version="0.92.3 (unknown)"
-   sodipodi:docname="small_font.svg">
+   sodipodi:docname="↓.svg">
   <sodipodi:namedview
      inkscape:snap-global="false"
      id="base"
@@ -24,11 +24,11 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="44.8"
-     inkscape:cx="16.674264"
+     inkscape:zoom="22.4"
+     inkscape:cx="11.953282"
      inkscape:cy="14.334539"
      inkscape:document-units="px"
-     inkscape:current-layer="g17173"
+     inkscape:current-layer="layer5"
      showgrid="false"
      units="px"
      inkscape:window-width="1366"
@@ -2598,5 +2598,20 @@
        d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer5"
+     inkscape:label="GlyphLayer-�"
+     style="display:none">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.37795275;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1"
+       embroider_satin_column="true"
+       d="m 14.773481,8.5147102 h 0.789182 4.754671 V 22.524457 H 9.8106215 V 8.5147102 h 4.9628595 m 0,-2.4944882 h 0.789182 7.249159 V 25.018945 H 7.3161333 V 6.020222 h 7.4573477 m 3.700266,2.7708704 V 5.649138 m 1.219965,15.411788 h 3.394492 m -11.621622,0.839909 v 3.741732 M 10.181706,10.372833 H 6.8819148 M 10.16466,21.00333 6.8185297,21.0349 m 11.7114563,0.66291 v 3.756505 m 1.199556,-15.02602 h 3.377697 M 11.332649,8.9762007 V 5.7247722"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="0.90" />
   </g>
 </svg>

--- a/fonts/small_font/↓.svg
+++ b/fonts/small_font/↓.svg
@@ -1,0 +1,2602 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="30"
+   height="30"
+   viewBox="0 0 30 30"
+   id="svg8375"
+   version="1.1"
+   inkscape:version="0.92.3 (unknown)"
+   sodipodi:docname="small_font.svg">
+  <sodipodi:namedview
+     inkscape:snap-global="false"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="16.674264"
+     inkscape:cy="14.334539"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17173"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <sodipodi:guide
+       id="guide19919"
+       inkscape:label="baseline"
+       position="0,5"
+       orientation="0.00059113112,0.99999983"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19921"
+       inkscape:label="ascender"
+       position="0,25.67"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19923"
+       inkscape:label="caps"
+       position="19.697974,23.959556"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19925"
+       inkscape:label="xheight"
+       position="0,19.598"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       id="guide19927"
+       inkscape:label="descender"
+       position="0,0"
+       orientation="0,1"
+       inkscape:locked="false"
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <defs
+     id="defs8377">
+    <symbol
+       style="display:inline"
+       id="inkstitch_satin_cut_point">
+      <title
+         id="inkstitch_title9427-675">Satin Column cut point</title>
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;fill-rule:evenodd;stroke:#003399;stroke-width:1.06500006;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:3.19500017, 3.19500017;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 9.220113,0.07922893 c -1.9e-6,5.10672897 -4.1398241,9.24654997 -9.24655297,9.24654997 -5.10672933,0 -9.24655213,-4.139821 -9.24655403,-9.24654997 1e-7,-2.45233803 0.9741879,-4.80423503 2.7082531,-6.53830103 1.7340653,-1.734065 4.0859624,-2.708252 6.53830093,-2.708252 5.10673007,0 9.24655277,4.139823 9.24655297,9.24655303 0,0 0,0 0,0"
+         id="inkstitch_circle13166-3" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.37812883;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         d="m -7.8132269,-1.4510415 c -0.4413094,0.88338563 -0.07931,1.96814513 0.8040823,2.40945763 0.8833854,0.44130937 1.9681488,0.079303 2.4094581,-0.8040818 0.1983467,-0.3970378 0.2270074,-0.8329413 0.1264064,-1.23463743 0,0 1.3053145,0.13034233 1.3053145,0.13034233 0,0 3.29416163,3.58901577 3.29416163,3.58901577 0.2487872,-0.7097192 0.2411124,-0.9255141 -0.09365,-1.4617903 0,0 -1.70824193,-1.97779537 -1.70824193,-1.97779537 0,0 2.61658533,0.2619947 2.61658533,0.2619947 0.60556237,0.1061633 0.82089997,-0.3026842 1.25878787,-0.70526413 0,0 -4.8501007,-0.6859624 -4.8501007,-0.6859624 0,0 -0.9370561,-1.0856429 -0.9370561,-1.0856429 0.4268116,-0.1490142 0.7990019,-0.4558243 1.0156363,-0.8894695 0.4413094,-0.8833854 0.079303,-1.9681487 -0.8040822,-2.4094581 -0.8833921,-0.4413128 -1.9681487,-0.079303 -2.4094581,0.8040822 -0.3590398,0.7187033 -0.1792857,1.5648425 0.373288,2.0951784 0,0 -0.014508,0.00264 -0.014508,0.00264 0,0 1.1504733,1.2533541 1.1504733,1.2533541 0,0 -1.3945129,-0.196367 -1.3945129,-0.196367 -0.8248385,-0.2578481 -1.7446631,0.1079194 -2.1425563,0.9043974 0,0 -2.71e-5,3.4e-6 -2.71e-5,3.4e-6 m 0.6765348,0.337974 c 0.2586549,-0.517759 0.877184,-0.7241797 1.3949495,-0.4655215 0.5177589,0.2586549 0.7241761,0.87719093 0.4655214,1.39494953 -0.2586548,0.5177587 -0.8771906,0.7241758 -1.3949494,0.4655211 -0.5177657,-0.2586579 -0.7241762,-0.8771902 -0.4655215,-1.39494913 0,0 0,0 0,0 m 2.0278432,-4.0592094 c 0.2586548,-0.5177589 0.8771839,-0.7241794 1.3949495,-0.4655213 0.5177588,0.2586548 0.724176,0.8771905 0.4655213,1.3949494 -0.2586548,0.5177588 -0.8771906,0.7241761 -1.3949494,0.4655213 -0.5177656,-0.2586581 -0.7241761,-0.8771906 -0.4655214,-1.3949494 0,0 0,0 0,0"
+         id="path24356" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#242424;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 4.4798843,-4.3110508 c 0.219827,2.414579 -0.180079,4.01786863 -1.429103,5.5454305 0,0 2.023437,1.0507812 2.023437,1.0507812 1.715964,-1.67359867 1.847271,-3.9809016 1.75755,-6.660665 0,0 -2.351884,0.064453 -2.351884,0.064453 m -2.097072,6.2192586 c -2.10168637,1.4056146 -3.14434337,3.5358281 -3.667017,6.0218201 0,0 2.3918915,0.212651 2.3918915,0.212651 0.3238246,-2.741001 2.2229845,-4.191785 3.3298135,-5.1368148 0,0 -2.054688,-1.0976563 -2.054688,-1.0976563"
+         id="path24362" />
+    </symbol>
+  </defs>
+  <metadata
+     id="metadata8380">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1" />
+  <g
+     id="g20096"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-A">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7548-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.341398,20.538671 c 0,0 8.748998,0 8.748998,0 m -7.956,-2.73257 c 0,0 7.137001,0 7.137001,0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7550-3"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.5733955,25.02241 1.7680025,-4.758019 0.792998,-2.184 3.84207,-10.1974773 v -1.79027 M 5.8043989,25.02241 13.214397,6.0553637 M 8.8266135,15.025951 h 4.1142875"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="path7570-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 16.1914,6.0553637 23.497503,25.011091 M 14.415784,6.1269237 v 1.72298 L 20.905547,24.999845 M 16.095188,14.991671 h 4.491426"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-B"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20473">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 8.55091,25.04999 c 0,0 0,-18.99757 0,-18.99757 m 2.625999,18.96529 c 0,-6.33386 0,-12.66772 0,-19.00158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7385"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_running_stitch_length_mm="1.5"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_repeats=""
+       d="m 11.230984,5.84671 c 0,0 4.027926,0 4.027926,0 2.001999,0 3.544665,0.416 4.627998,1.248 1.083333,0.832 1.625,2.015 1.625,3.54899 0,1.18734 -0.277332,2.132 -0.832001,2.83401 -0.554665,0.702 -1.369333,1.13966 -2.443999,1.313 m -7.058999,-6.786 c 0,0 3.886998,0 3.886998,0 1.282667,0 2.510288,0.10552 3.134288,0.59085 0.632667,0.48534 1.154715,1.21767 1.154715,2.19701 0,0.98799 -0.796335,1.8618 -1.429002,2.34713 -0.441915,0.33758 -1.049007,0.55562 -1.821274,0.65413"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9054"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path9052"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.176909,13.85471 c 0,0 3.886998,0 3.886998,0 0.374285,0 0.720526,-0.0203 0.951475,-0.0558 0,0 2.220526,0.9918 2.220526,0.9918 1.291334,0.27733 2.292334,0.85799 3.003003,1.742 0.719332,0.87533 1.078998,1.97166 1.078998,3.289 0,1.73333 -0.589333,3.07233 -1.768002,4.017 -1.178665,0.94466 -2.855666,1.41699 -5.030999,1.41699 0,0 -4.356495,0 -4.356495,0 m 0.01448,-9.269 c 0,0 4.212,0 4.212,0 1.412667,0 2.457001,0.29034 3.132998,0.87101 0.684668,0.572 1.507001,1.53323 1.507001,2.74657 0,1.20466 -0.513762,2.13595 -1.19843,2.72528 -0.675997,0.58067 -2.028902,0.76815 -3.441569,0.76815 0,0 -4.212,0 -4.212,0 m 12.019791,-3.65029 c 0,0 -3.942858,0.10286 -3.942858,0.10286"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-C"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20573">
+    <path
+       sodipodi:nodetypes="ccscccsccccscccscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.196141,7.3383156 c -0.90133,-0.61533 -1.86766,-1.07467 -2.899,-1.378 -1.02266,-0.312 -2.11466,-0.468 -3.276,-0.468 -2.938,0 -5.251995,0.90133 -6.9419952,2.7040001 -1.689999,1.79399 -2.534999,4.2510003 -2.534999,7.3710003 0,3.11133 0.845,5.56833 2.534999,7.371 1.6900002,1.794 4.0039952,2.691 6.9419952,2.691 1.14401,0 2.22734,-0.156 3.25,-0.468 1.03134,-0.312 2.00634,-0.78 2.925,-1.404 m 0,-13.65 c -0.88399,-0.8233403 -1.82866,-1.4386703 -2.83399,-1.8460003 -0.99667,-0.4073401 -2.05834,-0.6110001 -3.18501,-0.6110001 -2.21866,0 -3.917326,0.6803301 -5.095995,2.0410001 -1.1786692,1.3520003 -1.7680022,3.3106603 -1.7680022,5.8760003 0,2.55666 0.589333,4.51533 1.7680022,5.87599 1.178669,1.352 2.877335,2.028 5.095995,2.028 1.12667,0 2.18834,-0.20366 3.18501,-0.61099 1.00533,-0.40734 1.95,-1.02267 2.83399,-1.84601"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7387"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20639"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-D">
+    <path
+       id="path7389"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.20561,24.76751 c 0,0 0,-18.73017 0,-18.73017 m 2.626,18.70562 c 0,0 0,-18.65682 0,-18.65682"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path13248"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.80992,5.7949 c 0,0 2.79069,0 2.79069,0 3.76133,0 6.52166,0.78433 8.281,2.353 1.75933,1.56 2.639,4.00399 2.639,7.332 0,3.34533 -0.884,5.80233 -2.652,7.371 -1.76801,1.56866 -4.524,2.35299 -8.268,2.35299 0,0 -2.76645,0 -2.76645,0 M 12.83116,7.9529 c 0,0 3.17201,0 3.17201,0 2.678,0 4.63666,0.60666 5.87599,1.82 1.248,1.20466 1.872,3.107 1.872,5.707 0,2.61733 -0.624,4.53266 -1.872,5.746 -1.23933,1.21333 -3.19799,1.82 -5.87599,1.82 0,0 -3.17201,0 -3.17201,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-E"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20732">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019"
+       d="m 21.211258,5.8241056 c 0,0 -9.66628,0 -9.66628,0 m 9.66628,2.62142 c 0,0 -9.64599,0 -9.64599,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015"
+       d="m 20.808258,13.574385 c 0,0 -9.24299,0 -9.24299,0 m 9.24299,2.62143 c 0,0 -9.24299,0 -9.24299,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.9392548,6.7571256 c 0,0 0,17.7368994 0,17.7368994 M 11.565268,6.8071156 c 0,0 0,17.6026194 0,17.6026194"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14011"
+       d="m 21.445258,22.611665 c 0,0 -9.87999,0 -9.87999,0 m 9.87999,2.62143 c 0,0 -9.90028,0 -9.90028,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g20851"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-F">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14015-0"
+       d="m 21.11677,13.50927 c 0,0 -7.7207,0 -7.7207,0 m 7.7207,2.62143 c 0,0 -7.7207,0 -7.7207,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.77006,6.69201 c 0,0 0,18.27026 0,18.27026 M 13.39607,6.742 c 0,0 0,18.13598 0,18.13598"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7391-0"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path14019-6"
+       d="m 21.9312,5.75899 c 0,0 -8.55543,0 -8.55543,0 m 8.55543,2.62142 c 0,0 -8.53513,0 -8.53513,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-G"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21249">
+    <path
+       sodipodi:nodetypes="ccccscscscccsscscscccccc"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       inkscape:connector-curvature="0"
+       d="m 14.28486,22.73404 -0.89143,3.18857 M 22.64778,7.35748 c -0.96201,-0.60667 -2.015,-1.066 -3.159,-1.378 -1.13533,-0.312 -2.33567,-0.468 -3.601,-0.468 -3.03334,0 -5.408,0.88833 -7.124,2.665 -1.70733,1.768 -2.561,4.238 -2.561,7.41 0,3.16333 0.85367,5.63333 2.561,7.41 1.716,1.768 4.09066,2.652 7.124,2.652 1.38666,0 2.691,-0.182 3.913,-0.546 0.11954,-0.0365 0.2381,-0.0746 0.35565,-0.11436 m 2.49135,-14.83564 c -0.97067,-0.82333 -2.002,-1.443 -3.094,-1.859 -1.092,-0.416 -2.24034,-0.624 -3.445,-0.624 -2.37467,0 -4.16,0.663 -5.356,1.989 -1.18734,1.326 -1.781,3.302 -1.781,5.928 0,2.61733 0.59366,4.58899 1.781,5.91499 1.196,1.326 2.98133,1.989 5.356,1.989 0.92733,0 1.755,-0.078 2.483,-0.23399 0.41935,-0.0949 0.81427,-0.21847 1.18474,-0.37084 M 11.2853,10.3178 8.01808,7.65037 M 19.3823,9.00776 19.477,5.39331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14890"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 23.15478,24.38676 c 0,0 0,-7.12957 0,-7.12957 m -2.6,7.02472 c 0,0 0,-6.99244 0,-6.99244"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14866"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.26478,14.75433 c 0,0 6.44429,0 6.44429,0 m -6.44429,2.53514 c 0,0 6.55286,0 6.55286,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path14868"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-H"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21438">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.81729,25.03703 V 6.06218 m 2.626,18.97485 V 6.05589"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18656"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 10.44329,16.015 c 0,0 9.542,0 9.542,0 m -9.542,-2.21 c 0,0 9.542,0 9.542,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18640"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 19.98529,6.06998 v 18.96705 m 2.626,-18.96705 v 18.96705"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path18642"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21538"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-I">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.91116,6.02767 v 19.0072 m -2.626,-19.0072 v 19.0072"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g21746"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-J">
+    <path
+       id="path7401-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 8.927444,18.3716 c 0,2.33999 0.446339,4.45009 1.339004,5.50742 0.884003,1.05734 2.309668,1.58601 4.197842,1.58601 1.888174,0 3.313839,-0.52867 4.197842,-1.58601 0.892666,-1.05733 1.339,-3.16743 1.339,-5.50742 V 5.99925 M 11.553447,18.3716 c 0,1.68133 0.238334,3.25842 0.715,3.90842 0.476667,0.65 1.295666,0.975 2.195843,0.975 0.900177,0 1.719176,-0.325 2.195843,-0.975 0.476666,-0.65 0.715,-2.22709 0.715,-3.90842 V 5.99925"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscccscsc" />
+  </g>
+  <g
+     id="g22082"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-K">
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7403"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 9.369659,25.06451 V 14.86593 6.01265 m 2.626,19.05182 V 14.863705 6.01265"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22148"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.456095,6.06912 -8.460436,7.96796 v 0.86314 0.99586 l 9.076795,9.10211 M 23.836098,6.06912 14.45266,14.88208 24.530454,24.99819 M 16.294877,9.27736 h 4.662858 m -4.479622,5.63349 h -5.113897 m 9.438613,5.587403 h -5.08233"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-L"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22205">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.303032,6.04876 v 16.67973 m 2.626,-16.67973 v 16.6983"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7405" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.57732,25.29992 c 0,0 11.802712,0 11.802712,0 m -11.851,-2.55286 c 0,0 11.851,0 11.851,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path24793" />
+  </g>
+  <g
+     id="g22344"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-M">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.71766,25.01839 V 8.41733 l 0.5722,-0.48269 V 6.1406 M 7.16966,25.01839 V 6.05133 m -0.37088,10.3201 h 3.15167"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7407"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.0292,6.16485 c 0,0 0,1.79403 0,1.79403 0,0 0.68846,0.45845 0.68846,0.45845 0,0 5.005,13.312 5.005,13.312 m -3.34907,-15.678 c 0,0 4.953,13.208 4.953,13.208 0,0 0,2.32449 0,2.32449 M 11.3081,14.06828 c 0,0 3.56382,0 3.56382,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26115"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.36166,21.72933 c 0,0 5.005,-13.312 5.005,-13.312 0,0 0.60264,-0.38572 0.60264,-0.38572 0,0 0,-1.86676 0,-1.86676 m -7.22456,15.41897 c 0,0 0,-2.32449 0,-2.32449 0,0 4.979,-13.208 4.979,-13.208 m -3.50019,8.01695 c 0,0 3.41836,0 3.41836,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26117"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.70863,6.21334 v 1.79403 l 0.65803,0.40996 v 16.60106 m 2.561,-18.96706 V 25.01839 M 21.99955,16.5169 h 3.39412"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26119"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-N"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22488">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.83756,24.99409 V 6.0586 m 2.548,18.93549 V 9.2306 L 10.84678,8.57616 V 6.10759 m -3.56572,8.83318 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27051" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.37356,6.0586 8.606,15.76349 0.7415,0.44056 v 2.66613 M 9.71535,6.10759 v 2.57143 l 0.67021,0.55158 8.606,15.85819 M 12.73249,14.70077 h 4.01143"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path27049" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.4182,24.8945 v -2.66613 l 0.56136,-0.40628 V 6.0586 m 2.54799,18.93549 V 6.0586 m -3.04077,8.47074 h 3.6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7409" />
+  </g>
+  <g
+     id="g14481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-O">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7411"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.52515,15.56902 c 0,2.444 -0.559,4.37666 -1.677,5.798 -1.10933,1.42133 -2.61733,2.132 -4.524,2.132 -1.90666,0 -3.42333,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12667,-1.42134 2.64334,-2.132 4.55,-2.132 1.90667,0 3.41467,0.71066 4.524,2.132 1.118,1.42133 1.677,3.35833 1.677,5.811 m 2.769,0 c 0,3.05933 -0.81467,5.50333 -2.444,7.332 -1.62933,1.82 -3.80466,2.73 -6.526,2.73 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82 -2.44399,-4.264 -2.44399,-7.332 0,-3.068 0.81466,-5.512 2.44399,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72134,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g14770"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-P">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 9.73878,25.04481 V 6.06992 m 2.626,18.97489 V 6.09448"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29324" />
+    <path
+       sodipodi:nodetypes="cscccsccsccssc"
+       inkscape:connector-curvature="0"
+       d="m 12.36478,17.33951 h 3.302 c 2.17533,0 3.81766,-0.48967 4.927,-1.469 1.118,-0.97934 1.677,-2.42667 1.677,-4.342 0,-1.89801 -0.559,-3.33667 -1.677,-4.316 -1.10934,-0.988 -2.75167,-1.482 -4.927,-1.482 H 12.3571 m 0.008,9.451 h 3.302 c 1.222,0 2.44927,-0.0781 3.1166,-0.71073 0.66734,-0.63266 1.05781,-1.77227 1.05781,-2.94227 0,-1.16134 -0.45489,-2.25229 -1.12222,-2.88495 C 18.05195,8.01089 16.8891,7.88851 15.6671,7.88851 h -3.302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path29322"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Q"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15502">
+    <path
+       sodipodi:nodetypes="cccscscscccscscscscc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.74008,24.7112 c -1.28002,0.60999 -2.83572,0.85445 -4.01673,0.88612 -2.73,0 -4.914,-0.91 -6.552,-2.73 -1.62933,-1.82867 -2.444,-4.27267 -2.444,-7.332 0,-3.068 0.81467,-5.512 2.444,-7.332 1.638,-1.82867 3.822,-2.743 6.552,-2.743 2.72133,0 4.89667,0.91433 6.526,2.743 1.62933,1.82 2.444,4.264 2.444,7.332 0,2.25333 -0.45501,4.18166 -1.365,5.785 -0.42739,0.76024 -0.94635,1.42599 -1.5569,1.99722 m -3.65284,-0.31068 c -0.7127,0.30563 -1.51112,0.45844 -2.39526,0.45844 -1.90667,0 -3.42334,-0.71067 -4.55,-2.132 -1.118,-1.42134 -1.677,-3.354 -1.677,-5.798 0,-2.45267 0.559,-4.38967 1.677,-5.811 1.12666,-1.42134 2.64333,-2.132 4.55,-2.132 1.90667,0 3.41466,0.71066 4.524,2.132 1.11799,1.42133 1.677,3.35833 1.677,5.811 0,1.70168 -0.271,3.15547 -0.813,4.36138 -0.30413,0.65637 -0.65817,1.1707 -1.0577,1.67288"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30716" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 15.21754,20.83476 c 0,0 5.77481,6.28154 5.77481,6.28154 m -3.78727,-7.61334 c 0,0 5.65582,6.18738 5.65582,6.18738"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30718" />
+  </g>
+  <g
+     id="g15673"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-R">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.27399,24.96841 V 6.06429 m -2.626,18.90412 V 6.03973"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32125"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,7.90681 c 0,0 3.30198,0 3.30198,0 1.26534,0 2.21868,0.29033 2.86002,0.871 0.64999,0.572 1.24928,1.42566 1.24928,2.561 0,1.13533 -0.59929,1.99767 -1.24928,2.587 C 17.04556,14.2793 16.5395,14.5252 15.9178,14.6635 M 11.21782,5.74881 c 0,0 3.35816,0 3.35816,0 2.21868,0 3.87401,0.46366 4.96601,1.391 1.092,0.92733 1.638,2.327 1.638,4.199 0,1.222 -0.286,2.236 -0.858,3.042 -0.56333,0.806 -1.38667,1.365 -2.47002,1.677"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7417"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.27399,14.79681 h 3.30198 c 0.49503,0 0.94231,-0.0444 1.34183,-0.13331 l 1.93417,1.39431 c 0.56335,0.19066 1.10935,0.598 1.63801,1.222 0.53733,0.624 1.07467,1.482 1.61201,2.574 l 2.665,5.1146 m -12.493,-8.0136 h 2.86 c 1.03999,0 1.859,0.21233 2.457,0.637 0.60667,0.42467 1.23067,1.287 1.872,2.587 l 2.483,4.7896 m -4.66742,-6.69333 1.84252,-3.00621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path32150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccccsccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-S"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15839">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.588194,21.41444 c 1.065999,0.598 2.110333,1.04866 3.132998,1.352 1.022665,0.30333 2.028,0.455 3.016002,0.455 1.499331,0 3.06776,-0.10072 3.882428,-0.69005 0.814667,-0.58934 1.221999,-1.43 1.221999,-2.522 0,-0.95334 -0.294666,-1.69867 -0.883999,-2.236 -0.580665,-0.53734 -1.949763,-0.94034 -3.284428,-1.209 0,0 -1.598999,-0.312 -1.598999,-0.312 -1.958669,-0.39 -3.375671,-1.001 -4.251003,-1.833 -0.875332,-0.832 -1.313,-1.989 -1.313,-3.471 0,-1.716 0.602335,-3.068 1.807,-4.056 1.213333,-0.988 2.881667,-1.67595 5.005003,-1.67595 0.909999,0 1.837332,0.0823 2.781999,0.247 0.944667,0.16467 1.910999,0.41167 2.899,0.741 m -12.415,18.3019 c 1.109334,0.40733 2.179665,0.715 3.211,0.923 1.039999,0.208 2.019333,0.312 2.938,0.312 2.435331,0 4.281331,-0.67929 5.537998,-1.64995 1.265333,-0.97067 1.898,-2.39634 1.898,-4.277 0,-1.57734 -0.468,-2.834 -1.404,-3.77 -0.927333,-0.94467 -2.370336,-1.60333 -4.329001,-1.976 0,0 -1.585996,-0.325 -1.585996,-0.325 -1.438668,-0.26867 -2.829431,-0.61967 -3.349433,-1.053 -0.51133,-0.442 -0.766998,-1.09201 -0.766998,-1.95 0,-1.02267 0.385667,-1.81133 1.157,-2.366 0.78,-0.55467 2.296428,-0.63805 3.726428,-0.63805 0.823335,0 1.677001,0.117 2.561,0.351 0.884003,0.234 1.824334,0.58933 2.821002,1.066"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7419" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-T"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16335">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.343011,5.71018 h 6.759526 M 6.343011,8.40505 h 6.806173"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path34968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       d="M 15.87201,25.02448 V 8.40505 M 13.233008,25.02448 V 8.40505"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7421"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.102537,5.71018 c 3.219824,0 6.439649,0 9.659473,0 m -9.612826,2.69487 c 3.204275,0 6.408551,0 9.612826,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path31333"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     id="g16687"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-U">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7423"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.933604,6.0089 v 11.80033 c 0,2.53067 0.624,4.44166 1.872,5.733 1.256667,1.29133 3.111333,1.937 5.563999,1.937 2.444005,0 4.290005,-0.64567 5.538005,-1.937 1.25666,-1.29134 1.885,-3.20233 1.885,-5.733 V 6.0089 m -12.220002,0 v 11.47533 c 0,2.08 0.376999,3.57933 1.130999,4.498 0.753999,0.91 1.975998,1.365 3.665998,1.365 1.681335,0 2.899005,-0.455 3.652995,-1.365 0.754,-0.91867 1.131,-2.418 1.131,-4.498 V 6.0089"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscscsccscscsc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-V"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16861">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.45786,25.15192 7.397,-19.12489 m -9.68698,18.88708 v -2.23042 l 0.79498,-0.59977 6.16201,-16.05689 m -4.14473,8.31684 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.07086,6.02703 7.41001,19.12489 M 8.81386,6.02703 l 6.149,16.05689 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425" />
+  </g>
+  <g
+     id="g17062"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-W">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 5.29834,5.99521 4.082,16.09032 0.74798,0.58326 v 2.23042 m -7.48198,-18.904 4.862,19.09332 M 4.0674,14.48681 h 4.16991"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7427"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.9558,25.08853 15.08981,9.17335 15.65587,8.86147 V 6.72803 m -6.93369,18.0742 v -2.13344 l 0.56119,-0.58326 4.069,-15.47318 m -2.93313,7.87446 h 3.78201"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39250"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.24974,6.77651 v 1.9395 l 0.54914,0.45734 4.095,15.91518 m -2.39656,-18.47618 4.082,15.47318 0.55562,0.53477 v 2.18193 M 15.51041,14.48681 h 3.97596"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39252"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.34134,25.08853 4.875,-19.09332 m -7.43905,18.75854 v -2.18193 l 0.70505,-0.48629 4.069,-16.09032 m -2.98001,8.54009 h 4.12142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path39256"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-X"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17279">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 10.26577,6.05887 4.823,7.0256 m -7.644,-7.0256 6.045,8.8586"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40772"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 6.56077,25.08907 6.929,-10.1716 m -4.095,10.1716 5.499,-8.0656"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40754" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 19.93777,6.05887 -4.849,7.0256 m 7.67,-7.0256 -6.24,9.1316"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40770"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.49209,14.90426 6.86168,10.18481 m -5.23668,-12.01781 8.05768,12.01781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path40760" />
+  </g>
+  <g
+     id="g17493"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-Y">
+    <path
+       id="path7431"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.68468,6.09711 6.864,9.94503 m -3.84905,-9.94503 5.382,7.76103"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       id="path42255"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.54868,25.00103 v -8.95889 l 1.24202,-2.184 5.343,-7.76103 m -3.94602,18.90392 v -8.95889 l 6.864,-9.94503 M 12.92754,19.32583 h 4.07293"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-Z"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17715">
+    <path
+       inkscape:connector-curvature="0"
+       id="path43759"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.62245,8.53258 c 0,0 14.93072,0 14.93072,0 M 7.62245,5.83771 c 0,0 15.24899,0 15.24899,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43761"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.59544,8.53258 c 0,0 -12.272,14.22726 -12.272,14.22726 m 15.548,-14.43526 c 0,0 -12.272,14.22726 -12.272,14.22726"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path43765"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 7.32344,25.24671 c 0,0 15.847,0 15.847,0 M 7.39928,22.55184 c 0,0 15.77116,0 15.77116,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g17946"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-a">
+    <path
+       d="m 18.140733,15.634487 c 0,0 -3.354,0 -3.354,0 -2.175219,-0.02236 -3.813334,0.657303 -4.914,1.4893 -1.092,0.832002 -1.638,2.066999 -1.638,3.705001 0,1.404 0.437666,2.526332 1.313,3.367001 0.884,0.832001 2.071334,1.248 3.562,1.248 1.809285,-0.01225 3.585431,-0.254861 4.868213,-1.703785 0.05519,-0.06234 0.426455,-0.524475 0.479779,-0.591353 m -0.316992,-5.400864 c 0,0 -2.379,0 -2.379,0 -1.932666,0 -3.271667,0.221 -4.017,0.662999 -0.745333,0.442 -1.118001,1.196003 -1.118001,2.262002 0,0.849335 0.277333,1.525333 0.832002,2.028 0.563332,0.494001 1.325997,0.741001 2.287998,0.741001 1.241318,0 2.250985,-0.410135 3.029006,-1.230401 0.05307,-0.05596 1.519023,-1.773669 1.569944,-1.833447 m -8.025424,4.790247 c 0,0 1.80375,-2.388753 1.80375,-2.388753 m -0.78,-6.751872 c 0,0 1.072501,2.510623 1.072501,2.510623 m 2.486248,7.605001 c 0,0 0.487501,-3.485626 0.487501,-3.485626"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path847"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.300733,11.031903 c 0.875333,-0.338001 1.724668,-0.589333 2.548001,-0.754002 0.823333,-0.173332 1.624998,-0.259998 2.404998,-0.259998 2.106,0 3.678999,0.546 4.719,1.638 0.854261,0.896972 1.357674,2.267062 1.510243,3.957433 0.123434,3.075996 0.04976,6.299231 0.04976,9.453453 M 9.300733,13.517674 c 0.846852,-0.440362 1.73231,-0.830334 2.683274,-1.073138 0.641664,-0.163832 1.313151,-0.260659 2.022726,-0.260747 1.308665,0 2.322665,0.303334 3.042,0.91 0.613891,0.514932 1.110395,1.493504 1.092001,2.540698 l 2e-6,9.432302"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4609"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccscccc" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-b"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18617">
+    <path
+       inkscape:connector-curvature="0"
+       d="M 10.17228,25.038159 V 12.005186 6.013445 m 2.392001,19.024714 V 12.005186 6.013445"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13821"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path13834"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.543215,22.122558 1.53398,2.98178 m -7.487063,-9.949696 c 0.219817,-0.472451 0.798071,-1.186277 1.066153,-1.556484 0.727998,-0.996667 1.724667,-1.495001 2.99,-1.495001 1.26533,0 2.261998,0.498334 2.989997,1.495001 0.719336,1.005332 1.079002,2.387666 1.079002,4.147 0,1.759334 -0.359666,3.137334 -1.079002,4.133998 -0.727999,1.005335 -1.724667,1.508003 -2.989997,1.508003 -1.265333,0 -2.309552,-0.454787 -3.038749,-1.45925 -0.297301,-0.409532 -0.768484,-1.125174 -0.99504,-1.467049 m -0.04822,-8.384717 c 1.213352,-1.708275 2.873841,-1.961664 4.666998,-1.974985 1.759334,0 3.193667,0.702 4.303,2.106 1.100667,1.404 1.651001,3.249999 1.651004,5.538 4e-6,2.287999 -0.550329,4.133998 -1.650996,5.537998 -1.109334,1.404 -2.543666,2.106002 -4.303,2.106002 -2.022659,-0.0012 -3.640858,-0.657066 -4.666998,-2.009457 m 5.1909,-10.766297 1.023752,-2.827501"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g18852"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-c">
+    <path
+       d="m 20.186758,10.98633 c -0.658668,-0.303335 -1.338996,-0.528668 -2.040998,-0.675999 -0.701998,-0.155998 -1.421334,-0.233998 -2.158004,-0.233998 -2.270665,0 -4.060331,0.680329 -5.368995,2.040996 -1.300002,1.360668 -1.950002,3.228334 -1.950002,5.603001 0,2.34 0.645665,4.199001 1.936999,5.577 1.291335,1.378 3.033335,2.067 5.225998,2.067 0.806001,0 1.564336,-0.078 2.275005,-0.233999 0.719331,-0.156 1.412666,-0.390001 2.079997,-0.702001 m 0,-11.206001 C 19.510761,12.849663 18.830424,12.57233 18.14576,12.39033 c -0.675998,-0.190667 -1.360666,-0.286 -2.054001,-0.286 -1.551333,0 -2.756003,0.494001 -3.614001,1.482 -0.858002,0.979333 -1.286999,2.357331 -1.286999,4.134 0,1.776664 0.428997,3.158999 1.286999,4.147 0.857998,0.979334 2.062668,1.469 3.614001,1.469 0.693335,0 1.378003,-0.091 2.054001,-0.273001 0.684664,-0.190664 1.365001,-0.472336 2.040998,-0.845"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9367"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-d"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19099">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.6495,12.076147 c -1.21335,-1.708275 -2.87384,-1.961664 -4.667,-1.974985 -1.75933,0 -3.19366,0.702 -4.303,2.106 -1.10066,1.404 -1.651,3.249999 -1.651,5.538 0,2.287999 0.55034,4.133998 1.651,5.537998 1.10934,1.404 2.54367,2.106002 4.303,2.106002 2.02266,-0.0012 3.64086,-0.657066 4.667,-2.009457 m -0.0108,-7.606268 c -0.17604,-0.856546 -0.65135,-1.581636 -1.08123,-2.175275 -0.728,-0.996667 -1.72466,-1.495001 -2.99,-1.495001 -1.26533,0 -2.262,0.498334 -2.98999,1.495001 -0.71934,1.005332 -1.07901,2.387666 -1.07901,4.147 0,1.759334 0.35967,3.137334 1.07901,4.133998 0.72799,1.005335 1.72466,1.508003 2.98999,1.508003 1.26534,0 2.262,-0.502668 2.99,-1.508003 0.42152,-0.577075 0.89336,-1.281992 1.07082,-2.114749 m -7.7085,-1.739755 c 0,0 -3.46125,-0.04875 -3.46125,-0.04875 m 7.90905,-5.177876 c 0,0 -0.10341,-3.274787 -0.10341,-3.274787 m 0.27576,12.892325 c 0,0 -0.0345,3.171371 -0.0345,3.171371"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path13733-0" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="M 19.6495,6.013449 V 25.038163 M 22.0415,6.013449 V 25.038163"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9395-2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g19346"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-e">
+    <path
+       sodipodi:nodetypes="cccc"
+       id="path6501"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.83805,18.07543 h 10.62807 m -10.55007,-2.042177 10.528,-0.01429"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscscsccccsccccscccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 21.768888,15.401243 C 21.58734,13.56331 21.037727,11.913677 20.12005,10.80629 18.98471,9.416275 17.43771,8.721268 15.47905,8.721268 c -2.184,0 -3.92167,0.771173 -5.213,2.313519 -1.28267,1.532824 -1.924,3.608329 -1.924,6.226509 0,2.532495 0.676,4.541353 2.028,6.026577 1.36067,1.485223 3.20233,2.227833 5.525,2.227833 0.92733,0 1.84166,-0.104728 2.743,-0.314181 0.90133,-0.209456 1.781,-0.514118 2.639,-0.913985 m -1.865431,-8.927771 c -0.105435,-1.218338 -0.46298,-2.399237 -1.072569,-3.125373 -0.71067,-0.856859 -1.65533,-1.285289 -2.834,-1.285289 -1.33467,0 -2.405,0.414149 -3.211,1.242446 -0.79734,0.828296 -1.25667,2.337432 -1.378,3.841696 l -0.078,2.042181 c 0.104,1.808924 0.598,2.846565 1.482,3.798631 0.89266,0.942544 2.132,1.413819 3.718,1.413819 0.91866,0 1.807,-0.123771 2.665,-0.371308 0.86667,-0.247538 1.72467,-0.618843 2.574,-1.113915 m -5.7746,-10.460113 -0.0487,-3.05256 m -1.73062,14.031069 -1.17,3.266776"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9371"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-f"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20089">
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 12.90049,13.85176 v 11.203401 m 2.405,-11.203401 v 11.203401"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4599" />
+    <path
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       inkscape:connector-curvature="0"
+       d="m 19.88149,4.827162 h -2.262 c -1.638,0 -2.834,0.372666 -3.588,1.117998 -0.754,0.736668 -1.131,1.915336 -1.131,3.536001 v 2.0124 m 6.981,-4.677399 h -2.288 c -0.78303,0.06911 -1.32961,0.346417 -1.69212,0.751024 -0.38873,0.433862 -0.56583,1.014098 -0.59588,1.640975 v 2.2854 M 13.794643,5.5580359 16.25,7.9241073"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9759" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path4595"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.61249,11.493561 h 2.288 2.405 3.939 m -8.632,2.358199 h 2.288 2.405 3.939"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20354"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-g">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.90145,23.104224 c -1.0362,1.771096 -2.87813,2.181811 -4.667,2.195374 -1.78533,0 -3.224,-0.948457 -4.316,-2.309123 -1.092,-1.360669 -1.638,-3.163338 -1.638,-5.408002 0,-2.253334 0.546,-4.060332 1.638,-5.421 1.092,-1.360667 2.53067,-2.040999 4.316,-2.040999 1.07466,0 1.99767,0.212332 2.769,0.636999 0.77133,0.424668 1.25774,0.724749 1.898,1.485248 m -0.0584,6.830559 c -0.38154,2.104262 -2.17261,3.76681 -4.02341,3.79311 -1.24431,0 -2.21537,-0.462409 -2.9132,-1.387235 -0.68941,-0.924825 -1.03412,-2.223786 -1.03412,-3.896878 0,-1.681498 0.34471,-2.98466 1.03412,-3.909483 0.69783,-0.924825 1.66889,-1.240986 2.9132,-1.240986 1.25272,0 2.22379,0.462411 2.9132,1.387237 0.43013,0.570044 0.89832,1.228266 1.06332,2.043165 m -3.35569,6.561309 c 0,0 -0.22407,3.567797 -0.22407,3.567797 m -3.91251,-8.393802 c 0,0 -3.36096,-0.03448 -3.36096,-0.03448 m 6.60128,-4.653645 c 0,0 -0.20682,-3.016254 -0.20682,-3.016254"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9375"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccscccccscsccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.03545,30.618547 c 0.702,0.260003 1.42567,0.450666 2.171,0.572003 0.74533,0.129999 1.53833,0.194999 2.379,0.194999 2.27067,0 3.95633,-0.60667 5.057,-1.820003 0.94231,-1.031347 1.48125,-3.12773 1.61682,-5.264974 0.0228,-0.359167 0.0342,-0.719485 0.03419,-1.076098 l -10e-6,-12.753 M 10.03547,27.974673 c 0.702,0.381331 1.39533,0.565501 2.08,0.747498 0.68467,0.182 1.38233,0.273001 2.093,0.273001 1.56866,0 2.743,-0.314166 3.523,-1.137497 0.78,-0.814667 1.170014,-1.915119 1.17,-3.570451 l -10e-6,-1.153102 -10e-6,-12.662648"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6095"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-h"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20629">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 10.4817,24.993285 V 5.9933271 M 8.0767,24.993285 V 5.9526621"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6479" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.56971,15.932006 c 0.18607,-0.58843 0.64314,-1.291311 1.02999,-1.718646 0.32074,-0.3543 0.69203,-0.742865 1.11387,-1.082251 0.55845,-0.449287 1.20549,-0.812385 1.94113,-0.895699 1.06784,-0.120939 1.88067,0.269208 2.418,0.953873 0.53734,0.684669 0.806,1.716003 0.806,3.094002 0,0 0,8.71 0,8.71 m -7.397,-12.517376 c 0.25312,-0.387354 0.52576,-0.688471 0.81792,-0.941371 0.36806,-0.318602 0.76708,-0.560682 1.19708,-0.802254 0.78,-0.433334 1.67701,-0.649999 2.691,-0.649999 1.67267,0 2.938,0.52 3.796,1.56 0.858,1.031333 1.287,2.552332 1.287,4.562999 0,0 0,8.788001 0,8.788001"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6452" />
+  </g>
+  <g
+     id="g20904"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-i">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.19045,25.002936 c 0,0 0,-13.978152 0,-13.978152 m -2.392,13.978152 c 0,0 0,-13.978152 0,-13.978152"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path6852"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path9379"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.79845,6.341563 c 0,0 0,-3.028999 0,-3.028999 m 2.392,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-j"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21185">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9381"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 16.901864,6.290836 c 0,0 0,-3.028999 0,-3.028999 m -2.391999,3.028999 c 0,0 0,-3.028999 0,-3.028999"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7095"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.983614,30.521773 c 0,0 1.446252,0 1.446252,0 1.568666,0 2.703999,-0.416 3.405999,-1.248 0.710667,-0.831996 1.065999,-2.175332 1.065999,-4.029998 0,0 0,-14.238151 0,-14.238151 m -5.91825,17.488151 c 0,0 1.173252,0 1.173252,0 0.909999,0 1.529666,-0.212329 1.858998,-0.636999 0.329335,-0.415999 0.494001,-1.286999 0.494001,-2.613001 0,0 0,-14.238151 0,-14.238151"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g21481"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-k">
+    <path
+       id="path7639"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.698021,24.997868 V 17.276466 6.032561 m 2.405,18.965307 V 17.276466 6.032561"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9383"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.240018,10.437867 c 0,0 -7.136997,6.279003 -7.136997,6.279003 0,0 0,1.169998 0,1.169998 0,0 7.397,7.111 7.397,7.111 m 2.795002,-14.560001 c 0,0 -7.722002,6.812003 -7.722002,6.812003 0,0 8.047,7.747998 8.047,7.747998 m -7.347629,-7.686935 c 0,0 -3.619503,0 -3.619503,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-l"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21769">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path9385"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.977709,25.031674 V 6.021161 m 2.391997,19.010513 V 6.021161" />
+  </g>
+  <g
+     id="g22083"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-m">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 4.556354,25.009621 V 12.014082 10.449616 M 6.961358,25.009621 V 12.005592 10.44962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9321"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="path9327"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.981358,25.009621 v -8.709999 c 0,-1.404 -0.247,-2.439667 -0.741,-3.107001 -0.49401,-0.676001 -1.28178,-0.99888 -2.288,-0.772701 -2.13453,0.479797 -3.47091,1.826466 -3.99878,2.866253 m 9.43278,9.723448 c 0,-2.884984 -0.0224,-5.835598 0.0138,-8.684014 0.0616,-1.164345 0.0822,-2.354761 -0.84701,-4.1496 -1.16317,-1.412736 -1.95158,-1.833346 -3.91175,-2.077386 -1.04866,0 -1.95433,0.212333 -2.717,0.636999 -0.76266,0.424669 -1.10675,0.687548 -1.963,1.269972 m 4.08715,0.727113 0.3788,-3.34613"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 16.506668,15.391988 c 0.17799,-0.522036 0.56255,-1.1113 0.95869,-1.564708 0.71933,-0.823334 1.69866,-1.235001 2.938,-1.235001 1.01399,0 1.76799,0.338 2.26199,1.013998 0.494,0.676001 0.74101,1.298012 0.74101,2.693345 0,0 0,8.709999 0,8.709999 m -7.85326,-12.833614 c 1.7574,-1.665838 3.58218,-2.042234 5.51326,-2.077386 1.51666,0 2.68666,0.533004 3.50999,1.598999 0.82334,1.057337 1.235,2.565335 1.235,4.524 0,0 0,8.788001 0,8.788001 m -4.31561,-11.92692 c 0,0 0.58602,-3.18861 0.58602,-3.18861"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9331"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-n"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22392">
+    <path
+       inkscape:connector-curvature="0"
+       id="path9321-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 10.09427,24.968785 V 11.973246 10.40878 m 2.40501,14.560005 V 11.964756 10.408784"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4915,15.245337 c 0.52787,-1.039787 1.86425,-2.386456 3.99877,-2.866253 1.00623,-0.226179 1.794,0.0967 2.288,0.772701 0.49401,0.667334 0.74101,1.703001 0.74101,3.107001 0,0 0,8.709999 0,8.709999 m -7.02,-13.004029 c 0.85625,-0.582424 1.20034,-0.845303 1.963,-1.269972 0.76267,-0.424666 1.66833,-0.636999 2.717,-0.636999 1.96017,0.24404 2.84466,0.590738 3.91175,2.077386 0.70781,0.986116 0.87535,2.983972 0.84698,4.1496 -0.0693,2.847802 -0.0137,5.79903 -0.0137,8.684014 M 16.64046,12.754306 c 0,0 0.34125,-3.4125 0.34125,-3.4125"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9327-6" />
+  </g>
+  <g
+     id="g22701"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-o">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.70057,17.714285 c 0,1.733334 -0.37266,3.102666 -1.118,4.107997 -0.74533,1.005335 -1.75499,1.410501 -3.02899,1.410501 -1.29134,0 -2.30967,-0.40083 -3.05501,-1.397498 -0.73666,-1.005335 -1.10499,-2.378999 -1.10499,-4.121 0,-1.742001 0.37266,-3.111333 1.118,-4.108001 0.74533,-1.005332 1.75933,-1.410498 3.042,-1.410498 1.274,0 2.28366,0.409498 3.02899,1.4235 0.74534,1.005331 1.118,2.370332 1.118,4.094999 m 2.53501,0 c 0,2.383334 -0.59367,4.255334 -1.78101,5.616 -1.18733,1.351999 -2.82099,2.028 -4.90099,2.028 -2.08867,0 -3.72667,-0.676001 -4.914,-2.028 -1.17867,-1.360666 -1.76801,-3.232666 -1.76801,-5.616 0,-2.392001 0.58934,-4.264001 1.76801,-5.616 1.18733,-1.351999 2.82533,-2.028 4.914,-2.028 2.08,0 3.71366,0.676001 4.90099,2.028 1.18734,1.351999 1.78101,3.223999 1.78101,5.616"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9391"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-p"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g15223">
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 9.73455,10.421144 v 5.064606 15.033394 m 2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 12.12654,23.38316 c 1.21336,1.708274 2.87385,1.961664 4.66701,1.974985 1.75933,0 3.19366,-0.701998 4.303,-2.105998 1.10066,-1.404 1.651,-3.25 1.651,-5.538002 0,-2.287999 -0.55034,-4.133998 -1.651,-5.537998 -1.10934,-1.404 -2.54367,-2.106002 -4.303,-2.106002 -2.02266,0.0012 -3.64086,0.657066 -4.66701,2.009456 m 0.002,8.484703 c 0.39983,0.372495 0.58744,0.762785 1.08954,1.296841 0.44362,0.471836 1.72467,1.495 2.99001,1.495 1.26533,0 2.26199,-0.498332 2.99,-1.495 0.71933,-1.005331 1.079,-2.387666 1.079,-4.147 0,-1.759335 -0.35966,-3.137334 -1.079,-4.133998 -0.728,-1.005335 -1.72467,-1.508003 -2.99,-1.508003 -1.26533,0 -2.57123,0.813642 -3.02447,1.439059 -0.23581,0.32539 -0.83468,1.068618 -1.04225,1.473969 m 5.73059,7.463812 0.90502,3.38046 m -0.6805,-12.739462 1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g15551"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-q">
+    <path
+       sodipodi:nodetypes="cccscccccscscssccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 19.953773,23.38316 c -1.21336,1.708274 -2.87385,1.961664 -4.66701,1.974985 -1.75933,0 -3.19366,-0.701998 -4.303,-2.105998 -1.1006597,-1.404 -1.6509991,-3.25 -1.6509991,-5.538002 0,-2.287999 0.5503394,-4.133998 1.6509991,-5.537998 1.10934,-1.404 2.54367,-2.106002 4.303,-2.106002 2.02266,0.0012 3.64086,0.657066 4.66701,2.009456 m -0.002,8.484703 c -0.39983,0.372495 -0.58744,0.762785 -1.08954,1.296841 -0.44362,0.471836 -1.72467,1.495 -2.99001,1.495 -1.26533,0 -2.26199,-0.498332 -2.99,-1.495 -0.71933,-1.005331 -1.079,-2.387666 -1.079,-4.147 0,-1.759335 0.35966,-3.137334 1.079,-4.133998 0.728,-1.005335 1.72467,-1.508003 2.99,-1.508003 1.26533,0 2.57123,0.813642 3.02447,1.439059 0.23581,0.32539 0.83468,1.068618 1.04225,1.473969 m -5.73059,7.463812 -0.90502,3.38046 m 0.6805,-12.739462 -1.34439,-3.033489"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17180-3"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 22.345763,10.421144 v 5.064606 15.033394 m -2.39199,-20.098 v 5.081842 15.016158"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path17144-6"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-r"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g16497">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       d="m 12.91122,10.386574 v 2.262001 c 10e-6,4.099331 0,8.198665 0,12.298 M 10.50623,10.386574 v 2.293923 12.266078"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path22973"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path22967"
+       d="m 12.91122,12.648575 c 0.50266,-0.884002 1.157,-1.538334 1.963,-1.963 0.806,-0.433332 1.78534,-0.65 2.938,-0.65 0.16467,0 0.34667,0.01302 0.546,0.039 0.29953,0.01279 0.94934,0.160427 1.24397,0.303252 1.01024,0.489734 1.93121,1.385226 1.92965,1.396501 m -8.60592,4.230059 c 0.17052,-0.827858 0.62279,-1.559167 1.06431,-2.096433 0.728,-0.884002 1.76799,-1.740376 3.12,-1.740376 0.38133,0 0.728,0.039 1.04,0.116997 0.27481,0.05942 0.97493,0.294075 1.29667,0.526986 1.2535,0.907431 1.52328,1.348708 1.5617,1.371015 M 15.494,10.093095 c 0,0 0.17062,2.827499 0.17062,2.827499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     id="g16825"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-s">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.696502,21.98718 c 0.884001,0.45933 1.755,0.806 2.613,1.03999 0.858,0.22534 1.707334,0.338 2.548,0.338 1.126666,0 1.993333,-0.12172 2.6,-0.50305 0.606666,-0.39 1.289184,-1.07389 1.289184,-1.77589 0,-0.65 -0.393357,-1.18391 -0.835356,-1.53058 -0.433333,-0.34667 -1.287587,-0.40456 -2.769587,-0.72523 0,0 -1.142241,-0.16053 -1.142241,-0.16053 -1.482,-0.312 -2.552333,-0.78867 -3.211,-1.43 -0.658667,-0.65 -0.988002,-1.74405 -0.988002,-2.87071 0,-1.36934 0.485335,-2.42667 1.456002,-3.17201 0.970667,-0.74533 2.348666,-1.118 4.134,-1.118 0.884001,0 1.716,0.065 2.496,0.19501 0.78,0.13 1.499332,0.325 2.157999,0.58499 m -10.347999,13.598 c 0.936,0.30334 1.824334,0.52867 2.665,0.67601 0.849334,0.156 1.664,0.23399 2.444,0.23399 1.872,0 3.341001,-0.39433 4.407,-1.18299 1.074666,-0.78867 1.611999,-1.859 1.611999,-3.21101 0,-1.18733 -0.359665,-1.90461 -1.079,-2.56328 -0.710666,-0.66733 -1.915333,-1.183 -3.613999,-1.547 0,0 -0.819,-0.182 -0.819,-0.182 -1.282667,-0.286 -2.205276,-0.44711 -2.629943,-0.75911 -0.631495,-0.5275 -0.8783,-1.27429 -0.8783,-1.82896 0,-0.728 0.501494,-1.30847 1.090828,-1.67248 0.597999,-0.36399 1.59408,-0.33917 2.781414,-0.33917 0.78,0 1.533999,0.0867 2.262,0.26001 0.728001,0.17333 1.430001,0.43333 2.106,0.78"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9399"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-t"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17173">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 19.234561,14.1854 H 14.307565 11.902561 9.751777 m 9.482784,-2.3582 H 14.307565 11.902561 9.751777"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path26335" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path55570"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 14.33908,6.60024 14.30755,11.8272 M 11.93408,6.60024 11.90255,11.8272"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       embroider_pull_compensation_mm="0.2"
+       id="path26331"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.30755,14.1854 0.03153,6.31184 c 0.006,1.18732 0.160335,1.95001 0.480998,2.28801 0.329338,0.338 0.992337,0.50699 1.989001,0.50699 h 2.457001 m -7.36353,-9.10684 0.03153,6.31184 c 0.0091,1.81998 0.350999,3.07667 1.053001,3.77 0.701998,0.68467 1.975999,1.027 3.821998,1.027 h 2.457001"
+       inkscape:connector-curvature="0"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     id="g17518"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-u">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.643209,10.44212 c 0,0 0,8.72299 0,8.72299 0,1.378 0.268666,2.41367 0.806001,3.10701 0.537331,0.68466 1.343332,0.95805 2.417998,0.95805 2.078876,-0.22618 3.652734,-1.43269 4.191475,-2.89172 M 9.251219,10.44212 c 0,0 0,8.81399 0,8.81399 0,2.002 0.433333,3.52301 1.299998,4.563 0.866669,1.04001 2.136334,1.56 3.809003,1.56 1.63579,-0.0131 3.388777,-0.74064 4.692999,-1.94144"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9403"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 19.053207,25.00211 c 0,0 0,-14.55999 0,-14.55999 m 2.392001,14.55999 c 0,0 0,-14.55999 0,-14.55999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path28174"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-v"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g17883">
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.7632206,10.394934 13.48087,25.15192 m -2.991451,-14.749501 4.473441,11.681501 0.70812,0.69675 v 2.23042 M 8.39788,14.2469 h 4.50932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path7425-5" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 16.45786,25.15192 22.145203,10.447336 M 14.16788,24.91411 v -2.23042 l 0.79498,-0.59977 4.461966,-11.626936 M 16.98014,14.34387 h 4.55781"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path37800-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-w"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g18646">
+    <path
+       id="path18119"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 5.63226,10.42691 3.809,14.55999 m -1.41699,-14.55999 2.99,11.362 0.52751,0.71421 0.0173,2.44612 M 9.91071,15.80357 H 6.29464"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18117"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.31225,24.93304 -0.001,-2.47146 0.70302,-0.67267 2.97699,-11.362 m -1.72899,14.56003 3.14599,-11.93399 0.59357,-0.51487 0.003,-2.09161 m -4.21912,5.53567 h 3.52679"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path18115"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.75448,10.46875 0.0317,2.16243 0.62208,0.42173 3.13301,11.93399 m -1.72901,-14.55995 2.99,11.362 0.67801,0.2575 -0.0115,2.90895 M 15.625,16.02679 h 3.39286"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+    <path
+       id="path9407"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 21.36226,24.9869 3.809,-14.55999 m -5.88509,14.52845 0.007,-2.85975 0.50909,-0.3067 2.977,-11.362 m -2.06497,5.55523 h 3.52678"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_zigzag_spacing_mm="0.4" />
+  </g>
+  <g
+     id="g19389"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-x">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.21948,25.03208 c 0,0 5.655,-7.618 5.655,-7.618 m -2.83399,7.618 c 0,0 4.23799,-5.71999 4.23799,-5.71999"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30893"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 22.06448,10.47209 c 0,0 -5.265,7.085 -5.265,7.085 m 2.44401,-7.085 c 0,0 -3.86101,5.187 -3.86101,5.187"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path30901"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.70048,10.47209 c 0,0 5.174,6.94199 5.174,6.94199 0,0 1.404,1.89801 1.404,1.89801 0,0 4.238,5.71999 4.238,5.71999 m -7.995,-14.55999 c 0,0 3.861,5.187 3.861,5.187 0,0 1.417,1.898 1.417,1.898 0,0 5.538,7.47499 5.538,7.47499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9409"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-y"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g19767">
+    <path
+       inkscape:connector-curvature="0"
+       id="path31664"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.57036,10.41471 c 0,0 4.55,11.388 4.55,11.388 m -7.08501,-11.388 c 0,0 5.889,14.326 5.889,14.326"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path31668"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.34836,28.51071 c 0,0 1.404,0 1.404,0 0.65866,0 1.16999,-0.156 1.53399,-0.468 0.364,-0.312 0.767,-1.04867 1.209,-2.21 2.06591,-5.13618 4.12093,-10.27695 6.175,-15.418 m -10.32199,20.098 c 0,0 1.91099,0 1.91099,0 1.07467,0 1.93267,-0.26433 2.574,-0.793 0.64134,-0.52866 1.3,-1.65967 1.97601,-3.393 0,0 6.39599,-15.912 6.39599,-15.912"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g20153"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-z">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.75279,10.42001 c 0,0 10.74152,0 10.74152,0 M 9.75279,12.33102 c 0,0 10.7321,0 10.7321,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path9413"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.49431,12.317 c 0,0 0,0.95857 0,0.95857 0,0 -8.37552,9.79345 -8.37552,9.79345 m 6.305,-10.738 c 0,0 -8.47893,10.01686 -8.47893,10.01686 0,0 0,0.73 0,0.73 m 3.66337,-6.00395 c 0,0 4.5069,0 4.5069,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3140"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.92838,23.06902 c 0,0 11.18641,0 11.18641,0 M 9.91335,24.98001 c 0,0 11.20144,0 11.20144,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3142"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-0"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g20540">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path49864"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 19.423692,15.54857 c 0,-2.66934 -0.342334,-4.667 -1.027,-5.993 -0.676,-1.33467 -1.694333,-2.002 -3.055,-2.002 -1.352,0 -2.370334,0.66733 -3.055,2.002 -0.676,1.326 -1.014,3.32366 -1.014,5.993 0,2.66066 0.338,4.65833 1.014,5.99299 0.684666,1.32601 1.703,1.98901 3.055,1.98901 1.360667,0 2.379,-0.663 3.055,-1.98901 0.684666,-1.33466 1.027,-3.33233 1.027,-5.99299 m 2.626,0 c 0,-3.276 -0.576334,-5.772 -1.729001,-7.488 -1.143999,-1.72467 -2.803666,-2.587 -4.978999,-2.587 -2.175334,0 -3.839334,0.86233 -4.992,2.587 -1.144,1.716 -1.716,4.212 -1.716,7.488 0,3.26733 0.572,5.76333 1.716,7.488 1.152666,1.716 2.816666,2.574 4.992,2.574 2.175333,0 3.835,-0.858 4.978999,-2.574 1.152667,-1.72467 1.729001,-4.22067 1.729001,-7.488" />
+  </g>
+  <g
+     id="g20941"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-1">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.966709,6.79157 c 0,0 4.640997,-0.936 4.640997,-0.936 M 9.966705,9.38928 c 0,0 4.666998,-0.936 4.666998,-0.936"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53139"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.233709,6.267 c 0,0 0,16.78756 0,16.78756 M 14.633706,6.25899 c 0,0 0,16.79557 0,16.79557"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53135"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 10.343708,25.26456 c 0,0 11.179999,0 11.179999,0 m -11.179999,-2.21 c 3.726667,0 7.453333,0 11.179999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path53129"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-2"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21342">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.673819,6.82294 c 1.057332,-0.42467 2.045333,-0.74534 2.964,-0.962 0.918666,-0.21667 1.759334,-0.325 2.522,-0.325 2.010667,0 3.613993,0.50266 4.810003,1.50799 1.196,1.00534 1.79399,2.34867 1.79399,4.03 0,0.79734 -0.15166,1.55567 -0.45499,2.27501 -0.29467,0.71066 -0.83634,1.55133 -1.625,2.52199 -0.21667,0.25134 -0.90567,0.97934 -2.067002,2.184 -1.161335,1.19601 -2.799333,2.873 -4.914002,5.031 M 9.673819,9.47493 c 1.039998,-0.58066 2.015001,-1.01399 2.925001,-1.29999 0.918666,-0.286 1.789666,-0.429 2.612997,-0.429 1.161335,0 2.273095,0.22214 2.992431,0.87214 0.727994,0.65 1.297714,1.42209 1.297714,2.45343 0,0.63266 -0.54615,1.44976 -0.88415,2.10842 -0.329326,0.65001 -0.914327,1.44734 -1.754995,2.39201 -0.441999,0.50266 -1.525332,1.625 -3.249999,3.367 -1.716,1.73333 -3.072331,3.11566 -4.068999,4.14699"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49868" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.852394,25.29593 c 0,0 12.015428,0 12.015428,0 m -11.976433,-2.21 c 0,0 11.976433,0 11.976433,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path54384" />
+  </g>
+  <g
+     id="g21752"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-3">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.5492,13.74906 c 0,0 2.366,0 2.366,0 0.29276,0 0.56993,-0.0131 0.8315,-0.0394 0,0 2.2235,1.02743 2.2235,1.02743 1.25666,0.26866 2.23599,0.82766 2.938,1.677 0.71067,0.84933 1.066,1.89799 1.066,3.14599 0,1.91534 -0.65867,3.39734 -1.976,4.446 -1.31733,1.04867 -3.18933,1.57301 -5.616,1.57301 -0.81467,0 -1.65533,-0.0823 -2.522,-0.24701 -0.858,-0.156 -1.74634,-0.39433 -2.665,-0.71499 m 3.354,-8.71 c 0,0 2.262,0 2.262,0 1.43,0 2.54366,0.325 3.341,0.975 0.806,0.64133 1.689,1.43113 1.689,2.57513 0,1.23934 -0.53619,2.28686 -1.40286,2.93686 -0.858,0.65 -2.48748,0.97501 -4.13414,0.97501 -0.94467,0 -1.85034,-0.10834 -2.717,-0.325 -0.86667,-0.21667 -1.664,-0.53734 -2.392,-0.96201 M 19.3837,19.8738 c 0,0 3.05143,0 3.05143,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path55631"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.7802,6.27407 c 0.99666,-0.27734 1.92833,-0.48534 2.795,-0.624 0.87533,-0.13867 1.69866,-0.208 2.47,-0.208 1.99333,0 3.57067,0.455 4.732,1.365 1.16133,0.90133 1.742,2.12333 1.742,3.66599 0,1.07467 -0.30767,1.98467 -0.923,2.73001 -0.53198,0.63687 -1.25828,1.10532 -2.1789,1.40536 M 9.7802,8.61407 c 0.988,-0.32934 1.89366,-0.57201 2.717,-0.72801 0.82333,-0.156 1.59466,-0.23399 2.314,-0.23399 1.31733,0 2.63557,0.063 3.33757,0.60028 0.71066,0.52867 1.13457,1.29133 1.13457,2.288 0,0.97067 -0.71948,1.92171 -1.40414,2.44172 -0.42984,0.32101 -0.97923,0.54126 -1.64817,0.66074"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49870"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-4"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g22181">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,17.94324 c 0,0 7.9108,-12.0509 7.9108,-12.0509 M 9.85415,18.43138 c 0,0 6.63,-10.361 6.63,-10.361"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49872" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 7.585,20.61538 c 0,0 8.762,0 8.762,0 M 9.71701,18.08852 c 0,0 6.62999,0 6.62999,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58727" />
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.72901,20.61538 c 0,0 -2.769,0 -2.769,0 m 2.769,-2.52686 c 0,0 -2.769,0 -2.769,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58735" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 18.96001,6.05667 v 12.28728 6.71028 M 16.347,6.04208 v 12.30187 6.71028"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path58741" />
+  </g>
+  <g
+     id="g23013"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-5">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.00243,5.71223 c 0,0 10.01808,0 10.01808,0 m -9.98895,2.20999 c 0,0 9.98895,0 9.98895,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49874"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path74136"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.89251,22.02723 c 0.78,0.42466 1.586,0.741 2.418,0.949 0.83201,0.208 1.71167,0.312 2.63901,0.312 1.49933,0 3.02607,-0.39434 3.9014,-1.183 0.87534,-0.78867 1.40998,-1.85901 1.40998,-3.211 0,-1.352 -0.53464,-2.42234 -1.40998,-3.211 -0.87533,-0.78867 -2.40207,-1.183 -3.9014,-1.183 -0.70201,0 -1.404,0.078 -2.10601,0.234 -0.69333,0.156 -1.404,0.39866 -2.132,0.728 0,0 0,-7.13169 0,-7.13169 m -0.819,16.33569 c 0.90134,0.27733 1.77234,0.48533 2.613,0.624 0.84934,0.13866 1.68134,0.208 2.496,0.208 2.366,0 4.199,-0.57634 5.499,-1.72901 1.3,-1.16133 1.95,-2.78633 1.95,-4.87499 0,-2.028 -0.63266,-3.63567 -1.898,-4.823 -1.26533,-1.18734 -2.98133,-1.68403 -5.148,-1.68403 -0.38133,0 -0.76266,0.0347 -1.144,0.104 -0.38133,0.0607 -1.21082,0.27306 -1.59215,0.40306 0,0 0.27673,-4.58414 0.27673,-4.58414"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g24259"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-6">
+    <path
+       sodipodi:nodetypes="cccsccccscsccssscscccssscscccccccccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.27716,8.61419 c -0.65867,-0.312 -1.326,-0.55034 -2.002,-0.715 -0.66733,-0.1647 -1.33034,-0.247 -1.989,-0.247 -1.73334,0 -3.05934,0.585 -3.978,1.75499 -0.85881,1.10419 -1.6127,2.74099 -1.7768,4.91041 -0.01,0.1293 0.0302,3.93488 0.0694,4.16884 0.0465,1.49619 0.97071,2.98909 1.65538,3.80375 0.69333,0.80601 1.62933,1.20901 2.808,1.20901 1.17866,0 2.11033,-0.403 2.795,-1.20901 0.69333,-0.81466 1.04,-1.91966 1.04,-3.31499 0,-1.404 -0.34667,-2.50901 -1.04,-3.31501 -0.68467,-0.80599 -1.61634,-1.20899 -2.795,-1.20899 -1.17867,0 -2.16316,0.35451 -2.85649,1.16051 -0.34173,0.40228 -0.87667,0.93996 -1.13254,1.40652 M 20.27712,6.22219 c -0.728,-0.26 -1.43,-0.455 -2.106,-0.585 -0.66734,-0.13 -1.33034,-0.195 -1.989,-0.195 -2.45267,0 -4.407,0.91433 -5.863,2.743 -1.456,1.82 -2.184,4.264 -2.184,7.332 0,1.13012 0.071,2.16796 0.21308,3.11353 0.26864,1.78818 0.79128,3.24633 1.56794,4.37447 1.18733,1.716 2.90333,2.574 5.148,2.574 1.95866,0 3.52733,-0.60234 4.706,-1.80701 1.17866,-1.20466 1.768,-2.80366 1.768,-4.79699 0,-2.03667 -0.56767,-3.64434 -1.703,-4.823 -1.12667,-1.18734 -2.665,-1.78101 -4.615,-1.78101 -0.92734,0 -1.77667,0.20367 -2.548,0.61101 -0.77134,0.39866 -1.31569,0.78104 -1.82702,1.53504 M 10.95384,15.7316 7.54458,15.7 m 7.48144,7.3552 v 3.06203 m 3.3777,-6.91324 h 3.63023 m -5.93464,-3.81964 0.15783,-3.44083"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path77434" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-7"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g24692">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1140"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.4219,7.81207 c 0,0 11.40595,0 11.40595,0 M 9.4219,5.60208 c 0,0 12.14059,0 12.14059,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path1142"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 18.7429,7.81207 c 0,0 -6.63,17.199 -6.63,17.199 M 21.47022,7.84068 c -2.34867,6.097 -4.26565,11.0734 -6.61432,17.17039"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g25126"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-8">
+    <path
+       sodipodi:nodetypes="ccscscsccccscscsccccscscsccccscscscccccccccccc"
+       id="path49880"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 15.57967,13.95414 c 0.81627,-0.17505 1.92151,-0.60808 2.39389,-1.02869 0.64133,-0.56334 0.96199,-1.34767 0.96199,-2.353 0,-1.00534 -0.46613,-1.69269 -1.10745,-2.25603 -0.63267,-0.56333 -1.60931,-0.69953 -2.73598,-0.69953 -1.13533,0 -2.21328,0.0877 -2.84595,0.65105 -0.624,0.56333 -0.936,1.34766 -0.936,2.353 0,1.00533 0.50595,1.98361 1.12995,2.54695 0.63267,0.56333 1.51667,0.845 2.652,0.845 l 2.63901,0.94899 c 1.26532,0.29467 2.24898,0.87101 2.95099,1.729 0.71066,0.85801 1.066,1.90667 1.066,3.146 0,1.88067 -0.57634,3.32367 -1.72901,4.329 -1.144,1.00534 -2.78633,1.50801 -4.92699,1.50801 -2.14067,0 -3.78733,-0.50267 -4.93999,-1.50801 -1.14401,-1.00533 -1.716,-2.44833 -1.716,-4.329 0,-1.23933 0.35533,-2.28799 1.06599,-3.146 0.71067,-0.85799 1.69867,-1.43433 2.964,-1.729 m 5.39421,-0.13285 c 1.00546,-0.39347 2.07635,-0.9365 2.48379,-1.44014 0.63267,-0.77134 0.949,-1.71167 0.949,-2.82101 0,-1.55133 -0.55033,-2.77766 -1.651,-3.679 -1.10067,-0.90132 -2.61734,-1.35199 -4.55,-1.35199 -1.924,0 -3.44066,0.45067 -4.55,1.35199 -1.10066,0.90134 -1.651,2.12767 -1.651,3.679 0,1.10934 0.312,2.04967 0.936,2.82101 0.63267,0.77133 2.96695,1.65932 4.09362,1.93665 l 1.17138,0.75435 c 1.25666,0 2.24033,0.33366 2.95101,1.00099 0.71933,0.66734 1.27294,1.77995 1.27294,2.94995 0,1.16134 -0.45664,1.98303 -1.17597,2.65903 -0.71933,0.66733 -1.79997,0.90403 -3.04798,0.90403 -1.248,0 -2.28015,-0.18821 -2.99948,-0.85554 -0.71067,-0.66734 -1.21147,-1.63449 -1.21147,-2.80449 0,-1.17 0.54929,-2.18564 1.25995,-2.85298 0.59399,-0.55105 1.36823,-0.87459 2.32271,-0.9706 m 3.32729,1.48916 2.37588,-2.15768 m -8.29133,-3.78201 -2.61832,1.67281 m 9.10257,-2.75825 h 3.504243 M 11.415171,20.24288 H 7.79992 m 11.087874,0 h 3.174976"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-9"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g25564">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 10.03615,24.8856 c 0.728,0.26 1.43,0.45499 2.10601,0.585 0.67599,0.13 1.34333,0.195 2.00201,0.195 2.45267,0 4.40267,-0.91 5.85,-2.73 1.456,-1.82867 2.184,-4.27267 2.184,-7.332 0,-3.276 -0.59366,-5.772 -1.78099,-7.488 -1.17868,-1.72467 -2.89036,-2.587 -5.13502,-2.587 -1.95867,0 -3.52733,0.60233 -4.70599,1.807 -1.17868,1.20466 -1.76802,2.80366 -1.76802,4.797 0,2.03666 0.56334,3.64433 1.69002,4.82299 1.13533,1.17 2.67367,1.755 4.61501,1.755 0.936,0 1.78966,-0.19933 2.56099,-0.598 0.77133,-0.39866 1.40833,-0.97066 1.91099,-1.716 m -9.52901,6.09701 c 0.65868,0.312 1.32602,0.55033 2.00202,0.715 0.676,0.16466 1.33899,0.247 1.98899,0.247 1.73334,0 3.055,-0.58067 3.96499,-1.742 0.91868,-1.17001 1.54588,-3.06234 1.67587,-5.43701 0,0 -0.69167,-2.16606 -0.69167,-2.16606 0.29874,-0.60338 0.3951,-1.1827 0.3951,-1.97793 0,-1.39534 -0.62095,-2.496 -1.31427,-3.302 -0.68467,-0.81467 -1.61635,-1.222 -2.79502,-1.222 -1.17867,0 -2.11467,0.40733 -2.808,1.222 -0.68466,0.806 -1.2327,1.90666 -1.2327,3.302 0,1.404 0.54804,2.509 1.2327,3.315 0.69333,0.806 1.62933,1.209 2.808,1.209 1.17867,0 2.11035,-0.403 2.79502,-1.209 0.30061,-0.34948 0.58763,-0.75517 0.81632,-1.21707 m -0.0187,-2.02147 c 0,0 3.4426,0 3.4426,0 m -7.1519,3.97596 c 0,0 0,2.98197 0,2.98197 M 15.097,8.08764 c 0,0 0,-2.98197 0,-2.98197 m -3.51532,7.24885 c 0,0 -3.20017,0 -3.20017,0"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-@"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g27314">
+    <path
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_center_walk_underlay="True"
+       inkscape:connector-curvature="0"
+       d="m 18.524434,15.71229 h 3.140908 m -0.0698,3.26257 -2.457229,2.99278 m 4.363158,-4.15839 1.543646,2.1737 M 16.163182,6.28957 V 3.21549 m 5.896635,19.98338 c -0.900939,0.70169 -1.892839,1.23879 -2.975696,1.61129 -1.074197,0.38117 -2.17005,0.57175 -3.28756,0.57175 -1.36007,0 -2.637844,-0.23823 -3.83332,-0.71468 -1.195476,-0.4678 -2.248015,-1.15217 -3.157616,-2.0531 -0.944253,-0.91827 -1.667602,-1.97947 -2.170049,-3.18361 -0.493784,-1.20414 -0.740675,-2.4949 -0.740675,-3.8723 0,-1.67194 0.381166,-3.22259 1.143499,-4.65196 0.770995,-1.43804 1.836528,-2.59886 3.196599,-3.48248 0.831635,-0.55442 1.736905,-0.97024 2.715809,-1.24745 0.978905,-0.28588 2.001123,-0.42881 3.066656,-0.42881 1.524666,0 2.932381,0.3032 4.223149,0.9096 1.29943,0.59774 2.399614,1.46402 3.300552,2.59886 0.554426,0.69303 0.96591,1.4467 1.23446,2.26101 0.277211,0.81431 0.415818,1.68493 0.415818,2.61185 0,1.53333 -0.359508,2.78512 -1.078528,3.75536 -0.597216,0.80843 -1.390371,1.34437 -2.379465,1.60784 -0.374889,0.08504 -0.598104,-0.36344 -0.583234,-0.7062 v -8.73721 m 2.079086,14.59261 c -1.082857,0.8403 -2.265338,1.48135 -3.547443,1.92316 -1.273443,0.45047 -2.568542,0.6757 -3.885298,0.6757 -1.602631,0 -3.114302,-0.28588 -4.535012,-0.85762 C 9.840838,25.81939 8.576059,24.99641 7.467212,23.91356 6.358364,22.8307 5.513734,21.57891 4.933322,20.1582 4.35291,18.72883 4.062704,17.1955 4.062704,15.55822 c 0,-1.57664 0.294537,-3.07965 0.883612,-4.50903 C 5.535391,9.61982 6.37569,8.3637 7.467212,7.28085 8.584722,6.18066 9.87549,5.34036 11.339515,4.75995 12.80354,4.17088 14.354193,3.87634 15.991476,3.87634 c 1.836527,0 3.538782,0.37683 5.106761,1.1305 1.576641,0.75367 2.897729,1.82353 3.963261,3.20959 0.649716,0.84897 1.143498,1.77156 1.481353,2.76779 0.346514,0.99623 0.519771,2.02711 0.519771,3.09265 0,2.27833 -0.688697,4.07588 -2.066093,5.39263 -1.225129,1.1712 -2.864889,1.98307 -4.919283,2.18484 -0.506962,0.09524 -0.760027,-0.42324 -0.785217,-0.97832 v -0.66447 c -0.549565,-2.96443 -0.637134,-5.92887 0,-8.8933 v -1.06962"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3259"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+    <path
+       d="m 18.973724,18.01104 c -0.953206,0.98219 -1.738847,1.54746 -3.307106,1.6014 -1.074196,0 -1.918825,-0.35084 -2.533889,-1.05254 -0.615064,-0.71035 -0.922596,-1.68493 -0.922596,-2.92372 0,-1.22146 0.307532,-2.18737 0.922596,-2.89773 0.623727,-0.71035 1.459693,-1.06553 2.5079,-1.06553 1.170383,0.013 2.315595,0.4933 3.252689,1.38151 m 0.398711,6.95712 c -0.519771,0.66704 -1.117511,0.87124 -1.793214,1.19177 -0.667041,0.31186 -1.4467,0.26731 -2.338975,0.26731 -1.490014,0 -2.702815,-0.5371 -3.638405,-1.6113 -0.926927,-1.08286 -1.390391,-2.49057 -1.390391,-4.22315 0,-1.73257 0.467795,-3.14029 1.403385,-4.22315 0.93559,-1.08285 2.144061,-1.62428 3.625411,-1.62428 0.892275,0 1.899026,0.0978 2.351969,0.27102 0.675703,0.32053 1.157731,0.55603 1.78022,1.05848 m -6.648447,4.8168 c 0,0 -3.051806,0 -3.051806,0 m 5.686781,-6.8325808 0.315673,3.1882938"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path3287"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g27781"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-&lt;">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.726579,10.1565 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.832901,-3.2911 c 0,0 -9.414965,5.151 -9.414965,5.151 0,0 -1.276021,0 -1.276021,0 m 8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60030"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.893678,19.1353 c 0,0 10.832901,6.045 10.832901,6.045 M 10.035593,17.31977 c 0,0 1.305988,0 1.305988,0 0,0 9.384998,5.10663 9.384998,5.10663 m -2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path60034"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&gt;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g28228">
+    <path
+       inkscape:connector-curvature="0"
+       id="path60030-7"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 9.893678,10.1565 c 0,0 10.832901,6.045 10.832901,6.045 M 9.893678,12.9104 c 0,0 9.414965,5.151 9.414965,5.151 0,0 1.276021,0 1.276021,0 m -8.660471,-7.47787 c 0,0 0,3.84 0,3.84"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path60034-0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.726579,19.1353 c 0,0 -10.832901,6.045 -10.832901,6.045 m 10.690986,-7.86053 c 0,0 -1.305988,0 -1.305988,0 0,0 -9.384998,5.10663 -9.384998,5.10663 m 2.133373,2.11142 c 0,0 0,-3.80571 0,-3.80571"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g28695"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-:">
+    <path
+       id="path64532"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,24.61503 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path49890"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 14.09646,14.15003 c 0,0 0,-3.302 0,-3.302 m 2.743,3.302 c 0,0 0,-3.302 0,-3.302"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-,"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g29163">
+    <path
+       inkscape:connector-curvature="0"
+       id="path49892"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 11.59179,28.88132 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g29625"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-'">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 12.4735,12.47318 c 0,0 2.602,-4.15999 2.602,-4.15999 0,0 0,-2.236 0,-2.236 m 0.70798,6.39599 c 0,0 2.44717,-4.15999 2.44717,-4.15999 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-&quot;"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g30411">
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 18.237167,6.2097636 17.95084,10.369753 v 2.236 m -3.023653,-6.3959894 0.184175,4.1599894 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-0"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 11.795187,6.2097636 11.50886,10.369753 v 2.236 M 8.485207,6.2097636 8.6693823,10.369753 v 2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-23"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g34046"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-“">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 20.710676,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.268696,6.2097632 c 0,0 -2.602,4.1599898 -2.602,4.1599898 0,0 0,2.236 0,2.236 m -0.70798,-6.3959898 c 0,0 -2.44717,4.1599898 -2.44717,4.1599898 0,0 0,2.236 0,2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-”"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g34542">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.4734996,12.47318 c 0,0 2.6020004,-4.1599901 2.6020004,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-6-6-9"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 14.91548,12.47318 c 0,0 2.602,-4.1599901 2.602,-4.1599901 0,0 0,-2.236 0,-2.236 m 0.70798,6.3959901 c 0,0 2.44717,-4.1599901 2.44717,-4.1599901 0,0 0,-2.236 0,-2.236"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49892-9-62-1-2"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g35054"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-.">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 13.21903,25.02102 c 0,0 0,-3.67914 0,-3.67914 m 3.61385,3.67914 c 0,0 0,-3.67914 0,-3.67914"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path49894"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g36092"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-+">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 8.73408,16.48936 c 0,0 5.15643,0 5.15643,0 m -5.15643,2.48428 c 0,0 5.15643,0 5.15643,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70194" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 17.12921,18.97364 h 5.19887 m -5.19887,-2.48428 h 5.19887"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70206" />
+    <path
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       d="m 16.76022,24.5415 c 0,-4.54001 0,-9.08003 0,-13.62004 m -2.45829,13.62008 c 0,-4.54001 0,-9.08003 0,-13.62004"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path70200"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_center_walk_underlay_stitch_length_mm="1.2" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer--"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g36598">
+    <path
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 11.77518,18.59803 c 0,0 7.007,0 7.007,0 m -7.007,-2.61687 c 0,0 7.007,0 7.007,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155" />
+  </g>
+  <g
+     id="g37137"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-=">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 21.18132,21.77189 c 0,0 -12.05799,0 -12.05799,0 m 12.05799,-2.978 c 0,0 -12.05799,0 -12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72806"
+       inkscape:connector-curvature="0" />
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="m 9.12333,15.67389 c 0,0 12.05799,0 12.05799,0 m -12.05799,-2.952 c 0,0 12.05799,0 12.05799,0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72814"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-("
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g37653">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 18.29969,5.0598 c -1.16134,1.79768 -2.02367,3.57582 -2.587,5.33443 -0.56334,1.7586 -0.845,3.54065 -0.845,5.34615 0,1.8055 0.28166,3.59536 0.845,5.3696 0.572,1.76642 1.43433,3.54456 2.587,5.33443 M 14.68369,5.0598 c -1.30867,1.84458 -2.28367,3.65008 -2.925,5.4165 -0.64134,1.76641 -0.962,3.52111 -0.962,5.26408 0,1.75078 0.32066,3.5133 0.962,5.28753 0.65,1.77424 1.625,3.57973 2.925,5.4165"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path11049"
+       embroider_zigzag_spacing_mm="0.4"
+       embroider_satin_column="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_center_walk_underlay="True"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_contour_underlay="False"
+       embroider_zigzag_underlay="False" />
+  </g>
+  <g
+     id="g38173"
+     style="display:none"
+     inkscape:groupmode="layer"
+     inkscape:label="GlyphLayer-)">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path11049-4"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68445802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 12.79407,4.97629 c 1.16133,1.79768 2.02366,3.57582 2.58699,5.33443 0.56334,1.7586 0.84501,3.54065 0.84501,5.34615 0,1.80549 -0.28167,3.59536 -0.84501,5.3696 -0.572,1.76642 -1.43433,3.54456 -2.58699,5.33443 M 16.41006,4.97629 c 1.30867,1.84458 2.28367,3.65008 2.925,5.4165 0.64134,1.76641 0.962,3.52111 0.962,5.26408 0,1.75078 -0.32066,3.51329 -0.962,5.28753 -0.65,1.77423 -1.625,3.57973 -2.925,5.4165"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-_"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g38697">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       d="M 7.16633,26.06829 H 23.26471 M 7.16633,23.45142 h 16.09838"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path72155-7" />
+  </g>
+  <g
+     inkscape:label="GlyphLayer-/"
+     inkscape:groupmode="layer"
+     style="display:none"
+     id="g21638">
+    <path
+       embroider_zigzag_underlay="False"
+       embroider_contour_underlay="False"
+       embroider_center_walk_underlay_stitch_length_mm="1.2"
+       embroider_center_walk_underlay="True"
+       embroider_pull_compensation_mm="0.2"
+       embroider_satin_column="True"
+       embroider_zigzag_spacing_mm="0.4"
+       id="path7399-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:106.66666412px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:50px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 23.158687,4.3183179 11.247686,26.957795 M 20.532687,4.3183179 8.6216891,26.957795"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -19,6 +19,16 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 
 
+logger = logging.getLogger('shapely.geos')
+logger.setLevel(logging.DEBUG)
+shapely_errors = StringIO()
+ch = logging.StreamHandler(shapely_errors)
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
 parser = ArgumentParser()
 parser.add_argument("--extension")
 my_args, remaining_args = parser.parse_known_args()

--- a/lib/elements/__init__.py
+++ b/lib/elements/__init__.py
@@ -1,6 +1,7 @@
+from auto_fill import AutoFill
 from element import EmbroideryElement
+from fill import Fill
+from polyline import Polyline
 from satin_column import SatinColumn
 from stroke import Stroke
-from polyline import Polyline
-from fill import Fill
-from auto_fill import AutoFill
+from utils import node_to_elements, nodes_to_elements

--- a/lib/elements/utils.py
+++ b/lib/elements/utils.py
@@ -1,0 +1,47 @@
+
+from ..commands import is_command
+from ..svg.tags import SVG_POLYLINE_TAG, SVG_PATH_TAG
+
+from .auto_fill import AutoFill
+from .element import EmbroideryElement
+from .fill import Fill
+from .polyline import Polyline
+from .satin_column import SatinColumn
+from .stroke import Stroke
+
+
+def node_to_elements(node):
+    if node.tag == SVG_POLYLINE_TAG:
+        return [Polyline(node)]
+    elif node.tag == SVG_PATH_TAG:
+        element = EmbroideryElement(node)
+
+        if element.get_boolean_param("satin_column"):
+            return [SatinColumn(node)]
+        else:
+            elements = []
+
+            if element.get_style("fill", "black"):
+                if element.get_boolean_param("auto_fill", True):
+                    elements.append(AutoFill(node))
+                else:
+                    elements.append(Fill(node))
+
+            if element.get_style("stroke"):
+                if not is_command(element.node):
+                    elements.append(Stroke(node))
+
+            if element.get_boolean_param("stroke_first", False):
+                elements.reverse()
+
+            return elements
+    else:
+        return []
+
+
+def nodes_to_elements(nodes):
+    elements = []
+    for node in nodes:
+        elements.extend(node_to_elements(node))
+
+    return elements

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -1,18 +1,20 @@
+from auto_satin import AutoSatin
+from convert_to_satin import ConvertToSatin
+from cut_satin import CutSatin
 from embroider import Embroider
+from flip import Flip
+from global_commands import GlobalCommands
+from input import Input
 from install import Install
+from layer_commands import LayerCommands
+from lettering import Lettering
+from object_commands import ObjectCommands
+from output import Output
 from params import Params
 from print_pdf import Print
 from simulate import Simulate
-from input import Input
-from output import Output
 from zip import Zip
-from flip import Flip
-from object_commands import ObjectCommands
-from layer_commands import LayerCommands
-from global_commands import GlobalCommands
-from convert_to_satin import ConvertToSatin
-from cut_satin import CutSatin
-from auto_satin import AutoSatin
+
 
 __all__ = extensions = [Embroider,
                         Install,
@@ -28,4 +30,5 @@ __all__ = extensions = [Embroider,
                         GlobalCommands,
                         ConvertToSatin,
                         CutSatin,
-                        AutoSatin]
+                        AutoSatin,
+                        Lettering]

--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -109,6 +109,16 @@ class InkstitchExtension(inkex.Effect):
             if g.get(INKSCAPE_GROUPMODE) == "layer":
                 g.set("style", "display:none")
 
+    def ensure_current_layer(self):
+        # if no layer is selected, inkex defaults to the root, which isn't
+        # particularly useful
+        if self.current_layer is self.document.getroot():
+            try:
+                self.current_layer = self.document.xpath(".//svg:g[@inkscape:groupmode='layer']", namespaces=inkex.NSS)[0]
+            except IndexError:
+                # No layers at all??  Fine, we'll stick with the default.
+                pass
+
     def no_elements_error(self):
         if self.selected:
             inkex.errormsg(_("No embroiderable paths selected."))

--- a/lib/extensions/embroider.py
+++ b/lib/extensions/embroider.py
@@ -1,15 +1,15 @@
 import os
 
-from .base import InkstitchExtension
 from ..i18n import _
 from ..output import write_embroidery_file
 from ..stitch_plan import patches_to_stitch_plan
 from ..svg import render_stitch_plan, PIXELS_PER_MM
+from .base import InkstitchExtension
 
 
 class Embroider(InkstitchExtension):
     def __init__(self, *args, **kwargs):
-        InkstitchExtension.__init__(self)
+        InkstitchExtension.__init__(self, *args, **kwargs)
         self.OptionParser.add_option("-c", "--collapse_len_mm",
                                      action="store", type="float",
                                      dest="collapse_length_mm", default=3.0,

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -1,24 +1,14 @@
 import inkex
 
-from .commands import CommandsExtension
 from ..commands import LAYER_COMMANDS, get_command_description
 from ..i18n import _
-from ..svg.tags import SVG_USE_TAG, INKSCAPE_LABEL, XLINK_HREF
 from ..svg import get_correction_transform
+from ..svg.tags import SVG_USE_TAG, INKSCAPE_LABEL, XLINK_HREF
+from .commands import CommandsExtension
 
 
 class LayerCommands(CommandsExtension):
     COMMANDS = LAYER_COMMANDS
-
-    def ensure_current_layer(self):
-        # if no layer is selected, inkex defaults to the root, which isn't
-        # particularly useful
-        if self.current_layer is self.document.getroot():
-            try:
-                self.current_layer = self.document.xpath(".//svg:g[@inkscape:groupmode='layer']", namespaces=inkex.NSS)[0]
-            except IndexError:
-                # No layers at all??  Fine, we'll stick with the default.
-                pass
 
     def effect(self):
         commands = [command for command in self.COMMANDS if getattr(self.options, command)]

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -15,4 +15,5 @@ class Lettering(InkstitchExtension):
     def effect(self):
         font_path = os.path.join(get_resource_dir("fonts"), "small_font")
         font = Font(font_path)
+        self.ensure_current_layer()
         self.current_layer.extend(font.render_text(self.options.text))

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -1,19 +1,30 @@
 import os
 
-from ..i18n import _
 from ..lettering import Font
+from ..stitches.auto_satin import auto_satin
 from ..utils import get_resource_dir
+from .commands import CommandsExtension
 
-from .base import InkstitchExtension
 
+class Lettering(CommandsExtension):
+    COMMANDS = ["trim"]
 
-class Lettering(InkstitchExtension):
     def __init__(self, *args, **kwargs):
-        InkstitchExtension.__init__(self, *args, **kwargs)
+        CommandsExtension.__init__(self, *args, **kwargs)
+
         self.OptionParser.add_option("-t", "--text")
 
     def effect(self):
         font_path = os.path.join(get_resource_dir("fonts"), "small_font")
         font = Font(font_path)
         self.ensure_current_layer()
-        self.current_layer.extend(font.render_text(self.options.text))
+
+        lines = font.render_text(self.options.text)
+        for line in lines:
+            # they need to be SatinColumns
+            elements, trim_indices = auto_satin(line, preserve_order=True)
+            del line[:]
+            for element in elements:
+                line.append(element.node)
+
+        self.current_layer.extend(lines)

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -1,7 +1,6 @@
 import os
 
 from ..lettering import Font
-from ..stitches.auto_satin import auto_satin
 from ..utils import get_resource_dir
 from .commands import CommandsExtension
 
@@ -20,11 +19,5 @@ class Lettering(CommandsExtension):
         self.ensure_current_layer()
 
         lines = font.render_text(self.options.text)
-        for line in lines:
-            # they need to be SatinColumns
-            elements, trim_indices = auto_satin(line, preserve_order=True)
-            del line[:]
-            for element in elements:
-                line.append(element.node)
 
         self.current_layer.extend(lines)

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -1,0 +1,18 @@
+import os
+
+from ..i18n import _
+from ..lettering import Font
+from ..utils import get_resource_dir
+
+from .base import InkstitchExtension
+
+
+class Lettering(InkstitchExtension):
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.OptionParser.add_option("-t", "--text")
+
+    def effect(self):
+        font_path = os.path.join(get_resource_dir("fonts"), "small_font")
+        font = Font(font_path)
+        self.current_layer.extend(font.render_text(self.options.text))

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -18,6 +18,6 @@ class Lettering(CommandsExtension):
         font = Font(font_path)
         self.ensure_current_layer()
 
-        lines = font.render_text(self.options.text)
+        lines = font.render_text(self.options.text.decode('utf-8'))
 
         self.current_layer.extend(lines)

--- a/lib/lettering/__init__.py
+++ b/lib/lettering/__init__.py
@@ -1,0 +1,1 @@
+from font import Font

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -1,0 +1,85 @@
+from copy import deepcopy
+import json
+import os
+
+from ..svg import PIXELS_PER_MM
+from ..utils import Point
+from .font_variant import FontVariant
+
+
+def font_metadata(name, default=None):
+    def getter(self):
+        return self.metadata.get(name, default)
+
+    return property(getter)
+
+
+class Font(object):
+    """Represents a font with multiple variants.
+
+    Each font may have multiple FontVariants for left-to-right, right-to-left,
+    etc.  Each variant has a set of Glyphs, one per character.
+
+    Properties:
+      path     -- the path to the directory containing this font
+      metadata -- A dict of information about the font.
+      name     -- Shortcut property for metadata["name"]
+      license  -- contents of the font's LICENSE file, or None if no LICENSE file exists.
+      variants -- A dict of FontVariants, with keys in FontVariant.VARIANT_TYPES.
+    """
+
+    def __init__(self, font_path):
+        self.path = font_path
+        self._load_metadata()
+        self._load_license()
+        self._load_variants()
+
+    def _load_metadata(self):
+        try:
+            with open(os.path.join(self.path, "font.json")) as metadata_file:
+                self.metadata = json.load(metadata_file)
+        except IOError:
+            self.metadata = {}
+
+    def _load_license(self):
+        try:
+            with open(os.path.join(self.path, "LICENSE")) as license_file:
+                self.license = json.load(license_file)
+        except IOError:
+            self.license = None
+
+    def _load_variants(self):
+        self.variants = {}
+
+        for variant in FontVariant.VARIANT_TYPES:
+            try:
+                self.variants[variant] = FontVariant(self.path, variant, self.default_glyph)
+            except IOError:
+                # we'll deal with missing variants when we apply lettering
+                pass
+
+    name = font_metadata('name')
+    default_variant = font_metadata('default_variant', FontVariant.LEFT_TO_RIGHT)
+    default_glyph = font_metadata('defalt_glyph', u"�")
+    kerning = font_metadata('kerning', 2 * PIXELS_PER_MM)
+    leading = font_metadata('leading', 5 * PIXELS_PER_MM)
+
+    def render_text(self, text, variant=None):
+        glyph_set = self.variants.get(variant, self.default_variant)
+
+        nodes = []
+        position = Point(0, 0)
+        for line in text.splitlines():
+            line = line.strip()
+            for character in line:
+                glyph = glyph_set[character]
+                node = deepcopy(glyph.node)
+                transform = "translate(%s, %s)" % position.as_tuple()
+                glyph.set('transform', transform)
+                nodes.append(node)
+                position.x += self.kerning
+
+            position.y += self.leading
+            position.x = 0
+
+        return nodes

--- a/lib/lettering/font_variant.py
+++ b/lib/lettering/font_variant.py
@@ -1,0 +1,62 @@
+# -*- coding: UTF-8 -*-
+
+import os
+
+import inkex
+
+from ..svg.tags import INKSCAPE_GROUPMODE, INKSCAPE_LABEL
+from .glyph import Glyph
+
+
+class FontVariant(object):
+    """Represents a single variant of a font.
+
+    Each font may have multiple variants for left-to-right, right-to-left,
+    etc.  Each variant has a set of Glyphs, one per character.
+
+    A FontVariant instance can be accessed as a dict by using a unicode
+    character as a key.
+
+    Properties:
+      path    -- the path to the directory containing this font
+      variant -- the font variant, specified using one of the constants below
+      glyphs  -- a dict of Glyphs, with the glyphs' unicode characters as keys.
+    """
+
+    # We use unicode characters rather than English strings for font file names
+    # in order to be more approachable for languages other than English.
+    LEFT_TO_RIGHT = u"→"
+    RIGHT_TO_LEFT = u"←"
+    TOP_TO_BOTTOM = u"↓"
+    BOTTOM_TO_TOP = u"↑"
+    VARIANT_TYPES = (LEFT_TO_RIGHT, RIGHT_TO_LEFT, TOP_TO_BOTTOM, BOTTOM_TO_TOP)
+
+    def __init__(self, font_path, variant, default_glyph=None):
+        self.path = font_path
+        self.variant = variant
+        self.default_glyph = default_glyph
+        self.glyphs = {}
+        self._load_glyphs(font_path, variant)
+
+    def _load_glyphs(self):
+        svg_path = os.path.join(self.font_path, u"%s.svg" % self.variant)
+        svg = inkex.etree.parse(svg_path)
+
+        glyph_layers = svg.xpath(".//svg:g[starts-with(@inkscape:label, 'GlyphLayer-')]", namespaces=inkex.NSS)
+        for layer in glyph_layers:
+            # We'll repurpose the layer as a container group labelled with the
+            # glyph.
+            del layer.attrib[INKSCAPE_GROUPMODE]
+            layer.attrib[INKSCAPE_LABEL] = layer.attrib[INKSCAPE_LABEL].replace("GlyphLayer-", "", 1)
+
+            glyph_name = layer.attrib[INKSCAPE_LABEL]
+            self.glyphs[glyph_name] = Glyph([layer])
+
+    def __getitem__(self, character):
+        if character in self.glyphs:
+            return self.glyphs[character]
+        else:
+            return self.glyphs.get(self.default_glyph, None)
+
+    def __contains__(self, character):
+        return character in self.glyphs

--- a/lib/lettering/glyph.py
+++ b/lib/lettering/glyph.py
@@ -1,0 +1,76 @@
+import cubicsuperpath
+import simpletransform
+from copy import copy
+
+from ..svg import apply_transforms, get_guides
+from ..svg.tags import INKSCAPE_LABEL
+from ..utils import cache
+
+
+class Glyph(object):
+    """Represents a single character in a single font variant.
+
+    For example, the font inkstitch_small may have variants for left-to-right,
+    right-to-left, etc.  Each variant would have a set of Glyphs, one for each
+    character in that variant.
+
+    Properties:
+      width -- total width of this glyph including all component satins
+      nodes -- SVG path nodes of the component satins in this character
+    """
+
+    def __init__(self, nodes):
+        """Create a Glyph.
+
+        The nodes will be copied out of their parent SVG document (with nested
+        transforms applied).  The original nodes will be unmodified.
+
+        Arguments:
+          nodes -- an iterable of XML nodes
+        """
+        self.nodes = []
+
+        self._process_nodes(nodes)
+        self._process_bbox()
+        self._move_to_origin()
+
+    def _process_nodes(self, nodes):
+        self.baseline = None
+
+        for node in nodes:
+            if self.baseline is None:
+                self._process_baseline(node.getroottree().getroot())
+
+            node_copy = copy(node)
+            path = cubicsuperpath.parsePath(node.get(d))
+            apply_transforms(path, node)
+
+            node_copy.set("d", cubicsuperpath.formatPath(path))
+            if 'transform' in node_copy.attrib:
+                del node_copy.attrib['transform']
+
+            self.nodes.append(node_copy)
+
+    def _process_baseline(self, svg):
+        for guide in get_guides(svg):
+            if guide.label == "baseline":
+                self.baseline = guide.position.y
+                break
+        else:
+            # no baseline guide found, assume 0 for lack of anything better to use...
+            self.baseline = 0
+
+    def _process_bbox(self):
+        left, right, top, bottom = simpletransform.computeBBox(self.nodes)
+
+        self.width = right - left
+        self._min_x = left
+
+    def _move_to_origin(self):
+        translate_x = -self.min_x
+        translate_y = -self.baseline
+        transform = "translate(%s, %s)" % (translate_x, translate_y)
+
+        for node in self.nodes:
+            node.set('transform', transform)
+            simpletransform.fuseTransform(node)

--- a/lib/lettering/glyph.py
+++ b/lib/lettering/glyph.py
@@ -38,6 +38,7 @@ class Glyph(object):
     def _process_group(self, group):
         new_group = copy(group)
         new_group.attrib.pop('transform', None)
+        del new_group[:]  # delete references to the original group's children
 
         for node in group:
             if node.tag == SVG_GROUP_TAG:
@@ -63,11 +64,11 @@ class Glyph(object):
     def _process_baseline(self, svg):
         for guide in get_guides(svg):
             if guide.label == "baseline":
-                self.baseline = guide.position.y
+                self._baseline = guide.position.y
                 break
         else:
             # no baseline guide found, assume 0 for lack of anything better to use...
-            self.baseline = 0
+            self._baseline = 0
 
     def _process_bbox(self):
         left, right, top, bottom = simpletransform.computeBBox(self.node.iterdescendants())
@@ -76,8 +77,8 @@ class Glyph(object):
         self._min_x = left
 
     def _move_to_origin(self):
-        translate_x = -self.min_x
-        translate_y = -self.baseline
+        translate_x = -self._min_x
+        translate_y = -self._baseline
         transform = "translate(%s, %s)" % (translate_x, translate_y)
 
         for node in self.node.iter(SVG_PATH_TAG):

--- a/lib/svg/__init__.py
+++ b/lib/svg/__init__.py
@@ -1,3 +1,4 @@
 from .svg import color_block_to_point_lists, render_stitch_plan
 from .units import *
 from .path import apply_transforms, get_node_transform, get_correction_transform, line_strings_to_csp, point_lists_to_csp
+from .guides import get_guides

--- a/lib/svg/guides.py
+++ b/lib/svg/guides.py
@@ -1,0 +1,39 @@
+from .tags import SODIPODI_NAMEDVIEW, SODIPODI_GUIDE, INKSCAPE_LABEL
+from .units import get_doc_size, get_viewbox_transform
+from ..utils import string_to_floats, Point, cache
+
+class InkscapeGuide(object):
+    def __init__(self, node):
+        self.node = node
+        self.svg = node.getroottree().getroot()
+
+        self._parse()
+
+    def _parse(self):
+        self.label = self.node.get(INKSCAPE_LABEL, "")
+
+        doc_size = list(get_doc_size(self.svg))
+
+        # convert the size from viewbox-relative to real-world pixels
+        viewbox_transform = get_viewbox_transform(svg)
+        simpletransform.applyTransformToPoint(simpletransform.invertTransform(viewbox_transform), doc_size)
+
+        self.position = Point(*string_to_floats(self.node.get('position')))
+
+        # inkscape's Y axis is reversed from SVG's, and the guide is in inkscape coordinates
+        self.position.y = doc_size[1] - self.position.y
+
+        # This one baffles me.  I think inkscape might have gotten the order of
+        # their vector wrong?
+        parts = string_to_floats(self.node.get('orientation'))
+        self.direction = Point(parts[1], parts[0])
+
+@cache
+def get_guides(svg):
+    """Find all Inkscape guides and return as InkscapeGuide instances."""
+
+    namedview = svg.find(SODIPODI_NAMEDVIEW)
+    if namedview is None:
+        return []
+
+    return [InkscapeGuide(node) for node in namedview.findall(SODIPODI_GUIDE)]

--- a/lib/svg/guides.py
+++ b/lib/svg/guides.py
@@ -1,6 +1,9 @@
+import simpletransform
+
+from ..utils import string_to_floats, Point, cache
 from .tags import SODIPODI_NAMEDVIEW, SODIPODI_GUIDE, INKSCAPE_LABEL
 from .units import get_doc_size, get_viewbox_transform
-from ..utils import string_to_floats, Point, cache
+
 
 class InkscapeGuide(object):
     def __init__(self, node):
@@ -15,7 +18,7 @@ class InkscapeGuide(object):
         doc_size = list(get_doc_size(self.svg))
 
         # convert the size from viewbox-relative to real-world pixels
-        viewbox_transform = get_viewbox_transform(svg)
+        viewbox_transform = get_viewbox_transform(self.svg)
         simpletransform.applyTransformToPoint(simpletransform.invertTransform(viewbox_transform), doc_size)
 
         self.position = Point(*string_to_floats(self.node.get('position')))
@@ -27,6 +30,7 @@ class InkscapeGuide(object):
         # their vector wrong?
         parts = string_to_floats(self.node.get('orientation'))
         self.direction = Point(parts[1], parts[0])
+
 
 @cache
 def get_guides(svg):

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -14,5 +14,7 @@ CONNECTION_START = inkex.addNS('connection-start', 'inkscape')
 CONNECTION_END = inkex.addNS('connection-end', 'inkscape')
 CONNECTOR_TYPE = inkex.addNS('connector-type', 'inkscape')
 XLINK_HREF = inkex.addNS('href', 'xlink')
+SODIPODI_NAMEDVIEW = inkex.addNS('namedview', 'sodipodi')
+SODIPODI_GUIDE = inkex.addNS('guide', 'sodipodi')
 
 EMBROIDERABLE_TAGS = (SVG_PATH_TAG, SVG_POLYLINE_TAG)

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -3,3 +3,4 @@ from cache import cache
 from io import *
 from inkscape import *
 from paths import *
+from string import *

--- a/lib/utils/string.py
+++ b/lib/utils/string.py
@@ -1,0 +1,5 @@
+def string_to_floats(string, delimiter=","):
+    """Convert a string of delimiter-separated floats into a list of floats."""
+
+    floats = string.split(delimiter)
+    return [float(num) for num in floats]

--- a/templates/lettering.inx
+++ b/templates/lettering.inx
@@ -4,7 +4,7 @@
     <id>org.inkstitch.lettering.{{ locale }}</id>
     <dependency type="executable" location="extensions">inkstitch.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
-    <param name="collapse_len_mm" type="string" _gui-text="{% trans %}Text{% endtrans %}"></param>
+    <param name="text" type="string" _gui-text="{% trans %}Text{% endtrans %}"></param>
     <param name="extension" type="string" gui-hidden="true">lettering</param>
     <effect>
         <object-type>all</object-type>

--- a/templates/lettering.inx
+++ b/templates/lettering.inx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Lettering{% endtrans %}</name>
+    <id>org.inkstitch.lettering.{{ locale }}</id>
+    <dependency type="executable" location="extensions">inkstitch.py</dependency>
+    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <param name="collapse_len_mm" type="string" _gui-text="{% trans %}Text{% endtrans %}"></param>
+    <param name="extension" type="string" gui-hidden="true">lettering</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                {# L10N This is used for the submenu under Extensions -> Ink/Stitch.  Translate this to your language's word for its language, e.g. "Español" for the spanish translation. #}
+                <submenu name="{% trans %}English{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        <command reldir="extensions" interpreter="python">inkstitch.py</command>
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Hot on the heels of auto-satin, here's an extension to do basic lettering! (#142)

Here's what it can do:
  * one font (my "small font" from https://github.com/inkstitch/embroidery-fonts)
  * can render snippets of text
  * applies auto-satin to each line
  * settings can be specified for a font such as letter spacing, word spacing, line spacing, etc
  * can apply special kerning to specific pairs of letters
    * currently "small font" only has one configured for "wo" because that was in my test string ("hello world")
  * can show a placeholder character if a requested character is not defined in the font

A font is a directory containing a set of SVG files, an optional LICENSE, and an optional `font.json` containing the font's settings.  Up to four SVG files can be specified:
  * left-to-right sewing
  * right-to-left sewing
  * top-to-bottom sewing (vertical text)
  * bottom-to-top sewing

I had to make individual files for each direction because the auto-satin uses "preserve order" mode.  That's necessary to ensure that letters like "t" are sewn properly (crossbar last).  If you don't include all four SVG files in a font, Ink/Stitch will just use the left-to-right one (or a default one you specify in `font.json`).

Font files are created using the Typography Extensions bundled with Inkscape.  Ink/Stitch will obey the baseline you specify, ensuring that all characters align on the same baseline when rendering text.  Fonts can contain satins, running stitch, fills, whatever you like.  This means it's possible to make a big applique or satin-plus-fill font, for example.

Since this is a first version, there's a lot that's yet to come with regard to the user interface.  Right now, for example, there's no option for changing the text direction.  My plan is to make a two-window UI similar to Params, with a text entry box and options on the left and an immediate preview in a simulator window on the right.  It's gonna be awesome. :D
