### PR TITLE
Prevent Auto Route Satin Without Satin Columns

### DIFF
--- a/lib/extensions/auto_satin.py
+++ b/lib/extensions/auto_satin.py
@@ -57,4 +57,8 @@ class AutoSatin(CommandsExtension):
 
         starting_point = self.get_starting_point()
         ending_point = self.get_ending_point()
-        auto_satin(self.elements, self.options.preserve_order, starting_point, ending_point, self.options.trim)
+
+        # Ignore fills
+        elements = [element for element in self.elements if isinstance(element, SatinColumn) or isinstance(element, Stroke)]
+
+        auto_satin(elements, self.options.preserve_order, starting_point, ending_point, self.options.trim)

--- a/lib/extensions/auto_satin.py
+++ b/lib/extensions/auto_satin.py
@@ -2,6 +2,7 @@ import sys
 
 import inkex
 
+from ..elements import SatinColumn
 from ..i18n import _
 from ..stitches.auto_satin import auto_satin
 from .commands import CommandsExtension
@@ -41,6 +42,11 @@ class AutoSatin(CommandsExtension):
         if not self.selected:
             # L10N auto-route satin columns extension
             inkex.errormsg(_("Please select one or more satin columns."))
+            return False
+
+        satincolumns = [element for element in self.elements if isinstance(element, SatinColumn)]
+        if len(satincolumns) == 0:
+            inkex.errormsg(_("Please select at least one satin column."))
             return False
 
         return True


### PR DESCRIPTION
This prevents a traceback to be shown to the user.