### PR TITLE
try to fix mac print pdf

### DIFF
--- a/lib/gui/electron.py
+++ b/lib/gui/electron.py
@@ -18,7 +18,7 @@ def open_url(url):
         electron_path = os.path.join(get_bundled_dir("electron"), "inkstitch-gui")
 
         if sys.platform == "darwin":
-            electron_path += ".app/Contents/MacOS/inkstitch-gui"
+            electron_path += ".app"
             command = ["open", "-a", electron_path, "--args", url]
         else:
             command = [electron_path, url]


### PR DESCRIPTION
@ALPHAMOTIF This _might_ fix the print pdf functionality on Mac.  Could you give it a go?  A test version of this branch will show up [here](https://github.com/inkstitch/inkstitch/releases/tag/dev-build-lexelby-fix-mac) when it finishes building.