### PR TITLE
Separate locales into different releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ ARCH:=$(shell uname -m)
 
 dist: distclean locales inx
 	bin/build-dist $(EXTENSIONS)
-	cp inx/*.inx dist
 	cp -a images/examples dist/inkstitch
 	cp -a palettes dist/inkstitch
 	cp -a symbols dist/inkstitch
@@ -15,11 +14,16 @@ dist: distclean locales inx
 	cp -a icons dist/inkstitch/bin
 	cp -a locales dist/inkstitch/bin
 	cp -a print dist/inkstitch/bin
-	if [ "$$BUILD" = "windows" ]; then \
-		cd dist; zip -r ../inkstitch-$(VERSION)-win32.zip *; \
-	else \
-		cd dist; tar zcf ../inkstitch-$(VERSION)-$(OS)-$(ARCH).tar.gz *; \
-	fi
+	for d in inx/*; do \
+		lang=$${d%.*}; \
+		lang=$${lang#*/}; \
+		cp $$d/*.inx dist; \
+		if [ "$$BUILD" = "windows" ]; then \
+			cd dist; zip -r ../inkstitch-$(VERSION)-win32-$$lang.zip *; cd ..; \
+		else \
+			cd dist; tar zcf ../inkstitch-$(VERSION)-$(OS)-$(ARCH)-$$lang.tar.gz *; cd ..; \
+		fi; \
+	done
 
 distclean:
 	rm -rf build dist inx locales *.spec *.tar.gz *.zip

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import gettext
 from os.path import dirname
@@ -28,8 +29,16 @@ def build_environment():
 
 
 def write_inx_file(name, contents):
-    inx_file_name = "inkstitch_%s_%s.inx" % (name, current_locale)
-    with open(os.path.join(inx_path, inx_file_name), 'w') as inx_file:
+    inx_locale_dir = os.path.join(inx_path, current_locale)
+
+    try:
+        os.makedirs(inx_locale_dir)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+    inx_file_name = "inkstitch_%s.inx" % name
+    with open(os.path.join(inx_locale_dir, inx_file_name), 'w') as inx_file:
         print >> inx_file, contents.encode("utf-8")
 
 

--- a/templates/auto_satin.inx
+++ b/templates/auto_satin.inx
@@ -11,9 +11,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Satin Tools{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/convert_to_satin.inx
+++ b/templates/convert_to_satin.inx
@@ -9,9 +9,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Satin Tools{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/cut_satin.inx
+++ b/templates/cut_satin.inx
@@ -9,9 +9,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Satin Tools{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/embroider.inx
+++ b/templates/embroider.inx
@@ -19,10 +19,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                {# L10N This is used for the submenu under Extensions -> Ink/Stitch.  Translate this to your language's word for its language, e.g. "Español" for the spanish translation. #}
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>

--- a/templates/flip.inx
+++ b/templates/flip.inx
@@ -9,9 +9,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Satin Tools{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/global_commands.inx
+++ b/templates/global_commands.inx
@@ -13,10 +13,8 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    {# L10N Inkscape submenu under Extensions -> Ink/Stitch #}
-                    <submenu name="{% trans %}Commands{% endtrans %}" />
-                </submenu>
+                {# L10N Inkscape submenu under Extensions -> Ink/Stitch #}
+                <submenu name="{% trans %}Commands{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/install.inx
+++ b/templates/install.inx
@@ -8,9 +8,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>

--- a/templates/layer_commands.inx
+++ b/templates/layer_commands.inx
@@ -13,9 +13,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Commands{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Commands{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/lettering.inx
+++ b/templates/lettering.inx
@@ -8,10 +8,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                {# L10N This is used for the submenu under Extensions -> Ink/Stitch.  Translate this to your language's word for its language, e.g. "Español" for the spanish translation. #}
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>

--- a/templates/object_commands.inx
+++ b/templates/object_commands.inx
@@ -12,9 +12,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}">
-                    <submenu name="{% trans %}Commands{% endtrans %}" />
-                </submenu>
+                <submenu name="{% trans %}Commands{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/params.inx
+++ b/templates/params.inx
@@ -8,9 +8,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>

--- a/templates/print.inx
+++ b/templates/print.inx
@@ -8,9 +8,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>

--- a/templates/simulate.inx
+++ b/templates/simulate.inx
@@ -8,9 +8,7 @@
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}English{% endtrans %}" />
-            </submenu>
+            <submenu name="Ink/Stitch" />
         </effects-menu>
     </effect>
     <script>


### PR DESCRIPTION
This changes the menus so that the languages does not need to be selected (#433). The locale is selected when the extension is downloaded.

<img width="830" alt="Screen Shot 2019-04-16 at 8 28 31 PM" src="https://user-images.githubusercontent.com/80069/56252548-491c8200-6086-11e9-8bc1-cfa52a7aaaa1.png">

The website will be updated in a separate PR.

I believe this makes `msgid "English"` obsolete, `grep -r English templates/` returns nothing.