### PR TITLE
Downgrade Python for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.9.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '15.x'
@@ -94,7 +94,7 @@ jobs:
           node-version: '15.x'
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.8.x'
           architecture: 'x86'
       - uses: microsoft/setup-msbuild@v1.0.2
       - name: install dependencies
@@ -126,7 +126,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.9.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '15.x'


### PR DESCRIPTION
Windows 7 does not support python 3.9 versions. Downgrading to python 3.8.8 will enable Ink/Stitch to work on windows 7 again. We will have to drop support for Windows XP in our next release though.

Thanks to Laure to bring this issue to our attention.