### PR TITLE
Stacking Commands

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -287,14 +287,15 @@ def ensure_symbol(document, command):
 
 
 def add_group(document, node, command):
-    return etree.SubElement(
-        node.getparent(),
+    group = etree.Element(
         SVG_GROUP_TAG,
         {
             "id": generate_unique_id(document, "command_group"),
             INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
             "transform": get_correction_transform(node)
         })
+    node.getparent().insert(node.getparent().index(node) + 1, group)
+    return group
 
 
 def add_connector(document, symbol, element):


### PR DESCRIPTION
I was told, that commands would be easier identified in the obbjects panel, if they were directly above the object to which they belong. This pull request changes the command insertion to do exactly that.