### PR TITLE
Update for Inkstitch Sulky Rayon Thread palette

### DIFF
--- a/palettes/InkStitch Sulky Rayon.gpl
+++ b/palettes/InkStitch Sulky Rayon.gpl
@@ -5,280 +5,289 @@ Columns: 4
 249	249	255	                  Bright White   1001
 249	249	244	                    Soft White   1002
 249	249	234	                     Off White   1071
-249	249	224	                 Pale Sea Foam   1086
-223	223	203	                   Silver Gray   1218
-203	203	189	                    Gray Khaki   1321
-183	183	175	                Dk. Gray Khaki   1270
-239	239	229	              Light Gray Khaki   1268
-224	219	219	                     Lt. Putty   1229
-193	203	185	                         Putty   1508
-149	164	144	                     Lt. Khaki   1211
-150	170	139	                    Drab Green   1228
- 99	 99	 39	                Lt. Army Green   1156
- 89	 89	 29	               Med. Army Green   1173
- 39	 59	  0	                Dk. Army Green   1210
-189	209	 99	                   Lt. Avocado   1209
-119	113	 19	                    Moss Green    630
- 99	 99	 45	                         Khaki   1212
- 74	 74	 25	                   Hedge Green   1272
- 54	 54	 31	                   Dark Forest   1273
- 60	 79	 49	                     Evergreen   1271
-240	248	236	             Pale Yellow-Green   1063
-237	246	212	                    Pale Green   1331
-194	211	125	               Lt. Grass Green   1100
-166	194	132	                    Mint Green   1047
-112	119	 15	                     Pistachio   1276
-122	179	 29	                    Lime Green   1510
- 92	154	 26	                    Nile Green   1274
- 66	160	 33	                   Grass Green   1049
-  2	118	  2	                     Ivy Green   1277
-147	209	108	                  Willow Green   1279
- 70	183	116	              Dk. Willow Green   1280
-  9	133	 49	                    True Green   1101
-  0	175	 56	                  Bright Green   1278
- 30	100	 25	               Christmas Green   1051
- 25	 50	  7	                 Classic Green   1232
- 22	 95	 40	                  Garden Green    569
- 23	 85	 35	                 Emerald Green   1079
- 12	 61	  3	                 Mallard Green   1208
- 46	131	 89	                          Teal   1046
- 52	 72	 30	                 English Green    525
- 17	 20	  8	                  Forest Green    538
- 11	 65	 51	                      Dk. Teal   1230
-165	175	104	           Pastel Yellow-Green   1104
-137	152	 18	                       Avocado   1177
-129	137	  1	                    Chartreuse   1322
-134	129	  5	               Deep Chartreuse   1332
- 81	 83	  8	              Med. Dk. Avocado   1176
- 21	 45	  4	                   Dk. Avocado   1175
- 13	 41	  4	                Dk. Pine Green   1174
-190	205	200	                     Jade Tint   1077
-224	230	200	                      Sea Mist   1275
-128	163	136	                Sea Foam Green   1207
- 65	 85	 69	                  French Green   1287
-  2	 20	 15	                     Dk. Khaki   1103
- 53	105	 61	                    Mint Julep    580
- 52	 50	 19	              Dk. French Green   1286
-195	239	191	                      Lt. Teal   1045
- 15	165	111	                          Aqua   1288
- 28	111	 81	                     Med. Aqua    640
-  8	142	108	                     Deep Aqua    571
- 52	150	105	                 Green Peacock   1503
-  1	 79	 58	                Coachman Green   1517
-226	226	235	              Powder Blue Tint   1151
-168	200	188	                   Pastel Jade   1204
-110	144	165	                     Med. Jade   1205
-174	198	187	                    Sage Green   1305
- 19	 79	 69	                Dk. Sage Green   1285
- 16	 57	 74	                     Deep Teal   1162
- 13	 34	 16	                    Ocean Teal   1233
-  8	 24	 14	                Weathered Blue   1171
-  8	 23	  5	                 Midnight Teal   1536
-  0	122	103	                  Wild Peacock   1513
- 22	 98	 95	                  Deep Peacock   1090
- 30	110	111	                     Dark Jade   1206
- 15	105	120	                 Dk. Turquoise   1096
- 48	111	117	              Bright Turquoise   1251
- 39	 92	112	                Duck Wing Blue   1250
- 16	209	189	                     Turquoise   1095
- 38	191	202	                Med. Turquoise   1094
-  9	161	168	                Bright Peacock   1252
- 52	125	203	                      Sapphire   1534
- 27	 76	164	                  Dk. Sapphire   1253
- 24	 43	 86	                Deep Turquoise   1202
-166	162	198	                    Periwinkle   1030
- 87	 54	158	                Dk. Periwinkle   1226
- 84	 58	141	                   Nassau Blue   1242
- 68	 35	 93	              Deep Nassau Blue   1293
- 50	 30	 80	              Bright Navy Blue   1042
- 42	 20	 63	             Admiral Navy Blue   1199
- 34	 15	 52	                     Med. Navy   1197
- 20	 11	 45	                 Med. Dk. Navy   1200
- 90	 90	139	                    Royal Blue   1076
- 17	 54	117	                   Cobalt Blue    526
- 35	 35	139	                     Team Blue   1535
- 16	 10	124	                   Blue Ribbon    572
- 74	 88	112	                     True Blue   1143
- 60	 80	117	                    Dusty Navy   1198
- 38	 35	 69	                    Arctic Sky    643
- 12	  8	 45	               Deep Arctic Sky    505
- 72	 61	 89	                    Slate Gray   1283
- 65	 32	 68	               Deep Slate Gray   1294
- 29	  6	 47	                 Midnight Blue   1044
- 25	  5	 37	                      Dk. Navy   1043
-  2	  1	 20	                    Blue Black   1182
-220	224	241	                Baby Blue Tint   1223
-214	213	232	              Pale Powder Blue   1074
-114	116	131	                    Winter Sky   1291
-174	184	195	            Lt. Weathered Blue   1203
-110	120	140	           Med. Weathered Blue   1172
-209	219	255	                 Lt. Baby Blue   1222
-100	139	190	              Med. Powder Blue   1201
- 98	170	220	               Cornflower Blue   1249
- 80	125	170	                  Peacock Blue   1134
-220	235	240	                      Ice Blue   1289
-210	230	240	              Med. Pastel Blue   1248
-180	225	235	                   Powder Blue   1145
- 70	110	120	                Dk. Winter Sky   1284
-209	220	250	                    Heron Blue   1292
-190	195	225	                     Baby Blue   1028
-160	195	235	                     Med. Blue   1029
-150	195	225	                          Blue   1196
-120	 50	152	                   Deep Purple   1235
- 70	  1	110	                  Royal Purple   1112
- 50	  0	 70	                 Deep Eggplant   1301
-110	 10	150	                      Eggplant   1302
-223	229	235	                  Lt. Sky Blue   1165
-130	135	140	                      Sterling   1295
-100	 70	100	                      Dk. Plum   1298
-115	 90	100	                      Lt. Plum   1297
-230	175	210	                      Lavender   1193
-223	190	200	                   Med. Orchid   1031
-220	130	160	                        Orchid   1080
-216	100	150	                    Dk. Orchid   1033
-126	 30	 70	                          Plum   1300
- 75	 18	 45	                  Dk. Chestnut   1189
+255	247	213	                         Cream   1022
+255	247	185	                   Pale Yellow   1061
+255	255	133	                  Lemon Yellow   1067
+255	241	128	                      Primrose   1066
+255	240	114	                 Pastel Yellow   1135
+255	210	 38	                  Maize Yellow   1167
+239	200	 16	                      Cornsilk    502
+255	229	  0	                 Mimosa Yellow   1187
+255	230	105	                        Yellow   1023
+255	236	  0	                    Sun Yellow   1124
+252	190	  5	                 Golden Yellow   1185
+255	193	  0	                    Spark Gold   1083
+255	184	  0	                     Goldenrod   1024
+255	190	  0	                 Yellow Orange   1137
+243	160	  1	                Butterfly Gold    567
+243	182	  0	                Sunflower Gold   1333
+231	144	  2	                   Autumn Gold    523
+215	128	  0	                     Mine Gold   1025
+169	136	  3	               Dk. Autumn Gold   1262
+211	157	  0	                   Temple Gold   1159
+175	137	  1	                    Gold Green   1227
+221	171	  0	                   Summer Gold   1260
+224	198	 59	                   Spring Moss   1243
+253	243	218	                          Bone    520
+247	227	187	                          Ecru   1082
+249	230	202	                          Sand    508
+250	236	198	                     Med. Ecru   1127
+232	200	156	                     Deep Ecru   1149
+195	148	113	                      Dk. Ecru   1128
+172	135	131	                      Mushroom   1269
+238	190	174	                 Med. Dk. Ecru   1054
+151	 31	  1	                      Chestnut   1217
+106	  0	  0	                        Cognac   1264
+246	206	105	                          Gold   1070
+235	188	128	                     Tawny Tan   1055
+205	168	104	                          Flax   1549
+255	180	 53	                         Spice    562
+252	143	 12	                   Bittersweet   1313
+220	140	 23	                           Tan   1126
+175	 91	  0	                Med. Tawny Tan   1056
+178	108	 41	                        Nutmeg    521
+235	102	  2	                         Maple   1021
+230	109	  0	                      Cinnamon    568
+186	 69	  0	                     Dk. Maple   1158
+188	 61	 44	                    Deep Mauve   1237
+172	 28	  1	                    Med. Maple   1216
+205	 57	  0	                        Sunset    621
+ 50	  6	 20	                  Black Cherry   1183
+165	137	115	                    Med. Taupe   1180
+143	 98	 61	                     Dk. Taupe   1179
+156	109	 69	                         Toast   1266
+155	107	 44	                   Burnt Toast   1265
+151	 95	 47	                     Lt. Brown   1170
+134	 76	 49	                    Mink Brown   1267
+106	 31	  6	                         Brown   1129
+ 85	 22	  2	                     Dk. Brown   1130
+ 83	  6	  1	               Dk. Tawny Brown   1059
+ 73	  0	  2	                Cloister Brown   1131
+102	 53	  0	                   Tawny Brown   1058
+100	 39	  2	                 Dk. Tawny Tan   1057
+ 91	  0	  0	                   Sable Brown   1186
+102	  0	  0	                      Mahogany   1247
 100	 40	 40	                 Med. Chestnut   1214
  80	 10	 30	                    Blackberry   1215
- 50	  6	 20	                  Black Cherry   1183
-210	 30	130	                       Fuchsia   1192
-190	 25	130	                   Deep Orchid   1255
-230	140	235	                   Med. Purple   1032
-210	116	215	                    Lt. Purple   1194
-130	 40	142	                        Purple   1122
- 65	 20	 70	                 Purple Shadow   1299
-210	170	240	                      Hyacinth   1296
-230	185	245	                Dusty Lavender   1254
- 55	  1	 80	                    Dk. Purple   1195
-243	219	217	                     Pink Tint   1068
-240	200	180	                  Pastel Mauve   1113
+255	171	 87	                       Apricot   1239
+255	131	  0	                Orange Sunrise   1238
+255	145	  0	                 Orange Yellow   1065
+245	116	 10	                   True Orange   1168
+203	  0	  0	                          Rust   1181
+255	102	  0	                     Tangerine   1078
+255	102	  0	                    Orange Red   1184
+255	  0	  0	                  Orange Flame   1246
+255	  0	  0	                         Poppy   1317
+249	  0	  0	                       Lt. Red   1037
+235	  0	  0	                 Christmas Red   1147
+235	  0	  0	                      True Red   1039
+225	  0	  0	                      Lipstick    561
+205	  5	 77	                      Lt. Rose   1533
 240	214	210	                     Pale Pink   1120
-230	180	170	                    Pale Peach   1064
-225	175	154	                    Med. Peach   1015
-236	150	140	                  Pastel Coral   1016
-240	130	120	                    Dark Peach   1020
-226	130	100	                  Salmon Peach   1259
-236	160	130	                         Peach   1019
+243	219	217	                     Pink Tint   1068
+240	200	180	                 Pastel  Mauve   1113
+250	203	203	                   Pastel Pink   1225
+250	185	203	                          Pink   1121
+240	185	185	                      Lt. Pink   1115
+250	164	164	                     Lt. Mauve   1108
+245	169	160	                         Mauve   1117
+240	160	185	                   Bright Pink   1224
+235	130	150	                    Sweet Pink   1256
+255	130	180	                       Rosebud   1515
+220	100	150	                      Hot Pink   1109
+219	100	120	                    Petal Pink   1307
+238	 80	120	                     Deep Rose   1511
+229	 50	106	                     Med. Rose   1231
+189	 30	 96	                      Dk. Rose   1191
+185	160	150	                         Taupe   1213
+180	115	100	                      Dewberry   1304
+180	110	117	                     Dk. Mauve   1119
+160	 70	 86	                 Med. Burgundy   1190
+240	110	120	                         Brick   1081
+198	 50	 60	                      Burgundy   1034
+179	  0	  0	                   Red Jubilee   1263
+150	 26	 50	                      Mulberry   1311
+156	  0	  0	                  Bayberry Red   1169
+132	  0	  0	                          Wine   1312
+121	  0	  0	                  Dk. Burgundy   1035
+120	 35	 70	                       Magenta   1309
 239	223	189	                  Pastel Peach   1017
 240	196	160	                    Coral Reef   1258
 233	189	150	                   Dusty Peach    619
-219	100	120	                    Petal Pink   1307
-180	110	117	                     Dk. Mauve   1119
-160	 70	 86	                 Med. Burgundy   1190
-120	 35	 70	                       Magenta   1309
-198	 50	 60	                      Burgundy   1034
-150	 26	 50	                      Mulberry   1311
-252	203	223	                 Pastel Orchid   1111
-250	185	203	                          Pink   1121
-250	203	203	                   Pastel Pink   1225
-240	185	185	                      Lt. Pink   1115
-250	164	164	                     Lt. Mauve   1108
-240	160	185	                   Bright Pink   1224
-235	130	150	                    Sweet Pink   1256
-220	100	150	                      Hot Pink   1109
-189	 30	 96	                      Dk. Rose   1191
-238	 80	120	                     Deep Rose   1511
-229	 50	106	                     Med. Rose   1231
-205	  5	 77	                      Lt. Rose   1533
-255	  0	 75	                  Red Geranium   1188
-230	  0	 65	                    Deep Coral   1257
+236	160	130	                         Peach   1019
+226	130	100	                  Salmon Peach   1259
+230	180	170	                    Pale Peach   1064
+225	175	154	                    Med. Peach   1015
+236	150	140	                  Pastel Coral   1016
 255	189	189	                     Lt. Coral   1148
+240	130	120	                     Dk. Peach   1020
 250	153	153	                         Coral   1154
-240	110	120	                         Brick   1081
-188	 61	 44	                    Deep Mauve   1237
-245	169	160	                         Mauve   1117
-180	115	100	                      Dewberry   1304
-185	160	150	                         Taupe   1213
+250	 95	127	                    Watermelon   1303
+240	 90	115	                      Tea Rose   1558
+230	  0	 65	                    Deep Coral   1257
+255	  0	 75	                  Red Geranium   1188
+252	203	223	                 Pastel Orchid   1111
+223	190	200	                   Med. Orchid   1031
+216	100	150	                    Dk. Orchid   1033
+220	130	160	                        Orchid   1080
+190	 25	130	                   Deep Orchid   1255
+210	 30	130	                       Fuchsia   1192
+230	175	210	                      Lavender   1193
+115	 90	100	                 Purple Shadow   1297
+100	 70	100	                      Dk. Plum   1298
+230	140	235	                   Med. Purple   1032
+210	116	215	                    Lt. Purple   1194
+130	 40	142	                        Purple   1122
+ 55	  1	 80	                    Dk. Purple   1195
+ 65	 20	 70	                 Purple Shadow   1299
+120	 50	152	                   Deep Purple   1235
+ 70	  1	110	                  Royal Purple   1112
+156	100	132	                 Purple Accent   1545
+126	 30	 70	                          Plum   1300
+ 75	 18	 45	                  Dk. Chestnut   1189
+230	185	245	                Dusty Lavender   1254
+210	170	240	                      Hyacinth   1296
+ 87	 54	158	                Dk. Periwinkle   1226
+125	120	199	                 Deep Hyacinth   1561
+110	 10	150	                      Eggplant   1302
+ 50	  0	 70	                 Deep Eggplant   1301
+ 42	 20	 63	             Admiral Navy Blue   1199
+ 34	 15	 52	                     Med. Navy   1197
 248	245	241	                  Whisper Gray   1325
-213	199	195	              Dk. Whisper Gray   1327
+239	239	229	                Lt. Gray Khaki   1268
 234	228	228	                    Lt. Silver   1236
-192	178	183	                   Nickel Gray   1328
+213	199	195	              Dk. Whisper Gray   1327
+223	223	203	                   Silver Gray   1218
 183	169	172	                    Steel Gray   1011
+192	178	183	                   Nickel Gray   1328
+171	160	168	               Dk. Nickel Gray   1329
+130	135	140	                      Sterling   1295
 152	136	140	                          Gray   1219
 135	115	117	                Med. Dk. Khaki   1040
 140	127	131	                 Med. Dk. Gray   1041
 142	126	126	               Med. Steel Gray   1166
-118	 89	 96	                 Charcoal Gray   1220
-171	160	168	               Dk. Nickel Gray   1329
 126	108	124	                Gun Metal Gray   1306
-116	 88	108	                   Smokey Grey   1240
- 60	 27	 31	                  Almost Black   1234
- 38	  6	  5	                         Black   1005
-175	137	  1	                    Gold Green   1227
-255	247	213	                         Cream   1022
-255	255	133	                  Lemon Yellow   1067
-255	247	185	                   Pale Yellow   1061
-255	241	128	                      Primrose   1066
-255	240	114	                 Pastel Yellow   1135
-255	210	 38	                  Maize Yellow   1167
-246	206	105	                          Gold   1070
-255	230	105	                        Yellow   1023
-255	229	  0	                 Mimosa Yellow   1187
-255	236	  0	                    Sun Yellow   1124
-252	190	  5	                 Golden Yellow   1185
-239	200	 16	                      Cornsilk    502
-255	193	  0	                    Spark Gold   1083
-243	182	  0	                Sunflower Gold   1333
-255	184	  0	                     Goldenrod   1024
-255	190	  0	                 Yellow Orange   1137
-211	157	  0	                   Temple Gold   1159
-255	180	 53	                         Spice    562
-252	143	 12	                   Bittersweet   1313
-231	144	  2	                   Autumn Gold    523
-220	140	 23	                           Tan   1126
-175	 91	  0	                Med. Tawny Tan   1056
-122	  0	  0	                   Tawny Brown   1058
-102	  0	  0	                      Mahogany   1247
-230	109	  0	                      Cinnamon    568
-186	 69	  0	                     Dk. Maple   1158
-255	171	 87	                       Apricot   1239
-235	102	  2	                         Maple   1021
-205	 57	  0	                        Sunset    621
-172	 28	  1	                    Med. Maple   1216
-151	 31	  1	                      Chestnut   1217
-106	  0	  0	                        Cognac   1264
-238	190	174	                 Med. Dk. Ecru   1054
- 91	  0	  0	                   Sable Brown   1186
-243	160	  1	                Butterfly Gold    567
-215	128	  0	                     Mine Gold   1025
-255	145	  0	                 Orange Yellow   1065
-255	131	  0	                Orange Sunrise   1238
-245	116	 10	                   True Orange   1168
-255	102	  0	                     Tangerine   1078
-255	102	  1	                    Orange Red   1184
-203	  0	  0	                          Rust   1181
-249	  0	  0	                       Lt. Red   1037
-235	  0	  0	                 Christmas Red   1147
-225	  0	  0	                      Lipstick    561
-235	  0	  1	                      True Red   1039
-179	  0	  0	                   Red Jubilee   1263
-156	  0	  0	                  Bayberry Red   1169
-121	  0	  0	                  Dk. Burgundy   1035
-132	  0	  0	                          Wine   1312
-247	227	187	                          Ecru   1082
-250	236	198	                     Med. Ecru   1127
-235	188	128	                     Tawny Tan   1055
-232	200	156	                     Deep Ecru   1149
-195	148	113	                      Dk. Ecru   1128
-156	109	 69	                         Toast   1266
-151	 95	 47	                     Lt. Brown   1170
-155	107	 44	                   Burnt Toast   1265
- 85	 22	  2	                    Dark Brown   1130
-134	 76	 49	                    Mink Brown   1267
-106	 31	  6	                         Brown   1129
- 83	  6	  1	               Dk. Tawny Brown   1059
- 73	  0	  2	                Cloister Brown   1131
-143	 98	 61	                     Dk. Taupe   1179
+118	 89	 96	                 Charcoal Gray   1220
+116	 88	108	                   Smokey Gray   1240
+ 93	 52	 70	                       Dk. Ash   1241
+249	249	224	                  Pale Seafoam   1086
+240	248	236	             Pale Yellow Green   1063
+237	246	212	                    Pale Green   1331
+190	205	200	                     Jade Tint   1077
+224	230	200	                      Sea Mist   1275
+ 53	105	 61	                    Mint Julep    580
+ 25	 50	  7	                 Classic Green   1232
+194	211	125	               Lt. Grass Green   1100
+166	194	132	                    Mint Green   1047
+147	209	108	                  Willow Green   1279
+ 70	183	116	              Dk. Willow Green   1280
+122	179	 29	                    Lime Green   1510
+ 92	154	 26	                    Nile Green   1274
+ 66	160	 33	                   Grass Green   1049
+  2	118	  2	                     Ivy Green   1277
+  0	175	 56	                  Bright Green   1278
+  9	133	 49	                    True Green   1101
+ 23	 85	 35	                 Emerald Green   1079
+ 22	 95	 40	                  Garden Green    569
+ 30	100	 25	               Christmas Greem   1051
+ 12	 61	  3	                 Mallard Green   1208
 226	207	199	                        Silver   1085
-165	137	115	                    Med. Taupe   1180
-237	156	181	                       Rosebud   1515
-252	212	176	                   Peach Fluff   1543
-135	105	107	                 Purple Accent   1545
-199	171	125	                          Flax   1549
-138	138	135	                 Desert Cactus   1550
- 56	140	140	                    Ocean Aqua   1551
-143	145	140	             Dk. Desert Cactus   1552
-117	105	120	                Purple Passion   1554
-224	130	117	                      Tea Rose   1558
- 84	186	196	                   Marine Aqua   1560
-143	138	176	                 Deep Hyacinth   1561
+203	203	189	                    Gray Khaki   1321
+224	219	219	                     Lt. Putty   1229
+193	203	185	                         Putty   1508
+183	183	175	                Dk. Gray Khaki   1270
+150	170	139	                    Drab Green   1228
+149	164	144	                     Lt. Khaki   1211
+ 99	 99	 45	                         Khaki   1212
+ 74	 74	 25	                   Hedge Green   1272
+119	113	 19	                    Moss Green    630
+ 99	 99	 39	                Lt. Army Green   1156
+ 89	 89	 29	               Med. Army Green   1173
+ 39	 59	  0	                Dk. Army Green   1210
+ 54	 54	 31	                    Dk. Forest   1273
+165	175	104	           Pastel Yellow Green   1104
+189	209	 99	                   Lt. Avocado   1209
+129	137	  1	                    Chartreuse   1322
+134	129	  5	               Deep Chartreuse   1332
+137	152	 18	                       Avocado   1177
+112	119	 15	                     Pistachio   1276
+ 81	 83	  8	              Med. Dk. Avocado   1176
+ 21	 45	  4	                   Dk. Avocado   1175
+ 13	 41	  4	                Dk. Pine Green   1174
+ 65	 85	 69	                  French Green   1287
+108	124	113	             Dk. Desert Cactus   1552
+108	142	135	                 Desert Cactus   1550
+ 60	 79	 49	                     Evergreen   1271
+  2	 20	 15	                     Dk. Khaki   1103
+168	200	188	                   Pastel Jade   1204
+110	144	165	                     Med. Jade   1205
+174	198	187	                    Sage Green   1305
+128	163	136	                 Seafoam Green   1207
+ 52	 72	 30	                  Enlish Green    525
+ 52	 50	 19	              Dk. French Green   1286
+ 48	 91	 78	                  Forest Green    538
+ 46	131	 89	                          Teal   1046
+ 28	111	 81	                     Med. Aqua    640
+  1	 79	 58	                Coachman Green   1517
+195	239	191	                      Lt. Teal   1045
+ 15	165	111	                          Aqua   1288
+  8	142	108	                     Deep Aqua    571
+ 52	150	105	                 Green Peacock   1503
+ 11	 65	 51	                      Dk. Teal   1230
+226	226	235	              Powder Blue Tint   1151
+223	229	235	                  Lt. Sky Blue   1165
+174	184	195	            Lt. Weathered Blue   1203
+220	224	241	                Baby Blue Tint   1223
+214	213	232	              Pale Powder Blue   1074
+220	235	240	                      Ice Blue   1289
+180	225	235	                   Powder Blue   1145
+210	230	240	              Med. Pastel Blue   1248
+100	139	190	              Med. Powder Blue   1201
+209	220	250	                    Heron Blue   1292
+209	219	255	                 Lt. Baby Blue   1222
+190	195	225	                     Baby Blue   1028
+ 98	170	220	               Cornflower Blue   1249
+166	162	198	                    Periwinkle   1030
+ 80	125	170	                  Peacock Blue   1134
+160	195	235	                     Med. Blue   1029
+150	195	225	                          Blue   1196
+ 90	 90	139	                    Royal Blue   1076
+ 74	 88	112	                     True Blue   1143
+ 60	 80	117	                    Dusty Navy   1198
+ 27	 76	164	                  Dk. Sapphire   1253
+ 17	 54	117	                   Cobalt Blue    526
+ 35	 35	139	                     Team Blue   1535
+ 24	 43	 86	                Deep Turquoise   1202
+114	116	131	                    Winter Sky   1291
+110	120	140	           Med. Weathered Blue   1172
+ 70	110	120	                Dk. Witner Sky   1284
+ 13	 34	 16	                    Ocean Teal   1233
+ 84	 58	141	                   Nassau Blue   1242
+ 16	 10	124	                   Blue Ribbon    572
+ 68	 35	 93	              Deep Nassau Blue   1293
+ 50	 30	 80	              Bright Navy Blue   1042
+ 20	 11	 45	                 Med. Dk. Navy   1200
+ 65	 32	 68	               Deep Slate Gray   1294
+ 25	  5	 37	                      Dk. Navy   1043
+ 12	  8	 45	               Deep Arctic Sky    505
+  8	 24	 14	                Weathered Blue   1171
+ 72	 61	 89	                    Slate Gray   1283
+ 38	 35	 69	                    Arctic Sky    643
+ 29	  6	 47	                 Midnight Blue   1044
+  2	  1	 20	                    Blue Black   1182
+ 60	 27	 31	                  Almost Black   1234
+  0	  0	  0	                         Black   1005
+ 30	110	111	                     Dark Jade   1206
+ 19	 79	 69	                Dk. Sage Green   1285
+ 16	 57	 74	                     Deep Teal   1162
+  8	 23	  5	                 Midnight Teal   1536
+104	224	248	                   Marine Aqua   1560
+ 22	 98	 95	                  Deep Peacock   1090
+ 39	 92	112	                Duck Wing Blue   1250
+ 15	105	120	                 Dk. Turquoise   1096
+  0	122	103	                  Wild Peacock   1513
+ 48	111	117	              Bright Turquoise   1251
+ 16	209	189	                     Turquoise   1095
+ 38	191	202	                Med. Turquoise   1094
+  9	161	168	                Bright Peacock   1252
+ 52	125	203	                      Sapphire   1534


### PR DESCRIPTION
I don't remember from where but I have a file "RGB-Liste SULKY RAYON 40.xlsx" with RGB values for all threads currently available from Sulky as Rayon 40 threads.
The order in the file is a bit different from the current one. This is the file converted to a gpl palette. It has 9 additional colors.