### PR TITLE
kerning corrections

### DIFF
--- a/lib/lettering/kerning.py
+++ b/lib/lettering/kerning.py
@@ -36,7 +36,7 @@ class FontKerning(object):
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     from fontTools.agl import toUnicode
-            if not (index + 1) % 3 == 0:
+            if len(glyph) > 1 and not (index + 1) % 3 == 0:
                 # glyph names need to be converted to unicode
                 # we need to take into account, that there can be more than one start/end letter in the very same hkern element
                 # in this case they will be commas separated and each first letter needs to be combined with each next letter
@@ -65,8 +65,8 @@ class FontKerning(object):
         u_end = [k for k in hkern[1::3]]
         hkern = {}
         for i, start in enumerate(u_start):
-            for e in u_end[i]:
-                for s in start:
+            for s in start:
+                for e in u_end[i]:
                     hkern[s+e] = k[i]
         return hkern
 

--- a/lib/lettering/kerning.py
+++ b/lib/lettering/kerning.py
@@ -28,47 +28,67 @@ class FontKerning(object):
     def hkern(self):
         xpath = ".//svg:hkern[(@u1 or @g1) and (@u1 or @g1) and @k]/@*[contains(name(), '1') or contains(name(), '2') or name()='k']"
         hkern = self.svg.xpath(xpath, namespaces=NSS)
-        for index, glyph in enumerate(hkern):
+
+        # the kerning list now contains the kerning values as a list where every first value contains the first letter(s),
+        # every second value contains the second letter(s) and every third value contains the kerning
+        u_first = [k for k in hkern[0::3]]
+        u_second = [k for k in hkern[1::3]]
+        k = [int(x) for x in hkern[2::3]]
+
+        # sometimes a font file contains conflicting kerning value for a letter pair
+        # in this case the value which is specified as a single pair overrules the one specified in a list of letters
+        # therefore we want to sort our list by length of the letter values
+        kern_list = list(zip(u_first, u_second, k))
+        kern_list.sort(key=lambda x: len(x[0] + x[1]), reverse=True)
+
+        for index, kerning in enumerate(kern_list):
+            first, second, key = kerning
             # fontTools.agl will import fontTools.misc.py23 which will output a deprecation warning
             # ignore the warning for now - until the library fixed it
             if index == 0:
                 import warnings
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
+                    global toUnicode
                     from fontTools.agl import toUnicode
-            if len(glyph) > 1 and not (index + 1) % 3 == 0:
-                # glyph names need to be converted to unicode
-                # we need to take into account, that there can be more than one start/end letter in the very same hkern element
-                # in this case they will be commas separated and each first letter needs to be combined with each next letter
-                # e.g. <hkern g1="A,Agrave,Aacute,Acircumflex,Atilde,Adieresis,Amacron,Abreve,Aogonek" g2="T,Tcaron" k="5" />
-                glyphs = []
-                glyph_names = glyph.split(",")
-                for glyph_name in glyph_names:
-                    # each glyph can have additional special markers, e.g. o.cmp
-                    # toUnicode will not respect those and convert them to a simple letter
-                    # this behaviour will generate a wrong spacing for this letter.
-                    # Let's make sure to also transfer the separators and extensions to our json file
-                    separators = [".", "_"]
-                    used_separator = False
-                    for separator in separators:
-                        glyph_with_separator = glyph_name.split(separator)
-                        if len(glyph_with_separator) == 2:
-                            glyphs.append("%s%s%s" % (toUnicode(glyph_with_separator[0]), separator, glyph_with_separator[1]))
-                            used_separator = True
-                            continue
-                    # there is no extra separator
-                    if not used_separator:
-                        glyphs.append(toUnicode(glyph_name))
-                hkern[index] = glyphs
-        k = [int(x) for x in hkern[2::3]]
-        u_start = [k for k in hkern[0::3]]
-        u_end = [k for k in hkern[1::3]]
+            first = self.split_glyph_list(first)
+            second = self.split_glyph_list(second)
+            kern_list[index] = (first, second, key)
+
         hkern = {}
-        for i, start in enumerate(u_start):
-            for s in start:
-                for e in u_end[i]:
-                    hkern[s+e] = k[i]
+        for first, second, key in kern_list:
+            for f in first:
+                for s in second:
+                    hkern[f+s] = key
         return hkern
+
+    def split_glyph_list(self, glyph):
+        glyphs = []
+        if len(glyph) > 1:
+            # glyph names need to be converted to unicode
+            # we need to take into account, that there can be more than one first/second letter in the very same hkern element
+            # in this case they will be commas separated and each first letter needs to be combined with each next letter
+            # e.g. <hkern g1="A,Agrave,Aacute,Acircumflex,Atilde,Adieresis,Amacron,Abreve,Aogonek" g2="T,Tcaron" k="5" />
+            glyph_names = glyph.split(",")
+            for glyph_name in glyph_names:
+                # each glyph can have additional special markers, e.g. o.cmp
+                # toUnicode will not respect those and convert them to a simple letter
+                # this behaviour will generate a wrong spacing for this letter.
+                # Let's make sure to also transfer the separators and extensions to our json file
+                separators = [".", "_"]
+                used_separator = False
+                for separator in separators:
+                    glyph_with_separator = glyph_name.split(separator)
+                    if len(glyph_with_separator) == 2:
+                        glyphs.append("%s%s%s" % (toUnicode(glyph_with_separator[0]), separator, glyph_with_separator[1]))
+                        used_separator = True
+                        continue
+                # there is no extra separator
+                if not used_separator:
+                    glyphs.append(toUnicode(glyph_name))
+        else:
+            glyphs.append(glyph)
+        return glyphs
 
     # the space character
     def word_spacing(self):


### PR DESCRIPTION
There has been two issues with the kerning.

1. The kerning changed letter such as o.cmp into o.
    But they are not identical at all, so that this behaviour resulted in wrong kerning.

2. There are kerning elements such as this: 
    `<hkern g1="L,Lacute,Lcaron" g2="yacute,ydieresis" k="2" />`
    Where each first letter needs to be combined with each second letter, while they all use k=2
