### PR TITLE
empty patches error message

### DIFF
--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -3,6 +3,11 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+import sys
+
+from inkex import errormsg
+
+from ..i18n import _
 from ..svg import PIXELS_PER_MM
 from ..threads import ThreadColor
 from ..utils.geometry import Point
@@ -18,6 +23,13 @@ def patches_to_stitch_plan(patches, collapse_len=None, disable_ties=False):  # n
     * adds tie-ins and tie-offs
     * adds jump-stitches between patches if necessary
     """
+
+    if len(patches) == 0:
+        msg = _('There is no embroiderable object in your selection or document.'
+                '\n\n'
+                'Please run "Extensions > Ink/Stitch > Troubleshoot > Troubleshoot Objects" to get more information.')
+        errormsg(msg)
+        sys.exit(1)
 
     if collapse_len is None:
         collapse_len = 3.0


### PR DESCRIPTION
Fixes #1199

Puts out an error messages if the only object in the selection/document happens to be non-embroiderable (text, image) and points to the troubleshoot extension.