### PR TITLE
remove additional jump stitches on import

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -289,6 +289,10 @@ def add_connector(document, symbol, element):
     start_pos = (symbol.get('x'), symbol.get('y'))
     end_pos = element.shape.centroid
 
+    # Make sure the element's XML node has an id so that we can reference it.
+    if element.node.get('id') is None:
+        element.node.set('id', generate_unique_id(document, "object"))
+
     path = inkex.etree.Element(SVG_PATH_TAG,
                                {
                                    "id": generate_unique_id(document, "connector"),

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -1,11 +1,13 @@
 import sys
+
 import shapely.geometry
 
-from .element import param, EmbroideryElement, Patch
 from ..i18n import _
-from ..utils import cache, Point
 from ..stitches import running_stitch, bean_stitch
 from ..svg import parse_length_with_units
+from ..utils import cache, Point
+from .element import param, EmbroideryElement, Patch
+
 
 warned_about_legacy_running_stitch = False
 
@@ -85,7 +87,11 @@ class Stroke(EmbroideryElement):
     @cache
     def shape(self):
         line_strings = [shapely.geometry.LineString(path) for path in self.paths]
-        return shapely.geometry.MultiLineString(line_strings)
+
+        # Using convex_hull here is an important optimization.  Otherwise
+        # complex paths cause operations on the shape to take a long time.
+        # This especially happens when importing machine embroidery files.
+        return shapely.geometry.MultiLineString(line_strings).convex_hull
 
     @property
     @param('manual_stitch',

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -18,8 +18,7 @@ class Input(object):
         color_block = None
 
         for raw_stitches, thread in pattern.get_as_colorblocks():
-            if len(raw_stitches) > 1:
-                color_block = stitch_plan.new_color_block(thread)
+            color_block = stitch_plan.new_color_block(thread)
             trim_after = False
             for x, y, command in raw_stitches:
                 if command == pyembroidery.STITCH:
@@ -29,6 +28,8 @@ class Input(object):
                     color_block.add_stitch(x * PIXELS_PER_MM / 10.0, y * PIXELS_PER_MM / 10.0)
                 if len(color_block) > 0 and command == pyembroidery.TRIM:
                     trim_after = True
+
+        stitch_plan.delete_empty_color_block(color_block)
 
         extents = stitch_plan.extents
         svg = etree.Element("svg", nsmap=inkex.NSS, attrib={

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -18,10 +18,21 @@ class Input(object):
 
         for raw_stitches, thread in pattern.get_as_colorblocks():
             color_block = stitch_plan.new_color_block(thread)
+            trim_after = False
+            jump_counter = 0
             for x, y, command in raw_stitches:
-                # let's ignore commands for now
                 if command == pyembroidery.STITCH:
+                    if trim_after:
+                        color_block.add_stitch(trim=True)
+                        trim_after = False
                     color_block.add_stitch(x * PIXELS_PER_MM / 10.0, y * PIXELS_PER_MM / 10.0)
+                    jump_counter = 0
+                elif len(color_block) > 0:
+                    # some file formats use 3 or more jump stitches in a row to indicate a trim
+                    if command == pyembroidery.JUMP:
+                        jump_counter += 1
+                    if command == pyembroidery.TRIM or jump_counter >=3:
+                        trim_after = True
 
         extents = stitch_plan.extents
         svg = etree.Element("svg", nsmap=inkex.NSS, attrib={

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -18,7 +18,8 @@ class Input(object):
         color_block = None
 
         for raw_stitches, thread in pattern.get_as_colorblocks():
-            color_block = stitch_plan.new_color_block(thread)
+            if len(raw_stitches) > 1:
+                color_block = stitch_plan.new_color_block(thread)
             trim_after = False
             for x, y, command in raw_stitches:
                 if command == pyembroidery.STITCH:

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -31,7 +31,7 @@ class Input(object):
                     # some file formats use 3 or more jump stitches in a row to indicate a trim
                     if command == pyembroidery.JUMP:
                         jump_counter += 1
-                    if command == pyembroidery.TRIM or jump_counter >=3:
+                    if command == pyembroidery.TRIM or jump_counter >= 3:
                         trim_after = True
 
         extents = stitch_plan.extents

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -19,9 +19,9 @@ class Input(object):
         for raw_stitches, thread in pattern.get_as_colorblocks():
             color_block = stitch_plan.new_color_block(thread)
             for x, y, command in raw_stitches:
-                color_block.add_stitch(x * PIXELS_PER_MM / 10.0, y * PIXELS_PER_MM / 10.0,
-                                       jump=(command == pyembroidery.JUMP),
-                                       trim=(command == pyembroidery.TRIM))
+                # let's ignore commands for now
+                if command == pyembroidery.STITCH:
+                    color_block.add_stitch(x * PIXELS_PER_MM / 10.0, y * PIXELS_PER_MM / 10.0)
 
         extents = stitch_plan.extents
         svg = etree.Element("svg", nsmap=inkex.NSS, attrib={

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -13,7 +13,7 @@ class Input(object):
     def affect(self, args):
         embroidery_file = args[0]
         pattern = pyembroidery.read(embroidery_file)
-        pattern = pattern.get_pattern_interpolate_trim(2)
+        pattern = pattern.get_pattern_interpolate_trim(3)
 
         stitch_plan = StitchPlan()
         color_block = None

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -1,11 +1,12 @@
 import os
-from inkex import etree
-import inkex
 import pyembroidery
 
+from inkex import etree
+import inkex
+
+from ..stitch_plan import StitchPlan
 from ..svg import PIXELS_PER_MM, render_stitch_plan
 from ..svg.tags import INKSCAPE_LABEL
-from ..stitch_plan import StitchPlan
 
 
 class Input(object):
@@ -29,7 +30,7 @@ class Input(object):
                 if len(color_block) > 0 and command == pyembroidery.TRIM:
                     trim_after = True
 
-        stitch_plan.delete_empty_color_block(color_block)
+        stitch_plan.delete_empty_color_blocks()
 
         extents = stitch_plan.extents
         svg = etree.Element("svg", nsmap=inkex.NSS, attrib={

--- a/lib/extensions/layer_commands.py
+++ b/lib/extensions/layer_commands.py
@@ -21,7 +21,7 @@ class LayerCommands(CommandsExtension):
         correction_transform = get_correction_transform(self.current_layer, child=True)
 
         for i, command in enumerate(commands):
-            ensure_symbol(command)
+            ensure_symbol(self.document, command)
 
             inkex.etree.SubElement(self.current_layer, SVG_USE_TAG,
                                    {

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -1,8 +1,8 @@
+from ..svg import PIXELS_PER_MM
+from ..threads import ThreadColor
+from ..utils.geometry import Point
 from .stitch import Stitch
 from .ties import add_ties
-from ..svg import PIXELS_PER_MM
-from ..utils.geometry import Point
-from ..threads import ThreadColor
 
 
 def patches_to_stitch_plan(patches, collapse_len=3.0 * PIXELS_PER_MM):
@@ -72,9 +72,13 @@ class StitchPlan(object):
         self.color_blocks.append(color_block)
         return color_block
 
-    def delete_empty_color_block(self, color_block):
-        if len(color_block) == 0:
-            self.color_blocks.remove(color_block)
+    def delete_empty_color_blocks(self):
+        color_blocks = []
+        for color_block in self.color_blocks:
+            if len(color_block) > 0:
+                color_blocks.append(color_block)
+
+        self.color_block = color_blocks
 
     def add_color_block(self, color_block):
         self.color_blocks.append(color_block)

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -72,6 +72,10 @@ class StitchPlan(object):
         self.color_blocks.append(color_block)
         return color_block
 
+    def delete_empty_color_block(self, color_block):
+        if len(color_block) == 0:
+            self.color_blocks.remove(color_block)
+
     def add_color_block(self, color_block):
         self.color_blocks.append(color_block)
 

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -78,7 +78,7 @@ class StitchPlan(object):
             if len(color_block) > 0:
                 color_blocks.append(color_block)
 
-        self.color_block = color_blocks
+        self.color_blocks = color_blocks
 
     def add_color_block(self, color_block):
         self.color_blocks.append(color_block)


### PR DESCRIPTION
This PR is intended to solve (partly) issue #486 

What it does:
It will ignore any commands listed in the input file. But since this was basically the case before this commit, it shouldn't be harmful.

With the previous version Ink/Stitch would not recognize commands such as e.g. color change. So it would use the coordinates as normal stitch instructions, which they were not intended to be in the first place. So it seems to be better to ignore them completely (at least I had much better import results with this method).

It will not have an impact on the creation of color blocks and jump stitches.
My only concern is the trim command. To make it accessible (as far as the command is properly recognized), we would need to insert a visual command into the SVG file for the specific path. @lexelby is it possible to insert a visual (trim) command from here?