### PR TITLE
avoid jumps when not underpathing autofill

### DIFF
--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -156,18 +156,21 @@ def build_fill_stitch_graph(shape, angle, row_spacing, end_row_spacing, starting
     return graph
 
 
-def insert_node(graph, shape, node):
+def insert_node(graph, shape, point):
     """Add node to graph, splitting one of the outline edges"""
 
-    node = nearest_node(graph, tuple(node))
-    point = shgeo.Point(node)
+    point = tuple(point)
+    outline = which_outline(shape, point)
+    projection = project(shape, point, outline)
+    projected_point = list(shape.boundary)[outline].interpolate(projection)
+    node = (projected_point.x, projected_point.y)
 
     edges = []
     for start, end, key, data in graph.edges(keys=True, data=True):
         if key == "outline":
             edges.append(((start, end), data))
 
-    edge, data = min(edges, key=lambda (edge, data): shgeo.LineString(edge).distance(point))
+    edge, data = min(edges, key=lambda (edge, data): shgeo.LineString(edge).distance(projected_point))
 
     graph.remove_edge(*edge, key="outline")
     graph.add_edge(edge[0], node, key="outline", **data)

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -158,7 +158,8 @@ def build_fill_stitch_graph(shape, angle, row_spacing, end_row_spacing, starting
 
 def insert_node(graph, shape, node):
     """Add node to graph, splitting one of the outline edges"""
-    node = tuple(node)
+
+    node = nearest_node(graph, tuple(node))
     point = shgeo.Point(node)
 
     edges = []


### PR DESCRIPTION
This bug was introduced with the underpathing feature for auto-fill.  When you disable underpathing, Ink/Stitch will jump from your starting point directly to the first line of stitching.  This is most obvious when you have a wide underlay on a square.  It can sometimes jump a long distance from the underlay to the first stitch of the top fill.

This fixes that, adding extra points along the border that Ink/Stitch can use to travel when underpathing is disabled.

Also fixes at least some cases of #563, which were a different manifestation of the same kind of problem.