### PR TITLE
Update simulator command path

### DIFF
--- a/templates/simulator.inx
+++ b/templates/simulator.inx
@@ -12,6 +12,6 @@
         </effects-menu>
     </effect>
     <script>
-        <command reldir="extensions" interpreter="python">inkstitch.py</command>
+        {{ command_tag | safe }}
     </script>
 </inkscape-extension>


### PR DESCRIPTION
Simulator is broken in releases due to an error in the command path. This should fix it.