### PR TITLE
update simulator stitch box

### DIFF
--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -211,6 +211,7 @@ class ControlPanel(wx.Panel):
 
         if stitch is None:
             stitch = 1
+            self.stitchBox.SetValue(1)
 
         self.slider.SetValue(stitch)
 

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -210,7 +210,7 @@ class ControlPanel(wx.Panel):
         self.parent.SetFocus()
 
         if stitch is None:
-            event.Skip()
+            stitch = 1
 
         self.slider.SetValue(stitch)
 


### PR DESCRIPTION
When I was creating the tutorial videos I tried to use the stitch box in the simulator.

It turned out, that it wasn't too easy to replace a number.
Stitch count couldn't go to 0 (which makes sense, but it made it hard to simply remove the number in order to add a new one).

The stitch box now should now:
* stop the animation when focused
* update the stitch count only after the stitch box loses focus

I am especially curious if it works as expected on windows and mac.
Try to unfocus either with:
* enter/return
* click in the control panel area
The animation should update then to the stitch number which has been entered.