### PR TITLE
Lettering: Add ability for font authors to force letter case

### DIFF
--- a/lib/extensions/lettering_generate_json.py
+++ b/lib/extensions/lettering_generate_json.py
@@ -24,6 +24,7 @@ class LetteringGenerateJson(InkstitchExtension):
         self.arg_parser.add_argument("-d", "--font-description", type=str, default="Description", dest="font_description")
         self.arg_parser.add_argument("-s", "--auto-satin", type=Boolean, default="true", dest="auto_satin")
         self.arg_parser.add_argument("-r", "--reversible", type=Boolean, default="true", dest="reversible")
+        self.arg_parser.add_argument("-u", "--letter-case", type=str, default="", dest="letter_case")
         self.arg_parser.add_argument("-g", "--default-glyph", type=str, default="", dest="default_glyph")
         self.arg_parser.add_argument("-i", "--min-scale", type=float, default=1.0, dest="min_scale")
         self.arg_parser.add_argument("-a", "--max-scale", type=float, default=1.0, dest="max_scale")
@@ -68,6 +69,7 @@ class LetteringGenerateJson(InkstitchExtension):
                 'leading': leading,
                 'auto_satin': self.options.auto_satin,
                 'reversible': self.options.reversible,
+                'letter_case': self.options.letter_case,
                 'default_glyph': self.options.default_glyph,
                 'min_scale': round(self.options.min_scale, 1),
                 'max_scale': round(self.options.max_scale, 1),

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -106,6 +106,7 @@ class Font(object):
 
     name = localized_font_metadata('name', '')
     description = localized_font_metadata('description', '')
+    letter_case = font_metadata('letter_case', '')
     default_glyph = font_metadata('defalt_glyph', "�")
     leading = font_metadata('leading', 100)
     kerning_pairs = font_metadata('kerning_pairs', {})
@@ -229,6 +230,11 @@ class Font(object):
 
         last_character = None
         for character in line:
+            if self.letter_case == "upper":
+                character = character.upper()
+            elif self.letter_case == "lower":
+                character = character.lower()
+
             if character == " ":
                 position.x += self.word_spacing
                 last_character = None

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -33,6 +33,11 @@
            gui-description="{% trans %}Disable if you defined manual routing in your font.{% endtrans %}" indent="1">true</param>
     <param type="bool" name="reversible" gui-text="{% trans %}Reversible{% endtrans %}"
           gui-description='{% trans %}If disabled back and forth stitching will not be possile for this font.{% endtrans %}' indent="1">true</param>
+    <param name="letter-case" type="optiongroup" appearance="combo" gui-text="{% trans %}Force letter case{% endtrans %}" indent="1">
+             <option value="">{% trans %}No{% endtrans %}</option>
+             <option value="upper">{% trans %}Upper{% endtrans %}</option>
+             <option value="lower">{% trans %}Lower{% endtrans %}</option>
+    </param>
     </vbox>
     <vbox indent="20">
     <param name="min-scale" type="float" precision="1" min="0.1" max="1" gui-text="{% trans %}Min Scale{% endtrans %}" indent="1">1</param>


### PR DESCRIPTION
Some of the new fonts only have capital letters. When lower case letters are entered the Ink/Stitch lettering tool react with the missing glyph character. This allows font authors to mark their font as upper or lower case only. All letters will be converted to the forced letter case.