### PR TITLE
Fix lettering tool encoding issues

### DIFF
--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -3,7 +3,7 @@
 VERSION="${GITHUB_REF##*/}"
 OS="${BUILD:-$(uname)}"
 
-if VERSION=""; then
+if VERSION==""; then
   VERSION="Manual Install"
 fi
 

--- a/bin/generate-version-file
+++ b/bin/generate-version-file
@@ -3,7 +3,7 @@
 VERSION="${GITHUB_REF##*/}"
 OS="${BUILD:-$(uname)}"
 
-if VERSION==""; then
+if [ $VERSION = "" ]; then
   VERSION="Manual Install"
 fi
 

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -79,7 +79,7 @@ class Font(object):
 
     def _load_metadata(self):
         try:
-            with open(os.path.join(self.path, "font.json")) as metadata_file:
+            with open(os.path.join(self.path, "font.json"), encoding="utf-8") as metadata_file:
                 self.metadata = json.load(metadata_file)
         except IOError:
             pass

--- a/lib/lettering/font_variant.py
+++ b/lib/lettering/font_variant.py
@@ -56,7 +56,7 @@ class FontVariant(object):
 
     def _load_glyphs(self):
         svg_path = os.path.join(self.path, "%s.svg" % self.variant)
-        with open(svg_path) as svg_file:
+        with open(svg_path, encoding="utf-8") as svg_file:
             svg = etree.parse(svg_file)
 
         glyph_layers = svg.xpath(".//svg:g[starts-with(@inkscape:label, 'GlyphLayer-')]", namespaces=inkex.NSS)


### PR DESCRIPTION
Windows had some issues with the encoding when loading json and glyph files. This should fix it.
Also fixes issues with the version declaration in the about file.
I will merge this branch directly into inkscape1.0 branch.