### PR TITLE
simulate needle penetration points

### DIFF
--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -69,6 +69,7 @@ class ControlPanel(wx.Panel):
         self.restartBtn.Bind(wx.EVT_BUTTON, self.animation_restart)
         self.restartBtn.SetToolTip(_('Restart (R)'))
         self.nppBtn = wx.ToggleButton(self, -1, label=_('O'))
+        self.nppBtn.Bind(wx.EVT_TOGGLEBUTTON, self.toggle_npp)
         self.nppBtn.SetToolTip(_('Display needle penetration point (O)'))
         self.quitBtn = wx.Button(self, -1, label=_('Quit'))
         self.quitBtn.Bind(wx.EVT_BUTTON, self.animation_quit)
@@ -119,7 +120,7 @@ class ControlPanel(wx.Panel):
             (wx.ACCEL_NORMAL, wx.WXK_SUBTRACT, self.animation_one_stitch_backward),
             (wx.ACCEL_NORMAL, wx.WXK_NUMPAD_SUBTRACT, self.animation_one_stitch_backward),
             (wx.ACCEL_NORMAL, ord('r'), self.animation_restart),
-            (wx.ACCEL_NORMAL, ord('o'), self.toggle_npp),
+            (wx.ACCEL_NORMAL, ord('o'), self.on_toggle_npp_shortcut),
             (wx.ACCEL_NORMAL, ord('p'), self.on_pause_start_button),
             (wx.ACCEL_NORMAL, wx.WXK_SPACE, self.on_pause_start_button),
             (wx.ACCEL_NORMAL, ord('q'), self.animation_quit)]
@@ -245,8 +246,14 @@ class ControlPanel(wx.Panel):
     def animation_restart(self, event):
         self.drawing_panel.restart()
 
-    def toggle_npp(self, event):
+    def on_toggle_npp_shortcut(self, event):
         self.nppBtn.SetValue(not self.nppBtn.GetValue())
+        self.toggle_npp(event)
+
+    def toggle_npp(self, event):
+        if self.pauseBtn.GetLabel() == _('Start'):
+            stitch = self.stitchBox.GetValue()
+            self.drawing_panel.set_current_stitch(stitch)
 
 
 class DrawingPanel(wx.Panel):

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -336,30 +336,30 @@ class DrawingPanel(wx.Panel):
             return
 
         dc = wx.PaintDC(self)
-        self.canvas = wx.GraphicsContext.Create(dc)
+        canvas = wx.GraphicsContext.Create(dc)
 
-        transform = self.canvas.GetTransform()
+        transform = canvas.GetTransform()
         transform.Translate(*self.pan)
         transform.Scale(self.zoom / self.PIXEL_DENSITY, self.zoom / self.PIXEL_DENSITY)
-        self.canvas.SetTransform(transform)
+        canvas.SetTransform(transform)
 
         stitch = 0
         last_stitch = None
 
         start = time.time()
         for pen, stitches in izip(self.pens, self.stitch_blocks):
-            self.canvas.SetPen(pen)
+            canvas.SetPen(pen)
             if stitch + len(stitches) < self.current_stitch:
                 stitch += len(stitches)
                 if len(stitches) > 1:
-                    self.canvas.DrawLines(stitches)
-                    self.draw_needle_penetration_points(pen, stitches)
+                    canvas.DrawLines(stitches)
+                    self.draw_needle_penetration_points(canvas, pen, stitches)
                 last_stitch = stitches[-1]
             else:
                 stitches = stitches[:self.current_stitch - stitch]
                 if len(stitches) > 1:
-                    self.canvas.DrawLines(stitches)
-                    self.draw_needle_penetration_points(pen, stitches)
+                    canvas.DrawLines(stitches)
+                    self.draw_needle_penetration_points(canvas, pen, stitches)
                 last_stitch = stitches[-1]
                 break
         self.last_frame_duration = time.time() - start
@@ -368,17 +368,17 @@ class DrawingPanel(wx.Panel):
             x = last_stitch[0]
             y = last_stitch[1]
             x, y = transform.TransformPoint(float(x), float(y))
-            self.canvas.SetTransform(self.canvas.CreateMatrix())
+            canvas.SetTransform(canvas.CreateMatrix())
             crosshair_radius = 10
-            self.canvas.SetPen(self.black_pen)
-            self.canvas.DrawLines(((x - crosshair_radius, y), (x + crosshair_radius, y)))
-            self.canvas.DrawLines(((x, y - crosshair_radius), (x, y + crosshair_radius)))
+            canvas.SetPen(self.black_pen)
+            canvas.DrawLines(((x - crosshair_radius, y), (x + crosshair_radius, y)))
+            canvas.DrawLines(((x, y - crosshair_radius), (x, y + crosshair_radius)))
 
-    def draw_needle_penetration_points(self, pen, stitches):
+    def draw_needle_penetration_points(self, canvas, pen, stitches):
         if self.control_panel.nppBtn.GetValue():
             npp_pen = wx.Pen(pen.GetColour(), width=int(0.3 * PIXELS_PER_MM * self.PIXEL_DENSITY))
-            self.canvas.SetPen(npp_pen)
-            self.canvas.StrokeLineSegments(stitches, stitches)
+            canvas.SetPen(npp_pen)
+            canvas.StrokeLineSegments(stitches, stitches)
 
     def clear(self):
         dc = wx.ClientDC(self)

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -46,9 +46,6 @@ class ControlPanel(wx.Panel):
         self.speed = 1
         self.direction = 1
 
-        # needle penetration point
-        self.display_npp = False
-
         # Widgets
         self.btnMinus = wx.Button(self, -1, label='-')
         self.btnMinus.Bind(wx.EVT_BUTTON, self.animation_slow_down)
@@ -72,7 +69,6 @@ class ControlPanel(wx.Panel):
         self.restartBtn.Bind(wx.EVT_BUTTON, self.animation_restart)
         self.restartBtn.SetToolTip(_('Restart (R)'))
         self.nppBtn = wx.ToggleButton(self, -1, label=_('O'))
-        self.nppBtn.Bind(wx.EVT_TOGGLEBUTTON, self.toggle_npp)
         self.nppBtn.SetToolTip(_('Display needle penetration point (O)'))
         self.quitBtn = wx.Button(self, -1, label=_('Quit'))
         self.quitBtn.Bind(wx.EVT_BUTTON, self.animation_quit)
@@ -250,7 +246,7 @@ class ControlPanel(wx.Panel):
         self.drawing_panel.restart()
 
     def toggle_npp(self, event):
-        self.display_npp = not self.display_npp
+        self.nppBtn.SetValue(not self.nppBtn.GetValue())
 
 
 class DrawingPanel(wx.Panel):
@@ -379,9 +375,9 @@ class DrawingPanel(wx.Panel):
             canvas.DrawLines(((x, y - crosshair_radius), (x, y + crosshair_radius)))
 
     def draw_needle_penetration_points(self, canvas, stitches):
-        if self.control_panel.display_npp:
+        if self.control_panel.nppBtn.GetValue():
             for npp in stitches:
-                canvas.DrawRoundedRectangle(npp[0]-2.5, npp[1]-2.5, 5, 5, 2)
+                canvas.DrawRoundedRectangle(npp[0]-2.5, npp[1]-2.5, 5, 5, 2.5)
 
     def clear(self):
         dc = wx.ClientDC(self)


### PR DESCRIPTION
This PR enables the simulator to optionally display needle penetration points. The shortcut would be `o` - derived from the visual perception.

I believe this is helpful especially for fill stitching, so you can actually visually see the stitch length setting without having to use the print pdf function.