### PR TITLE
Catch Palette IndexError

### DIFF
--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -55,7 +55,7 @@ class Zip(InkstitchExtension):
                         svg.write(etree.tostring(document).decode('utf-8'))
                 elif format == 'threadlist':
                     output_file = os.path.join(path, "%s_%s.txt" % (base_file_name, _("threadlist")))
-                    output = open(output_file, 'w')
+                    output = open(output_file, 'w', encoding='utf-8')
                     output.write(self.get_threadlist(stitch_plan, base_file_name))
                     output.close()
                 else:

--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -57,7 +57,7 @@ class ThreadPalette(Set):
 
                     thread = ThreadColor(thread_color, thread_name, thread_number, manufacturer=self.name)
                     self.threads[thread] = convert_color(sRGBColor(*thread_color, is_upscaled=True), LabColor)
-                except ValueError:
+                except (ValueError, IndexError):
                     continue
 
     def __contains__(self, thread):

--- a/templates/embroider_settings.xml
+++ b/templates/embroider_settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Settings{% endtrans %}</name>
+    <name>{% trans %}Preferences{% endtrans %}</name>
     <id>org.inkstitch.embroider_settings.{{ locale }}</id>
     <param name="extension" type="string" gui-hidden="true">embroider_settings</param>
     <effect needs-live-preview="false">


### PR DESCRIPTION
If users add their own palettes, they seem to like empty lines at the end. Ink/Stitch should not crash when this happens.

Also I rename the settings extension, because it seems to cause trouble for our french community (they use the same word for params and settings which will lead to some confusion and even the vanishing of one of these extensions on macOS).