### PR TITLE
Set Minimum Size for the Params Dialog

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -460,6 +460,13 @@ class SettingsFrame(wx.Frame):
         sizer_1.Add(sizer_3, 0, wx.ALIGN_RIGHT, 0)
         self.SetSizer(sizer_1)
         sizer_1.Fit(self)
+
+        # prevent the param dialog to become smaller than 500*400
+        # otherwise the scrollbar jumps to the side and produces a
+        # deprecation warning in wxpythons scrolledpanel.py line 225 -
+        # which is expecting an integer, but uses previously a division
+        self.SetSizeHints(500, 400)
+
         self.Layout()
         # end wxGlade
 


### PR DESCRIPTION
I am not very happy with this solution. On the other hand it dosn't hurt to have a minimum size for the params dialog (which will be replaced anyway).

Context: 
```
[...]/site-packages/wx/lib/scrolledpanel.py:225: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  self.Scroll(new_vs_x, new_vs_y)
```
This message will pop up, when the params window is squashed too strongly. The scrollbar tries to move into a certain position. This behaviour triggers the deprecation warning. I don't know where else to prevent the warning (other than wxpython itself). But it doesn't seem to pop up, when the window stays at a reasonable size.