### PR TITLE
Make the font names more reproducibly stable in generated pythonfile for translation

### DIFF
--- a/bin/inkstitch-fonts-gettext
+++ b/bin/inkstitch-fonts-gettext
@@ -8,7 +8,7 @@ import json
 
 fonts_dir = os.path.join(os.path.dirname(__file__), "..", "fonts")
 
-for font in os.listdir(fonts_dir):
+for font in sorted(os.listdir(fonts_dir)):
 	with open(os.path.join(fonts_dir, font, "font.json")) as font_json:
 		font_metadata = json.load(font_json)
 		


### PR DESCRIPTION
This should greatly reduce the noise crowdin creates
Before this the translations would often jump around in diff output this ought to make that a thing of the past.