### PR TITLE
empty string in about extension

### DIFF
--- a/templates/about.xml
+++ b/templates/about.xml
@@ -13,7 +13,7 @@
           <label indent="1" appearance="url">https://inkstitch.org</label>
       </page>
       <page name="license" gui-text="{%trans %}License{% endtrans %}">
-          <param name="license-text" gui-text="" type="string" appearance="multiline">
+          <param name="license-text" gui-text=" " type="string" appearance="multiline">
 {{ inkstitch_license }}
           </param>
       </page>


### PR DESCRIPTION
Fixes

`** (org.inkscape.Inkscape): WARNING **: Attempting to translate an empty string in extension 'org.inkstitch.about.en_US', which is not supported.`

on Inkscape startup.