### PR TITLE
Make InkStitch run in Inkscape 1.0 alpha

### DIFF
--- a/stub.py
+++ b/stub.py
@@ -48,12 +48,12 @@ if sys.platform == "win32":
     import msvcrt
     msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
-sys.stdout.write(stdout)
+sys.stdout.write(stdout.decode(sys.stdout.encoding))
 sys.stdout.flush()
 
 stderr = stderr.strip()
 if stderr:
-    sys.stderr.write(stderr.strip())
+    sys.stderr.write(stderr.decode(sys.stdout.encoding).strip())
     sys.stderr.flush()
 
 sys.exit(extension.returncode)


### PR DESCRIPTION
I downloaded inkscape 1.0 alpha for MacOS from the inkscape build server and installed inkstitch.

For me it seems to run with python 3. Thus I am getting error messages like `TypeError: write() argument must be str, not bytes` which are fixed by this commit.