### PR TITLE
Fix broken link in color_blending.md

### DIFF
--- a/collections/_tutorial/en/color_blending.md
+++ b/collections/_tutorial/en/color_blending.md
@@ -25,7 +25,7 @@ user-level:
 7. While this is not a true blend, in most instances, this type of blend is good enough to achieve the desired end look.
 8. The density values in this example are not set in stone, but just to illustrate the concept.  True settings will depend on the design, fabric it's going on and the size of design.
 
-[Download Sample File](/assets/images/tutorials/samples//assets/images/tutorials/samples/Faux_Fill_Blend.svg){: download="/assets/images/tutorials/samples/Faux_Fill_Blend.svg" }
+[Download Sample File](/assets/images/tutorials/samples/Faux_Fill_Blend.svg){: download="Faux_Fill_Blend.svg" }
 
 ## True Blend
 


### PR DESCRIPTION
The path "/assets/images/tutorials/samples/" was included twice, causing a broken link.
Should be clean, but I haven't tested it beyond devtools. Shouldn't make anything worse at least :)