### PR TITLE
adding minimum version requirement on jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ shapely
 lxml
 appdirs
 numpy<1.16.0
-jinja2
+jinja2>2.9
 requests
 colormath
 stringcase


### PR DESCRIPTION
This is a small change because my version of jinja2 was ancient