### PR TITLE
Improve Install Thread Color Palettes Extension

### DIFF
--- a/electron/src/renderer/components/InstallPalettes.vue
+++ b/electron/src/renderer/components/InstallPalettes.vue
@@ -19,7 +19,7 @@
         <translate>Ink/Stitch can install palettes for Inkscape matching the thread colors from popular machine embroidery thread manufacturers.
         </translate>
       </v-card-text>
-      <v-file-input class="mb-3 mx-3" webkitdirectory hide-details v-model="path"
+      <v-file-input class="mb-3 mx-3" webkitdirectory hide-details v-model="path" truncate-length="45"
                     :label="$gettext('Choose Inkscape directory')"></v-file-input>
       <v-card-actions>
         <v-btn text color="primary" v-on:click="install">

--- a/electron/src/renderer/components/InstallPalettes.vue
+++ b/electron/src/renderer/components/InstallPalettes.vue
@@ -20,7 +20,12 @@
         </translate>
       </v-card-text>
       <v-file-input class="mb-3 mx-3" webkitdirectory hide-details v-model="path" truncate-length="45"
-                    :label="$gettext('Choose Inkscape directory')"></v-file-input>
+                    :label="$gettext('Choose Inkscape directory')">
+      </v-file-input>
+      <v-card-text>
+        <translate>If you are not sure which file path to choose, click on install directly. In most cases Ink/Stitch will guess the correct path.
+        </translate>
+      </v-card-text>
       <v-card-actions>
         <v-btn text color="primary" v-on:click="install">
           <v-icon>mdi-palette</v-icon>


### PR DESCRIPTION
Reference #1124

For now it only fixes point 1.
The other points I have no idea how to fix them.

2: On Linux the correct path will open in the file browser window. So this could be a windows issue or something.

3: The default path will be set on the startup of the extension. Usually everybody just has to click install (except they have unusual installation paths). Maybe we should comment on that above the input field?

@Athira2199 is this an issue you would be interested in?