### PR TITLE
pin shapely to 1.6.3 for pyinstaller compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 backports.functools_lru_cache
 wxPython==4.0.6
 networkx==2.2
-shapely
+shapely==1.6.3
 lxml
 appdirs
 numpy<1.16.0


### PR DESCRIPTION
Mac builds are breaking because the new Shapely 1.7.1 doesn't work with pyinstaller 3.3.1.  We're stuck on 3.3.1 for now because newer versions break mac (at least last I checked, #325).  Once we switch to Electron, we can upgrade pyinstaller, and hopefully Shapely.