### PR TITLE
handle self-intersecting paths in convert to satin

### DIFF
--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -54,7 +54,7 @@ class ConvertToSatin(InkstitchExtension):
 
             parent.remove(element.node)
 
-    def convert_path_to_satins(self, path, stroke_width, style_args, correction_transform, path_style):
+    def convert_path_to_satins(self, path, stroke_width, style_args, correction_transform, path_style, depth=0):
         try:
             rails, rungs = self.path_to_satin(path, stroke_width, style_args)
             yield self.satin_to_svg_node(rails, rungs, correction_transform, path_style)
@@ -62,11 +62,16 @@ class ConvertToSatin(InkstitchExtension):
             # The path intersects itself.  Split it in two and try doing the halves
             # individually.
 
+            if depth >= 20:
+                # At this point we're slicing the path way too small and still
+                # getting nowhere.  Just give up on this section of the path.
+                return
+
             half = int(len(path) / 2.0)
             halves = [path[:half + 1], path[half:]]
 
             for path in halves:
-                for satin in self.convert_path_to_satins(path, stroke_width, style_args, correction_transform, path_style):
+                for satin in self.convert_path_to_satins(path, stroke_width, style_args, correction_transform, path_style, depth=depth + 1):
                     yield satin
 
     def fix_loop(self, path):

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -164,6 +164,13 @@ class ConvertToSatin(InkstitchExtension):
                 # The dot product of two vectors is |v1| * |v2| * cos(angle).
                 # These are unit vectors, so their magnitudes are 1.
                 cos_angle_between = prev_direction * direction
+
+                # Clamp to the valid range for a cosine.  The above _should_
+                # already be in this range, but floating point inaccuracy can
+                # push it outside the range causing math.acos to throw
+                # ValueError ("math domain error").
+                cos_angle_between = max(-1.0, min(1.0, cos_angle_between))
+
                 angle = abs(math.degrees(math.acos(cos_angle_between)))
 
                 # Use the square of the angle, measured in degrees.


### PR DESCRIPTION
This one's bothered me since I wrote Convert to Satin.  This version automatically detects paths that loop back on themselves and splits them up.  No more telling the user to split up the path, now Ink/Stitch does it for them, splitting as many times as necessary to make it work.

The code isn't brilliant, but it seems to get the job done.  It just repeatedly splits the path in half until it finds pieces that don't self-intersect, then converts each to a satin by itself.  This means that if you convert a path you might end up with multiple satins, but they're in order so it's really not that big a deal.  Maybe in the future we can try to join the satins up, but I don't think it's going to matter all that much to the user.