### PR TITLE
preserveAspectRatio

### DIFF
--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -134,7 +134,7 @@ def get_viewbox_transform(node):
             unit = parse_length_with_units(node.get('width'))[1]
             if float(viewbox[2]) > parse_length_with_units(node.get('width'))[0]:
                 sx = convert_length(viewbox[2] + unit) / float(viewbox[2]) if 'slice' in aspect_ratio else 1.0
-            if float(viewbox[2]) > parse_length_with_units(node.get('width'))[0]:
+            if float(viewbox[3]) > parse_length_with_units(node.get('height'))[0]:
                 sy = convert_length(viewbox[3] + unit) / float(viewbox[3]) if 'slice' in aspect_ratio else 1.0
             sx = sy = max(sx, sy) if 'slice' in aspect_ratio else min(sx, sy)
 

--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -128,13 +128,15 @@ def get_viewbox_transform(node):
         sx = doc_width / float(viewbox[2])
         sy = doc_height / float(viewbox[3])
 
-        # preserve aspect ratio if not set to 'none'
-        # this does not meet the svg specs exactly, since it just checks for 'none' and nothing else
-        # but at least it will respect the default aspect ratio setting (?)
+        # preserve aspect ratio
         aspect_ratio = node.get('preserveAspectRatio', 'xMidYMid meet')
         if aspect_ratio != 'none':
-            sx = min(sx, sy)
-            sy = min(sx, sy)
+            unit = parse_length_with_units(node.get('width'))[1]
+            if float(viewbox[2]) > parse_length_with_units(node.get('width'))[0]:
+                sx = convert_length(viewbox[2] + unit) / float(viewbox[2]) if 'slice' in aspect_ratio else 1.0
+            if float(viewbox[2]) > parse_length_with_units(node.get('width'))[0]:
+                sy = convert_length(viewbox[3] + unit) / float(viewbox[3]) if 'slice' in aspect_ratio else 1.0
+            sx = sy = max(sx, sy) if 'slice' in aspect_ratio else min(sx, sy)
 
         scale_transform = simpletransform.parseTransform("scale(%f, %f)" % (sx, sy))
         transform = simpletransform.composeTransform(transform, scale_transform)

--- a/lib/svg/units.py
+++ b/lib/svg/units.py
@@ -127,6 +127,15 @@ def get_viewbox_transform(node):
     try:
         sx = doc_width / float(viewbox[2])
         sy = doc_height / float(viewbox[3])
+
+        # preserve aspect ratio if not set to 'none'
+        # this does not meet the svg specs exactly, since it just checks for 'none' and nothing else
+        # but at least it will respect the default aspect ratio setting (?)
+        aspect_ratio = node.get('preserveAspectRatio', 'xMidYMid meet')
+        if aspect_ratio != 'none':
+            sx = min(sx, sy)
+            sy = min(sx, sy)
+
         scale_transform = simpletransform.parseTransform("scale(%f, %f)" % (sx, sy))
         transform = simpletransform.composeTransform(transform, scale_transform)
     except ZeroDivisionError:


### PR DESCRIPTION
In issue #601 we wondered why the star was flattened by the viewbox attribute while all other svg viewers would show it differently. The reason is, that we do not check for the `preserveAspectRatio`-attribute and its default value is not 'none' (which we presume in our calculations).

The solution here is not giving it full credit, since there are different methods (meet and slice) and various ways to define the positioning. I am not really up to task to solve the issue, but wanted to bring it to our attention. For now I put something together that seems to follow the default setting.

What do you think?