### PR TITLE
Add instructions for changing Inkscape Python interpreter

### DIFF
--- a/collections/_developers/en/002-002-manual-setup.md
+++ b/collections/_developers/en/002-002-manual-setup.md
@@ -50,6 +50,12 @@ A manual setup will allow you to edit the code while running the extension.
 
 5. Run Inkscape.
 
+    **Info:** If Ink/Stitch returns `ImportError: No module named shapely`, then it is likely the version of Python used by Inkscape and the version you installed the Python dependencies for above are different. Configure the Inkscape Python executable by editing `preferences.xml`. The location of `preferences.xml` can be found in Inkscape under Edit > Preferences > System > User extensions. You must *close Inkscape before editing this file*, it is over-written when Inkscape closes.<br/><br/>
+    In `preferences.xml` update `<group id="extensions" />` to include the correct Python interpreter. For example,<br/><br/>
+    `<group id="extensions" python-interpreter="/usr/local/bin/python2" />`<br/><br/>
+    where, `/usr/local/bin/python2` is the value returned by `which python2`.
+    {: .notice--info }
 
-**Info:** Changes to the Python code take effect the next time the extension is run. Changes to the extension description files (*.inx) take effect the next time Inkscape is restarted.
+
+**Info:** Changes to the Python code take effect the next time the extension is run. Changes to the extension description files (`*.inx`) take effect the next time Inkscape is restarted.
 {: .notice--info }

--- a/collections/_developers/en/002-002-manual-setup.md
+++ b/collections/_developers/en/002-002-manual-setup.md
@@ -1,7 +1,7 @@
 ---
 title: "Manual Setup"
 permalink: /developers/inkstitch/manual-setup/
-last_modified_at: 2019-04-18
+last_modified_at: 2019-04-21
 toc: false
 ---
 A manual setup will allow you to edit the code while running the extension.
@@ -18,7 +18,7 @@ A manual setup will allow you to edit the code while running the extension.
 
     A few python modules are needed. In some cases this extension uses features that aren’t available in the versions of the modules pre-packaged in distributions, so we recommend installing them directly with pip:
     ```
-    pip install -r requirements.txt
+    pip2 install -r requirements.txt
     ```
 
     **Info:** You might need to remove wxPython and [install](https://wiki.wxpython.org/How%20to%20install%20wxPython) a platform specific package:<br />
@@ -26,7 +26,7 @@ A manual setup will allow you to edit the code while running the extension.
        ⚫ Ubuntu 16.04: `pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython`
     {: .notice--info }
     
-    **Info:** If you have multiple versions of python installed you may need to use **pip2**
+    **Info:** If you only have Python 2 installed you may be able to use `pip` instead of `pip2`.
     {: .notice--info }
 
 3. Prepare INX files


### PR DESCRIPTION
These instructions were needed for my macOS setup (#434). However, they could also be relevant to other OSes.

Default to using `pip2`, Python 2 is nearing EOL and it is unlikely to be the default on most systems.