### PR TITLE
Tools for Font Creators

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -22,6 +22,8 @@ from .reorder import Reorder
 from .simulator import Simulator
 from .stitch_plan_preview import StitchPlanPreview
 from .zip import Zip
+from .lettering_generate_json import LetteringGenerateJson
+from .lettering_remove_kerning import LetteringRemoveKerning
 
 __all__ = extensions = [Embroider,
                         StitchPlanPreview,
@@ -39,6 +41,8 @@ __all__ = extensions = [Embroider,
                         CutSatin,
                         AutoSatin,
                         Lettering,
+                        LetteringGenerateJson,
+                        LetteringRemoveKerning,
                         Troubleshoot,
                         RemoveEmbroiderySettings,
                         Cleanup,

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -24,6 +24,7 @@ from .stitch_plan_preview import StitchPlanPreview
 from .zip import Zip
 from .lettering_generate_json import LetteringGenerateJson
 from .lettering_remove_kerning import LetteringRemoveKerning
+from .lettering_custom_font_dir import LetteringCustomFontDir
 
 __all__ = extensions = [Embroider,
                         StitchPlanPreview,
@@ -43,6 +44,7 @@ __all__ = extensions = [Embroider,
                         Lettering,
                         LetteringGenerateJson,
                         LetteringRemoveKerning,
+                        LetteringCustomFontDir,
                         Troubleshoot,
                         RemoveEmbroiderySettings,
                         Cleanup,

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -6,7 +6,6 @@ import appdirs
 import inkex
 import wx
 import wx.adv
-
 from lxml import etree
 
 from ..elements import nodes_to_elements
@@ -18,6 +17,7 @@ from ..svg.tags import (INKSCAPE_LABEL, INKSTITCH_LETTERING, SVG_GROUP_TAG,
                         SVG_PATH_TAG)
 from ..utils import DotDict, cache, get_bundled_dir
 from .commands import CommandsExtension
+from .lettering_custom_font_dir import get_custom_font_dir
 
 
 class LetteringFrame(wx.Frame):
@@ -109,6 +109,7 @@ class LetteringFrame(wx.Frame):
             get_bundled_dir("fonts"),
             os.path.expanduser("~/.inkstitch/fonts"),
             os.path.join(appdirs.user_config_dir('inkstitch'), 'fonts'),
+            get_custom_font_dir()
         }
 
         self.fonts = {}

--- a/lib/extensions/lettering_custom_font_dir.py
+++ b/lib/extensions/lettering_custom_font_dir.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+import appdirs
+from inkex import errormsg
+
+from ..i18n import _
+from .base import InkstitchExtension
+
+
+class LetteringCustomFontDir(InkstitchExtension):
+    '''
+    This extension will create a json file to store a custom directory path for additional user fonts
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-d", "--path", type=str, default="", dest="path")
+
+    def effect(self):
+        path = self.options.path
+        if not os.path.isdir(path):
+            errormsg(_("Please specify the directory of your custom fonts."))
+            return
+
+        data = {'custom_font_dir': '%s' % path}
+
+        try:
+            config_path = appdirs.user_config_dir('inkstitch')
+        except ImportError:
+            config_path = os.path.expanduser('~/.inkstitch')
+        config_path = os.path.join(config_path, 'custom_dirs.json')
+
+        with open(config_path, 'w', encoding="utf8") as font_data:
+            json.dump(data, font_data, indent=4, ensure_ascii=False)
+
+
+def get_custom_font_dir():
+    custom_font_dir_path = os.path.join(appdirs.user_config_dir('inkstitch'), 'custom_dirs.json')
+    try:
+        with open(custom_font_dir_path, 'r') as custom_dirs:
+            custom_dir = json.load(custom_dirs)
+    except (IOError, ValueError):
+        return ""
+    try:
+        return custom_dir['custom_font_dir']
+    except KeyError:
+        pass
+    return ""

--- a/lib/extensions/lettering_generate_json.py
+++ b/lib/extensions/lettering_generate_json.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+
+from inkex import Boolean
+
+from ..i18n import _
+from ..lettering.kerning import FontKerning
+from .base import InkstitchExtension
+
+
+class LetteringGenerateJson(InkstitchExtension):
+    '''
+    This extension helps font creators to generate the json file for the lettering tool
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-n", "--font-name", type=str, default="Font", dest="font_name")
+        self.arg_parser.add_argument("-d", "--font-description", type=str, default="Description", dest="font_description")
+        self.arg_parser.add_argument("-s", "--auto-satin", type=Boolean, default="true", dest="auto_satin")
+        self.arg_parser.add_argument("-r", "--reversible", type=Boolean, default="true", dest="reversible")
+        self.arg_parser.add_argument("-g", "--default-glyph", type=str, default="", dest="default_glyph")
+        self.arg_parser.add_argument("-i", "--min-scale", type=float, default=1, dest="min_scale")
+        self.arg_parser.add_argument("-a", "--max-scale", type=float, default=1, dest="max_scale")
+        self.arg_parser.add_argument("-l", "--leading", type=float, default=5, dest="leading")
+        self.arg_parser.add_argument("-p", "--font-file", type=str, default="", dest="path")
+
+    def effect(self):
+        # file paths
+        path = self.options.path
+        if not os.path.isfile(path):
+            print(_("Please specify a font file."), file=sys.stderr)
+            return
+        output_path = os.path.join(os.path.dirname(path), 'font.json')
+
+        # kerning
+        kerning = FontKerning(path)
+
+        horiz_adv_x = kerning.horiz_adv_x()
+        hkern = kerning.hkern()
+        word_spacing = kerning.word_spacing()
+        letter_spacing = kerning.letter_spacing()
+        # missing_glyph_spacing = kerning.missing_glyph_spacing()
+
+        # collect data
+        data = {'name': self.options.font_name,
+                'description': self.options.font_description,
+                'leading': self.options.leading,
+                'auto_satin': self.options.auto_satin,
+                'reversible': self.options.reversible,
+                'default_glyph': self.options.default_glyph,
+                'min_scale': self.options.min_scale,
+                'max_scale': self.options.max_scale,
+                'horiz_adv_x_default': letter_spacing,
+                'horiz_adv_x_space': word_spacing,
+                'horiz_adv_x': horiz_adv_x,
+                'kerning_pairs': hkern,
+                }
+
+        # write data to font.json into the same directory as the font file
+        with open(output_path, 'w', encoding="utf8") as font_data:
+            json.dump(data, font_data, indent=4, ensure_ascii=False)

--- a/lib/extensions/lettering_remove_kerning.py
+++ b/lib/extensions/lettering_remove_kerning.py
@@ -1,0 +1,30 @@
+import os
+
+from inkex import NSS
+from lxml import etree
+
+from .base import InkstitchExtension
+
+
+class LetteringRemoveKerning(InkstitchExtension):
+    '''
+    This extension helps font creators to generate the json file for the lettering tool
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-p", "--font-files", type=str, default="", dest="paths")
+
+    def effect(self):
+        # file paths
+        paths = self.options.paths.split("|")
+        for path in paths:
+            if not os.path.isfile(path):
+                continue
+            with open(path, 'r') as fontfile:
+                svg = etree.parse(fontfile)
+            xpath = ".//svg:glyph|.//svg:hkern"
+            kerning = svg.xpath(xpath, namespaces=NSS)
+            for k in kerning:
+                k.getparent().remove(k)
+            with open(path, 'w') as fontfile:
+                fontfile.write(etree.tostring(svg).decode('utf-8'))

--- a/lib/lettering/kerning.py
+++ b/lib/lettering/kerning.py
@@ -1,0 +1,57 @@
+from inkex import NSS
+from lxml import etree
+
+
+class FontKerning(object):
+    """
+    This class reads kerning information from an SVG file
+    """
+    def __init__(self, path):
+        with open(path) as svg:
+            self.svg = etree.parse(svg)
+
+    def horiz_adv_x(self):
+        # In XPath 2.0 we could use ".//svg:glyph/(@unicode|@horiz-adv-x)"
+        xpath = ".//svg:glyph[@unicode and @horiz-adv-x]/@*[name()='unicode' or name()='horiz-adv-x']"
+        hax = self.svg.xpath(xpath, namespaces=NSS)
+        if len(hax) == 0:
+            return {}
+        return dict(zip(hax[0::2], [float(x) for x in hax[1::2]]))
+
+    def hkern(self):
+        xpath = ".//svg:hkern[(@u1 or @g1) and (@u1 or @g1) and @k]/@*[contains(name(), '1') or contains(name(), '2') or name()='k']"
+        hkern = self.svg.xpath(xpath, namespaces=NSS)
+        for index, glyph in enumerate(hkern):
+            # fontTools.agl will import fontTools.misc.py23 which will output a deprecation warning
+            # ignore the warning for now - until the library fixed it
+            if index == 0:
+                import warnings
+                warnings.filterwarnings('ignore')
+                from fontTools.agl import toUnicode
+            if len(glyph) > 1 and not (index + 1) % 3 == 0:
+                glyph_names = glyph.split(",")
+                # the glyph name is written in various languages, second is english. Let's look it up.
+                if len(glyph_names) == 1:
+                    hkern[index] = toUnicode(glyph)
+                else:
+                    hkern[index] = toUnicode(glyph_names[1])
+        k = [float(x) for x in hkern[2::3]]
+        u = [k + v for k, v in zip(hkern[0::3], hkern[1::3])]
+        hkern = dict(zip(u, k))
+        return hkern
+
+    def word_spacing(self):
+        xpath = "string(.//svg:glyph[@glyph-name='space'][1]/@*[name()='horiz-adv-x'])"
+        word_spacing = self.svg.xpath(xpath, namespaces=NSS) or 3
+        return float(word_spacing)
+
+    def letter_spacing(self):
+        xpath = "string(.//svg:font[@horiz-adv-x][1]/@*[name()='horiz-adv-x'])"
+        letter_spacing = self.svg.xpath(xpath, namespaces=NSS) or 1.5
+        return float(letter_spacing)
+
+    """
+    def missing_glyph_spacing(self):
+        xpath = "string(.//svg:missing-glyph/@*[name()='horiz-adv-x'])"
+        return float(self.svg.xpath(xpath, namespaces=NSS))
+    """

--- a/lib/lettering/kerning.py
+++ b/lib/lettering/kerning.py
@@ -26,8 +26,9 @@ class FontKerning(object):
             # ignore the warning for now - until the library fixed it
             if index == 0:
                 import warnings
-                warnings.filterwarnings('ignore')
-                from fontTools.agl import toUnicode
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    from fontTools.agl import toUnicode
             if len(glyph) > 1 and not (index + 1) % 3 == 0:
                 glyph_names = glyph.split(",")
                 # the glyph name is written in various languages, second is english. Let's look it up.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ colormath
 stringcase
 tinycss2
 flask
+fonttools
 
 pywinutils; sys.platform == 'win32'
 pywin32; sys.platform == 'win32'

--- a/templates/lettering_custom_font_dir.xml
+++ b/templates/lettering_custom_font_dir.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Custom font directory{% endtrans %}</name>
+    <id>org.inkstitch.lettering_custom_font_dir.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">lettering_custom_font_dir</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Font Tools{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <param name="file-description" type="description" indent="1" >
+        {% trans %}Set a custom directory for additional fonts to be used with the lettering tool.{% endtrans %}
+    </param>
+    <param name="file-description" type="description" indent="1" >
+        {% trans %}The fonts specified in this folder can be used directly. Restarting Inkscape won't be necessary.{% endtrans %}
+    </param>
+    <spacer />
+    <param name="path" type="path" mode="folder" gui-text="{% trans %}Custom font directory{% endtrans %}"  indent="1"></param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Generate JSON{% endtrans %}</name>
+    <id>org.inkstitch.lettering_generate_json.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">lettering_generate_json</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Font Creation Tools{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <param name="header" type="description" appearance="header" indent="1" >
+        Generates font.json which can be used by the lettering tool.
+    </param>
+    <spacer />
+    <separator indent="1"/>
+    <param type="string" name="font-name" gui-text="Name" indent="1" />
+    <param type="string" name="font-description" gui-text="Beschreibung" indent="1" />
+    <separator indent="1"/>
+        <spacer />
+    <param name="file-description" type="description" indent="1" >
+        Insert a font SVG file with kerning information.
+    </param>
+    <param type="path" name="font-file" gui-text="Font File" indent="1" mode="file" filetypes="svg"/>
+    <spacer />
+    <separator indent="1"/>
+    <param type="bool" name="auto-satin" gui-text="AutoSatin" indent="1">true</param>
+    <param type="bool" name="reversible" gui-text="Reversible" indent="1">true</param>
+    <separator indent="1"/>
+    <param type="string" name="default-glyph" gui-text="Default Glyph" indent="1">&#65533;</param>
+    <separator indent="1"/>
+    <spacer />
+    <param name="min-scale" type="float" precision="1" min="0.1" max="1" gui-text="Min Scale" indent="1">1</param>
+    <param name="max-scale" type="float" precision="1" min="1" max="10" gui-text="Max Scale" indent="1">1</param>
+    <separator indent="1"/>
+    <param name="leading" type="float" precision="1" min="0" max="100" gui-text="Leading" indent="1">5</param>
+     <spacer />
+    <separator indent="1"/>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -35,7 +35,7 @@
     <param name="min-scale" type="float" precision="1" min="0.1" max="1" gui-text="Min Scale" indent="1">1</param>
     <param name="max-scale" type="float" precision="1" min="1" max="10" gui-text="Max Scale" indent="1">1</param>
     <separator indent="1"/>
-    <param name="leading" type="float" precision="1" min="0" max="100" gui-text="Leading" indent="1">5</param>
+    <param name="leading" type="float" precision="1" min="-100" max="100" gui-text="Leading" indent="1">5</param>
      <spacer />
     <separator indent="1"/>
     <script>

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -7,7 +7,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Font Creation Tools{% endtrans %}" />
+                <submenu name="{% trans %}Font Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/lettering_remove_kerning.xml
+++ b/templates/lettering_remove_kerning.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Remove Kerning{% endtrans %}</name>
+    <id>org.inkstitch.lettering_remove_kerning.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">lettering_remove_kerning</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Font Creation Tools{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <param name="header" type="description" appearance="header" indent="1" >
+        {% trans %}Removes Kerning information from given SVG files{% endtrans %}
+    </param>
+    <param name="file-description" type="description" indent="1" >
+        &#9888; {% trans %}Make sure you keep a copy of the original file. After running this extension kerning information will be lost unrevertably from these files.{% endtrans %}
+    </param>
+    <param type="path" name="font-files" gui-text="{% trans %}Select Font Files{% endtrans %}" indent="1" mode="files" filetypes="svg"/>
+    <spacer />
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>

--- a/templates/lettering_remove_kerning.xml
+++ b/templates/lettering_remove_kerning.xml
@@ -14,9 +14,12 @@
     <param name="header" type="description" appearance="header" indent="1" >
         {% trans %}Removes Kerning information from given SVG files{% endtrans %}
     </param>
+    <separator />
     <param name="file-description" type="description" indent="1" >
         &#9888; {% trans %}Make sure you keep a copy of the original file. After running this extension kerning information will be lost unrevertably from these files.{% endtrans %}
     </param>
+    <separator />
+    <spacer />
     <param type="path" name="font-files" gui-text="{% trans %}Select Font Files{% endtrans %}" indent="1" mode="files" filetypes="svg"/>
     <spacer />
     <script>

--- a/templates/lettering_remove_kerning.xml
+++ b/templates/lettering_remove_kerning.xml
@@ -7,7 +7,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Font Creation Tools{% endtrans %}" />
+                <submenu name="{% trans %}Font Tools{% endtrans %}" />
             </submenu>
         </effects-menu>
     </effect>


### PR DESCRIPTION
This adds
* an extension to create a json file to be used by the lettering tool
* an extension to remove kerning info out of the font svg file after the creation of the json file
* an extension to add a third possible place for the fonts (custom font dir)
 
To 3: For some users it could be difficult to find the inkstitch config folder and understand, that it is possible to add fonts into this folder as well. But they know the inkscape folder from the installation and see existing fonts in there. It is a logical place to add more fonts. But updating Ink/Stitch will be dangerous for their custom fonts. So I thought it would be nice to enable them to place their fonts into a custom directory in a location in the file system they are more used to. Thoughts?