### PR TITLE
output a warning in params if simulation cannot load

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -18,7 +18,7 @@ from ..commands import is_command, is_command_symbol
 from ..elements import (AutoFill, Clone, EmbroideryElement, Fill, Polyline,
                         SatinColumn, Stroke)
 from ..elements.clone import is_clone
-from ..gui import PresetsPanel, SimulatorPreview
+from ..gui import PresetsPanel, SimulatorPreview, WarningPanel
 from ..i18n import _
 from ..svg.tags import SVG_POLYLINE_TAG
 from ..utils import get_resource_dir
@@ -344,6 +344,8 @@ class SettingsFrame(wx.Frame):
 
         self.preview = SimulatorPreview(self)
         self.presets_panel = PresetsPanel(self)
+        self.warning_panel = WarningPanel(self)
+        self.warning_panel.Hide()
 
         self.cancel_button = wx.Button(self, wx.ID_ANY, _("Cancel"))
         self.cancel_button.Bind(wx.EVT_BUTTON, self.cancel)
@@ -379,6 +381,8 @@ class SettingsFrame(wx.Frame):
         nodes.sort(key=lambda node: node.order)
 
         try:
+            self.warning_panel.Hide()
+            self.Layout()
             for node in nodes:
                 if abort_early.is_set():
                     # cancel; params were updated and we need to start over
@@ -390,6 +394,9 @@ class SettingsFrame(wx.Frame):
 
                 patches.extend(copy(node).embroider(None))
         except SystemExit:
+            self.warning_panel.Show()
+            self.Layout()
+
             raise
         except Exception:
             # Ignore errors.  This can be things like incorrect paths for
@@ -457,6 +464,7 @@ class SettingsFrame(wx.Frame):
         sizer_3 = wx.BoxSizer(wx.HORIZONTAL)
         for tab in self.tabs:
             self.notebook.AddPage(tab, tab.name)
+        sizer_1.Add(self.warning_panel, 0, flag=wx.EXPAND | wx.ALL, border=10)
         sizer_1.Add(self.notebook, 1, wx.EXPAND | wx.LEFT | wx.TOP | wx.RIGHT, 10)
         sizer_1.Add(self.presets_panel, 0, flag=wx.EXPAND | wx.ALL, border=10)
         sizer_3.Add(self.cancel_button, 0, wx.RIGHT, 5)

--- a/lib/gui/__init__.py
+++ b/lib/gui/__init__.py
@@ -7,3 +7,4 @@ from .dialogs import confirm_dialog, info_dialog
 from .electron import open_url
 from .presets import PresetsPanel
 from .simulator import EmbroiderySimulator, SimulatorPreview, show_simulator
+from .warnings import WarningPanel

--- a/lib/gui/dialogs.py
+++ b/lib/gui/dialogs.py
@@ -13,7 +13,7 @@ def confirm_dialog(parent, question, caption='ink/stitch'):
     return result
 
 
-def info_dialog(parent, message, caption='ink/stitch'):
+def info_dialog(parent, message, caption='Ink/Stitch'):
     dlg = wx.MessageDialog(parent, message, caption, wx.OK | wx.ICON_INFORMATION)
     dlg.ShowModal()
     dlg.Destroy()

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -5,13 +5,11 @@
 
 import sys
 import time
-import traceback
 from threading import Event, Thread
 
 import wx
 from wx.lib.intctrl import IntCtrl
 
-from .dialogs import info_dialog
 from ..i18n import _
 from ..stitch_plan import patches_to_stitch_plan, stitch_plan_from_file
 from ..svg import PIXELS_PER_MM
@@ -822,16 +820,12 @@ class SimulatorPreview(Thread):
                                                            on_close=self.simulate_window_closed,
                                                            target_duration=self.target_duration)
             except Exception:
-                error = traceback.format_exc()
-
                 try:
                     # a window may have been created, so we need to destroy it
                     # or the app will never exit
                     wx.Window.FindWindowByName(_("Preview")).Destroy()
                 except Exception:
                     pass
-
-                info_dialog(self, error, _("Internal Error"))
 
             self.simulate_window.Show()
             wx.CallLater(10, self.parent.Raise)

--- a/lib/gui/warnings.py
+++ b/lib/gui/warnings.py
@@ -1,0 +1,28 @@
+# Authors: see git history
+#
+# Copyright (c) 2021 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import wx
+
+from ..i18n import _
+
+
+class WarningPanel(wx.Panel):
+    """A wx.Panel for to display warnings.
+    """
+
+    def __init__(self, parent, *args, **kwargs):
+        wx.Panel.__init__(self, parent, wx.ID_ANY, *args, **kwargs)
+
+        self.warning_box = wx.StaticBox(self, wx.ID_ANY)
+
+        self.warning = wx.StaticText(self)
+        self.warning.SetLabel(_("Cannot load simulator.\nClose Params to get full error message."))
+        self.warning.SetForegroundColour(wx.Colour(255, 25, 25))
+
+        warning_sizer = wx.StaticBoxSizer(self.warning_box, wx.HORIZONTAL)
+        warning_sizer.Add(self.warning, 1, wx.LEFT | wx.BOTTOM | wx.EXPAND, 10)
+
+        self.SetSizerAndFit(warning_sizer)
+        self.Layout()


### PR DESCRIPTION
I don't know if this makes a lot of sense, but the MessageDialog never really showed up and it seemed very unstable if implemented otherwhere. So I decided we maybe could add a message within the params panel itself and inform users if an error showed up while loading the simulator.

@lexelby Do you know, if we could retrieve the error message itself from there?

Otherwise... since we are going to update the whole params window, maybe a simple message may be enough for now.