### PR TITLE
don't show visual commands in print preview

### DIFF
--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -199,7 +199,7 @@ class Print(InkstitchExtension):
 
     def render_svgs(self, stitch_plan, realistic=False):
         svg = deepcopy(self.document).getroot()
-        render_stitch_plan(svg, stitch_plan, realistic)
+        render_stitch_plan(svg, stitch_plan, realistic, visual_commands=False)
 
         self.strip_namespaces(svg)
 


### PR DESCRIPTION
Fixes #556 

@simonkurka This should prevent visual commands from showing up in print preview.  An installable version should show up here as soon as it's done building: https://github.com/inkstitch/inkstitch/releases/tag/dev-build-lexelby-no-commands-in-print

I'd love to hear if it works for you!