### PR TITLE
added tips for ubuntu 16.04

### DIFF
--- a/collections/_developers/en/002-002-manual-setup.md
+++ b/collections/_developers/en/002-002-manual-setup.md
@@ -21,7 +21,10 @@ A manual setup will allow you to edit the code while running the extension.
     pip install -r requirements.txt
     ```
 
-    **Info:** You might need to remove wxPython and [install](https://wiki.wxpython.org/How%20to%20install%20wxPython) a platform specific package (e.g. Debian uses `python-wxgtk3.0`).
+    **Info:** You might need to remove wxPython and [install](https://wiki.wxpython.org/How%20to%20install%20wxPython) a platform specific package (e.g. Debian uses `python-wxgtk3.0` Ubuntu 16.04 use pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython ).
+    {: .notice--info }
+    
+    **Info:** If you have multiple versions of python installed you may need to use pip2
     {: .notice--info }
 
 3. Prepare INX files

--- a/collections/_developers/en/002-002-manual-setup.md
+++ b/collections/_developers/en/002-002-manual-setup.md
@@ -1,7 +1,7 @@
 ---
 title: "Manual Setup"
 permalink: /developers/inkstitch/manual-setup/
-last_modified_at: 2018-10-10
+last_modified_at: 2019-04-07
 toc: false
 ---
 A manual setup will allow you to edit the code while running the extension.


### PR DESCRIPTION
pip and wxpython can be issues on ubuntu 16.04. Latest wxpython in the repos is 3.03. If you have newer python version installed the latest pip will install for that instead. Use pip2 to install for python 2.7.