### PR TITLE
Read legacy base64 encoded lettering params

### DIFF
--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from base64 import b64decode
 
 import appdirs
 import inkex
@@ -86,12 +87,17 @@ class LetteringFrame(wx.Frame):
             "scale": 100
         })
 
-        try:
-            if INKSTITCH_LETTERING in self.group.attrib:
+        if INKSTITCH_LETTERING in self.group.attrib:
+            try:
                 self.settings.update(json.loads(self.group.get(INKSTITCH_LETTERING)))
-                return
-        except (TypeError, ValueError):
-            pass
+            except json.decoder.JSONDecodeError:
+                # legacy base64 encoded (changed in v2.0)
+                try:
+                    self.settings.update(json.loads(b64decode(self.group.get(INKSTITCH_LETTERING))))
+                except (TypeError, ValueError):
+                    pass
+            except (TypeError, ValueError):
+                pass
 
     def apply_settings(self):
         """Make the settings in self.settings visible in the UI."""

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -681,7 +681,6 @@ class EmbroiderySimulator(wx.Frame):
         stitch_plan = kwargs.pop('stitch_plan', None)
         stitches_per_second = kwargs.pop('stitches_per_second', 16)
         target_duration = kwargs.pop('target_duration', None)
-        size = kwargs.get('size', (0, 0))
         wx.Frame.__init__(self, *args, **kwargs)
         self.statusbar = self.CreateStatusBar(2)
         self.statusbar.SetStatusWidths([250, -1])


### PR DESCRIPTION
During the update to inkscape 1.0 the encoding of lettering params has changed.
Therefore the lettering tool could not read the lettering info from existing files anymore.
This should fix it. Thanks to @lexelby for pointing me to it.

The code isn't very beautiful. Is there a better way of doing this?