### PR TITLE
input: read STOP commands too

### DIFF
--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -31,6 +31,12 @@ class Input(object):
 
         stitch_plan.delete_empty_color_blocks()
 
+        if stitch_plan.last_color_block:
+            if stitch_plan.last_color_block.last_stitch:
+                if stitch_plan.last_color_block.last_stitch.stop:
+                    # ending with a STOP command is redundant, so remove it
+                    del stitch_plan.last_color_block[-1]
+
         extents = stitch_plan.extents
         svg = etree.Element("svg", nsmap=inkex.NSS, attrib={
             "width": str(extents[0] * 2),

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -13,22 +13,21 @@ class Input(object):
     def affect(self, args):
         embroidery_file = args[0]
         pattern = pyembroidery.read(embroidery_file)
-        pattern = pattern.get_pattern_interpolate_trim(3)
 
         stitch_plan = StitchPlan()
         color_block = None
 
         for raw_stitches, thread in pattern.get_as_colorblocks():
             color_block = stitch_plan.new_color_block(thread)
-            trim_after = False
             for x, y, command in raw_stitches:
                 if command == pyembroidery.STITCH:
-                    if trim_after:
-                        color_block.add_stitch(trim=True)
-                        trim_after = False
                     color_block.add_stitch(x * PIXELS_PER_MM / 10.0, y * PIXELS_PER_MM / 10.0)
-                if len(color_block) > 0 and command == pyembroidery.TRIM:
-                    trim_after = True
+                if len(color_block) > 0:
+                    if command == pyembroidery.TRIM:
+                        color_block.add_stitch(trim=True)
+                    elif command == pyembroidery.STOP:
+                        color_block.add_stitch(stop=True)
+                        color_block = stitch_plan.new_color_block(thread)
 
         stitch_plan.delete_empty_color_blocks()
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -98,7 +98,7 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
         settings['explicit_trim'] = False
 
     try:
-        pyembroidery.write(pattern, file_path.encode("UTF-8"), settings)
+        pyembroidery.write(pattern, file_path, settings)
     except IOError as e:
         # L10N low-level file error.  %(error)s is (hopefully?) translated by
         # the user's system automatically.

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -210,6 +210,20 @@ class ColorBlock(object):
         else:
             return False
 
+    @property
+    def trim_after(self):
+        # If there's a STOP, it will be at the end.  We still want to return
+        # True.
+        for stitch in reversed(self.stitches):
+            if stitch.stop or stitch.jump:
+                continue
+            elif stitch.trim:
+                return True
+            else:
+                break
+
+        return False
+
     def filter_duplicate_stitches(self):
         if not self.stitches:
             return

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -169,6 +169,12 @@ class ColorBlock(object):
     def __repr__(self):
         return "ColorBlock(%s, %s)" % (self.color, self.stitches)
 
+    def __getitem__(self, item):
+        return self.stitches[item]
+
+    def __delitem__(self, item):
+        del self.stitches[item]
+
     def has_color(self):
         return self._color is not None
 

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -151,7 +151,7 @@ def color_block_to_point_lists(color_block):
             point_lists[-1].append(stitch.as_tuple())
 
     # filter out empty point lists
-    point_lists = [p for p in point_lists if p]
+    point_lists = [p for p in point_lists if len(p) > 1]
 
     return point_lists
 
@@ -169,9 +169,6 @@ def get_correction_transform(svg):
 
 def color_block_to_realistic_stitches(color_block, svg, destination):
     for point_list in color_block_to_point_lists(color_block):
-        if not point_list:
-            continue
-
         color = color_block.color.visible_on_white.darker.to_hex_str()
         start = point_list[0]
         for point in point_list[1:]:

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -147,7 +147,7 @@ def color_block_to_point_lists(color_block):
                 point_lists.append([])
                 continue
 
-        if not stitch.jump and not stitch.color_change:
+        if not stitch.jump and not stitch.color_change and not stitch.stop:
             point_lists[-1].append(stitch.as_tuple())
 
     # filter out empty point lists
@@ -190,21 +190,23 @@ def color_block_to_realistic_stitches(color_block, svg, destination):
 
 
 def color_block_to_paths(color_block, svg, destination):
+    # If we try to import these above, we get into a mess of circular
+    # imports.
+    from ..commands import add_commands
+    from ..elements.stroke import Stroke
+
     # We could emit just a single path with one subpath per point list, but
     # emitting multiple paths makes it easier for the user to manipulate them.
     first = True
+    path = None
     for point_list in color_block_to_point_lists(color_block):
         if first:
             first = False
         else:
-            # If we try to import these above, we get into a mess of circular
-            # imports.
-            from ..commands import add_commands
-            from ..elements.stroke import Stroke
             add_commands(Stroke(destination[-1]), ["trim"])
 
         color = color_block.color.visible_on_white.to_hex_str()
-        destination.append(inkex.etree.Element(
+        path = inkex.etree.Element(
             SVG_PATH_TAG,
             {'style': simplestyle.formatStyle(
                 {'stroke': color,
@@ -213,7 +215,15 @@ def color_block_to_paths(color_block, svg, destination):
              'd': "M" + " ".join(" ".join(str(coord) for coord in point) for point in point_list),
              'transform': get_correction_transform(svg),
              'embroider_manual_stitch': 'true'
-             }))
+             })
+        destination.append(path)
+
+    if path is not None:
+        if color_block.trim_after:
+            add_commands(Stroke(path), ["trim"])
+
+        if color_block.stop_after:
+            add_commands(Stroke(path), ["stop"])
 
 
 def render_stitch_plan(svg, stitch_plan, realistic=False):


### PR DESCRIPTION
This version pulls in some work I did over in pyembroidery.  JEF and DST now read 3 jumps as a trim automatically, and PES handles STOP as a color change to the same thread color (both on reading and writing).

Even better, now the Input plugin renders STOP codes as visual commands, just like TRIMs.