### PR TITLE
params fixes

### DIFF
--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -150,7 +150,7 @@ class InkstitchExtension(inkex.Effect):
 
         # command connectors with a fill color set, will glitch into the elements list
         if is_command(node) or node.get(CONNECTOR_TYPE):
-            return[]
+            return []
 
         if self.svg.selected:
             if node.get("id") in self.svg.selected:
@@ -163,7 +163,9 @@ class InkstitchExtension(inkex.Effect):
             nodes.extend(self.descendants(child, selected, troubleshoot))
 
         if selected:
-            if getattr(node, "get_path", None):
+            if node.tag == SVG_GROUP_TAG:
+                pass
+            elif getattr(node, "get_path", None):
                 nodes.append(node)
             elif troubleshoot and (node.tag in NOT_EMBROIDERABLE_TAGS or node.tag in EMBROIDERABLE_TAGS or is_clone(node)):
                 nodes.append(node)

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -9,7 +9,7 @@ from itertools import groupby
 import wx
 from wx.lib.scrolledpanel import ScrolledPanel
 
-from ..commands import is_command
+from ..commands import is_command, is_command_symbol
 from ..elements import (AutoFill, Clone, EmbroideryElement, Fill, Polyline,
                         SatinColumn, Stroke)
 from ..elements.clone import is_clone
@@ -466,7 +466,7 @@ class Params(InkstitchExtension):
         element = EmbroideryElement(node)
         classes = []
 
-        if not is_command(node):
+        if not is_command(node) and not is_command_symbol(node):
             if node.tag == SVG_POLYLINE_TAG:
                 classes.append(Polyline)
             elif is_clone(node):

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -6,10 +6,10 @@ from threading import Event, Thread
 import wx
 from wx.lib.intctrl import IntCtrl
 
+from .dialogs import info_dialog
 from ..i18n import _
 from ..stitch_plan import patches_to_stitch_plan, stitch_plan_from_file
 from ..svg import PIXELS_PER_MM
-from .dialogs import info_dialog
 
 # L10N command label at bottom of simulator window
 COMMAND_NAMES = [_("STITCH"), _("JUMP"), _("TRIM"), _("STOP"), _("COLOR CHANGE")]
@@ -681,7 +681,6 @@ class EmbroiderySimulator(wx.Frame):
         stitch_plan = kwargs.pop('stitch_plan', None)
         stitches_per_second = kwargs.pop('stitches_per_second', 16)
         target_duration = kwargs.pop('target_duration', None)
-        size = kwargs.get('size', (0, 0))
         wx.Frame.__init__(self, *args, **kwargs)
         self.statusbar = self.CreateStatusBar(2)
         self.statusbar.SetStatusWidths([250, -1])


### PR DESCRIPTION
I was getting a weird error when I tried to run Params after selecting some objects.  I had a trim command selected, and Params was giving me errors as if it were trying to treat the connector and the symbol as things that were supposed to be embroidered.

I also noticed that group tags were being selected, because apparently inkex `Group` objects have a `get_path()` method.