### PR TITLE
Add threshold unit info

### DIFF
--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -5,10 +5,10 @@
     <param name="description" type="description">{% trans %}Use this extension to remove small objects from the document.{% endtrans %}</param>
     <param name="rm_fill" type="boolean" _gui-text="{% trans %}Remove Small Fill Areas{% endtrans %}"
            _gui-description="{% trans %}Removes areas smaller than dedined by threshold.{% endtrans %}">true</param>
-    <param name="fill_threshold" type="int" _gui-text="{% trans %}Fill area threshold{% endtrans %}" min="1" max="800">20</param>
+    <param name="fill_threshold" type="int" _gui-text="{% trans %}Fill area threshold (px²){% endtrans %}" min="1" max="800">20</param>
     <param name="rm_stroke" type="boolean" _gui-text="Remove Small strokes"
            _gui-description="{% trans %}Removes small strokes shorter than defined by threshold.{% endtrans %}">true</param>
-    <param name="stroke_threshold" type="int" _gui-text="{% trans %}Stroke threshold{% endtrans %}" min="2" max="800">5</param>
+    <param name="stroke_threshold" type="int" _gui-text="{% trans %}Stroke threshold (px){% endtrans %}" min="2" max="800">5</param>
     <param name="extension" type="string" gui-hidden="true">cleanup</param>
     <effect>
         <object-type>all</object-type>


### PR DESCRIPTION
Cleanup document values are in pixels but it is mentioned nowhere and users are confused.