### PR TITLE
install custom palette extension

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -17,6 +17,7 @@ from .global_commands import GlobalCommands
 from .import_threadlist import ImportThreadlist
 from .input import Input
 from .install import Install
+from .install_custom_palette import InstallCustomPalette
 from .layer_commands import LayerCommands
 from .lettering import Lettering
 from .lettering_custom_font_dir import LetteringCustomFontDir
@@ -55,6 +56,7 @@ __all__ = extensions = [StitchPlanPreview,
                         Cleanup,
                         BreakApart,
                         ImportThreadlist,
+                        InstallCustomPalette,
                         Simulator,
                         Reorder,
                         DuplicateParams,

--- a/lib/extensions/install_custom_palette.py
+++ b/lib/extensions/install_custom_palette.py
@@ -23,11 +23,18 @@ class InstallCustomPalette(InkstitchExtension):
         if not os.path.isfile(gpl):
             inkex.errormsg(_("File does not exist."))
 
+        palette_name = os.path.basename(gpl)
+        if not palette_name.endswith('.gpl'):
+            inkex.errormsg(_("Wrong file type. Ink/Stitch only accepts gpl color palettes."))
+
+        if not palette_name.startswith('InkStitch'):
+            palette_name = 'InkStitch %s' % palette_name
+
         palette_path = os.path.join(guess_inkscape_config_path(), 'palettes')
 
         if not os.path.isdir(palette_path):
             inkex.errormsg(_("Ink/Stitch cannot find your palette folder automatically. Please install your palette manually."))
-        dest = os.path.join(palette_path, os.path.basename(gpl))
+        dest = os.path.join(palette_path, palette_name)
         shutil.copyfile(gpl,  dest)
 
         if not os.path.isfile(dest):

--- a/lib/extensions/install_custom_palette.py
+++ b/lib/extensions/install_custom_palette.py
@@ -1,0 +1,35 @@
+# Authors: see git history
+#
+# Copyright (c) 2021 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import os
+import shutil
+
+import inkex
+
+from ..i18n import _
+from ..utils import guess_inkscape_config_path
+from .base import InkstitchExtension
+
+
+class InstallCustomPalette(InkstitchExtension):
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-f", "--filepath", type=str, default="", dest="filepath")
+
+    def effect(self):
+        gpl = self.options.filepath
+        if not os.path.isfile(gpl):
+            inkex.errormsg(_("File does not exist."))
+
+        palette_path = os.path.join(guess_inkscape_config_path(), 'palettes')
+
+        if not os.path.isdir(palette_path):
+            inkex.errormsg(_("Ink/Stitch cannot find your palette folder automatically. Please install your palette manually."))
+        dest = os.path.join(palette_path, os.path.basename(gpl))
+        shutil.copyfile(gpl,  dest)
+
+        if not os.path.isfile(dest):
+            inkex.errormsg("Something wwent wrong. Ink/Stitch wasn't able to copy your palette "
+                           "file into the Inkscape palettes folder. Please do it manually.")

--- a/templates/about.xml
+++ b/templates/about.xml
@@ -13,7 +13,7 @@
           <label indent="1" appearance="url">https://inkstitch.org</label>
       </page>
       <page name="license" gui-text="{%trans %}License{% endtrans %}">
-          <param name="license-text" gui-text="" type="string" appearance="multiline">
+          <param name="license-text" gui-text=" " type="string" appearance="multiline">
 {{ inkstitch_license }}
           </param>
       </page>

--- a/templates/install_custom_palette.xml
+++ b/templates/install_custom_palette.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Install custom palette{% endtrans %}</name>
+    <id>org.inkstitch.install_custom_palette.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">install_custom_palette</param>
+    <label indent="1">{% trans %}Choose a .gpl color palette file to install into Inkscape.{% endtrans %}</label>
+    <label indent="1">{% trans %}Restart Inkscape to use.{% endtrans %}</label>
+    <param indent="1" name="filepath" type="path" gui-text="{{ _('Choose file') }}" mode="file" filetypes="gpl"/>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Thread Color Management{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Users seem to try to use the extension import threadlist to import their custom thread palettes, which it is not meant for. Maybe we should offer this functionality as an extension ...