### PR TITLE
Add default path for inkex.py on macOS

### DIFF
--- a/bin/generate-inx-files
+++ b/bin/generate-inx-files
@@ -11,6 +11,8 @@ sys.path.append(parent_dir)
 # try find add inkex.py et al. as well
 sys.path.append(os.path.join(parent_dir, "inkscape", "share", "extensions"))
 sys.path.append(os.path.join("/usr/share/inkscape/extensions"))
+# default inkex.py location on macOS
+sys.path.append("/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions/")
 
 from lib.inx import generate_inx_files
 


### PR DESCRIPTION
This fixes an issue I encountered developing the extension on macOS: https://github.com/inkstitch/inkstitch/issues/434

This is not necessarily the correct location of Inkscape.app. However, it is the default location and is likely to be correct for most users.