### PR TITLE
Fix print metadata

### DIFF
--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -365,7 +365,6 @@ class Print(InkstitchExtension):
                 'num_trims': stitch_plan.num_trims,
                 'dimensions': stitch_plan.dimensions_mm,
                 'num_stitches': stitch_plan.num_stitches,
-                'estimated_time': '',  # TODO
                 'estimated_thread': '',  # TODO
             },
             svg_overview=overview_svg,

--- a/print/templates/operator_detailedview.html
+++ b/print/templates/operator_detailedview.html
@@ -18,9 +18,7 @@
             <span>##</span>
           </p>
           <p class="operator-svg operator-preview">
-            <svg>
             {{ svg_overview|replace("<li>", "")|replace("</li>", "")|safe }}
-            </svg>
           </p>
           <p>
             <span>{{ _('Unique Colors') }}: {{ job.num_colors }}</span>

--- a/print/templates/operator_detailedview.html
+++ b/print/templates/operator_detailedview.html
@@ -18,7 +18,9 @@
             <span>##</span>
           </p>
           <p class="operator-svg operator-preview">
-            {{ svg_overview|safe }}
+            <svg>
+            {{ svg_overview|replace("<li>", "")|replace("</li>", "")|safe }}
+            </svg>
           </p>
           <p>
             <span>{{ _('Unique Colors') }}: {{ job.num_colors }}</span>
@@ -51,7 +53,7 @@
               </svg>
             </p>
             <p class="operator-svg operator-preview">
-                {{ color_block.svg_preview|safe }}
+                {{ color_block.svg_preview|replace("<li>", "")|replace("</li>", "")|safe }}
             </p>
             <p>
               <span data-field-name="color-{{ color_block.color.hex_digits }}" contenteditable="true" data-placeholder="{{ _('Enter thread name...') }}">{{ color_block.color.name }}</span>

--- a/print/templates/operator_overview.html
+++ b/print/templates/operator_overview.html
@@ -26,7 +26,7 @@
         </header>
         <main>
             <figure class="inksimulation operator" data-field-name="operator-overview-transform" style="height: 210mm;" title="{{ _('Ctrl + Scroll to Zoom') }}">
-                {{ svg_overview|safe }}
+                {{ svg_overview|replace("<li>", "")|replace("</li>", "")|safe }}
                 {% include 'ui_svg_action_buttons.html' %}
             </figure>
         </main>

--- a/print/templates/print_detail.html
+++ b/print/templates/print_detail.html
@@ -16,7 +16,7 @@
         </header>
         <main>
             <figure class="inksimulation" data-field-name="client-detail-transform-block{{ loop.index0 }}" title="{{ _('Ctrl + Scroll to Zoom') }}">
-                {{color_block.svg_preview|safe}}
+                {{color_block.svg_preview|replace("<li>", "")|replace("</li>", "")|safe}}
                 {% include 'ui_svg_action_buttons.html' %}
             </figure>
             <div class="color-palette detailed">

--- a/print/templates/print_overview.html
+++ b/print/templates/print_overview.html
@@ -26,7 +26,7 @@
         </header>
         <main class="client-overview-main">
             <figure class="inksimulation" data-field-name="client-overview-transform" title="{{ _('Ctrl + Scroll to Zoom') }}">
-                {{ svg_overview|safe }}
+                {{ svg_overview|replace("<li>", "")|replace("</li>", "")|safe }}
                 {% include 'ui_svg_action_buttons.html' %}
             </figure>
 

--- a/print/templates/ui.html
+++ b/print/templates/ui.html
@@ -112,12 +112,12 @@
         </fieldset>
         <fieldset>
           <legend>{{ _('Display Time On') }}</legend>
-          <p>
+          <div>
             <p><input type="checkbox" class="time-display" id="time-clo" data-field-name="time-clo" /><label for="time-clo">{{ _('Client Overview') }}</label></p>
             <p><input type="checkbox" class="time-display" id="time-cld" data-field-name="time-cld" /><label for="time-cld">{{ _('Client Detailed View') }}</label></p>
             <p><input type="checkbox" class="time-display" id="time-opo" data-field-name="time-opo" CHECKED /><label for="time-opo">{{ _('Operator Overview') }}</label></p>
             <p><input type="checkbox" class="time-display" id="time-opd" data-field-name="time-opd" CHECKED /><label for="time-opd">{{ _('Operator Detailed View') }}</label></p>
-          </p>
+          </div>
         </fieldset>
         <button class="save-settings" title="{{ _('Includes page setup, estimated time and also the branding.') }}">{{ _("Save as defaults") }}</button>
       </fieldset>


### PR DESCRIPTION
This should fix #368 

The problem were the keywords in the documents metadata of the Inkscape file. This would create an li-tag to the svg output. Browsers would misinterpreted it as and HTML list item. They internally close the svg and display the keywords as a list right after.

The solution (for now?) is to simply remove every li-tag from the svg within the print output, while leaving the keywords alive. This might not be the best way to prevent this issue from happening. But it was the easiest way for me at this point.

@wwderw does it solve your issue?