### PR TITLE
add grbl laser options for g-code output

### DIFF
--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -46,7 +46,7 @@ class Output(InkstitchExtension):
             return
 
         patches = self.elements_to_patches(self.elements)
-        stitch_plan = patches_to_stitch_plan(patches)
+        stitch_plan = patches_to_stitch_plan(patches, disable_ties=self.settings.get('laser_mode', False))
 
         temp_file = tempfile.NamedTemporaryFile(suffix=".%s" % self.file_extension, delete=False)
 

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -14,10 +14,6 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM, disable_ti
     """
 
     stitch_plan = StitchPlan()
-
-    if not patches:
-        return stitch_plan
-
     color_block = stitch_plan.new_color_block(color=patches[0].color)
 
     for patch in patches:

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -1,11 +1,11 @@
+from ..svg import PIXELS_PER_MM
+from ..threads import ThreadColor
+from ..utils.geometry import Point
 from .stitch import Stitch
 from .ties import add_ties
-from ..svg import PIXELS_PER_MM
-from ..utils.geometry import Point
-from ..threads import ThreadColor
 
 
-def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
+def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM, disable_ties=False):
     """Convert a collection of inkstitch.element.Patch objects to a StitchPlan.
 
     * applies instructions embedded in the Patch such as trim_after and stop_after
@@ -56,7 +56,9 @@ def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
         del stitch_plan.color_blocks[-1]
 
     stitch_plan.filter_duplicate_stitches()
-    stitch_plan.add_ties()
+
+    if not disable_ties:
+        stitch_plan.add_ties()
 
     return stitch_plan
 

--- a/templates/output_params_txt.xml
+++ b/templates/output_params_txt.xml
@@ -1,5 +1,7 @@
     {# these parameters are for g-code files (*.txt) #}
     <param name="laser_mode" type="boolean" gui-text="{{ _("laser mode") }}" gui-description="{{ _("Laser mode (generate g-code for grbl laser mode)") }}">false</param>
+    <param name="dynamic_laser_power" type="boolean" gui-text="{{ _("dynamic laser power") }}" gui-description="{{ _("Use Grbl's M4 dynamic laser power mode.  Ensures consistent laser cutting power regardless of motor speed.  Only for PWM-capable lasers.") }}" min="0.0" max="5.0">true</param>
+    <param name="laser_warm_up_time" type="float" gui-text="{{ _("laser warm-up time") }}" gui-description="{{ _("When turning on the laser, wait this many seconds for laser to warm up (G4 command)") }}">0.0</param>
     <param name="flip_x" type="boolean" gui-text="{{ _("negate X coordinate values") }}" gui-description="{{ _("Negate x coordinates") }}">false</param>
     <param name="flip_y" type="boolean" gui-text="{{ _("negate Y coordinate values") }}" gui-description="{{ _("Negate y coordinates") }}">false</param>
     <param name="stitch_z_travel" type="float" gui-text="{{ _("Z travel per stitch") }}" gui-description="{{ _("increment z coordinate by this amount per stitch") }}">5.0</param>

--- a/templates/output_params_txt.xml
+++ b/templates/output_params_txt.xml
@@ -1,4 +1,9 @@
     {# these parameters are for g-code files (*.txt) #}
-    <param name="flip_x" type="boolean" gui-description="{{ _("Negate x coordinates") }}">false</param>
-    <param name="flip_y" type="boolean" gui-description="{{ _("Negate y coordinates") }}">false</param>
-    <param name="stitch_z_travel" type="float" gui-description="{{ _("increment z coordinate by this amount per stitch") }}">5.0</param>
+    <param name="laser_mode" type="boolean" gui-text="{{ _("laser mode") }}" gui-description="{{ _("Laser mode (generate g-code for grbl laser mode)") }}">false</param>
+    <param name="flip_x" type="boolean" gui-text="{{ _("negate X coordinate values") }}" gui-description="{{ _("Negate x coordinates") }}">false</param>
+    <param name="flip_y" type="boolean" gui-text="{{ _("negate Y coordinate values") }}" gui-description="{{ _("Negate y coordinates") }}">false</param>
+    <param name="stitch_z_travel" type="float" gui-text="{{ _("Z travel per stitch") }}" gui-description="{{ _("increment z coordinate by this amount per stitch") }}">5.0</param>
+    <param name="spindle_speed" type="int" gui-text="{{ _("spindle speed") }}" gui-description="{{ _("spindle speed (laser power for laser mode, set to -1 to omit)") }}" min="-1" max="1000000000">-1</param>
+    <param name="min_spindle_speed" type="int" gui-text="{{ _("min spindle speed") }}" gui-description="{{ _("minimum spindle speed value (grbl $31 setting)") }}" min="-1" max="1000000000">-1</param>
+    <param name="max_spindle_speed" type="int" gui-text="{{ _("max spindle speed") }}" gui-description="{{ _("minimum spindle speed value (grbl $30 setting)") }}" min="-1" max="1000000000">-1</param>
+    <param name="feed_rate" type="int" gui-description="{{ _("feed rate (in mm/min, set to -1 to omit)")}}" min="-1" max="1000000000">-1</param>


### PR DESCRIPTION
I bought a CNC laser cutter that I plan to use to cut patch shapes out of polyester fabric.  The laser melts the edge, preventing it from fraying when I sew a satin around it.

This PR adds several features that I find useful for generating G-code to drive the laser.  My laser is based on GRBL which comes with a special laser mode that makes this super easy.  The new features are:

* enable grbl laser mode
* disable the Z travel instructions if the Z-travel option is set to 0
* set spindle speed (= laser power in laser mode)
* set min/max spindle speed settings (used as a reference for the spindle speed)
* set feed rate
* disable tie-in and tie-off stitches (which just generate unnecessary moves / extra lasering)
* turn off laser for jumps

I would have loved to just use an existing Inkscape extension for this, but none of the many out there seemed to be targeted at grbl's laser mode.  With these changes, I can use the same file to contain both my embroidery design and the laser cut shape.