### PR TITLE
Label hard to find troubleshoot objects

### DIFF
--- a/lib/elements/auto_fill.py
+++ b/lib/elements/auto_fill.py
@@ -11,6 +11,7 @@ from shapely import geometry as shgeo
 
 from ..i18n import _
 from ..stitches import auto_fill
+from ..svg.tags import INKSCAPE_LABEL
 from ..utils import cache, version
 from .element import Patch, param
 from .fill import Fill
@@ -264,7 +265,8 @@ class AutoFill(Fill):
 
     def validation_warnings(self):
         if self.shape.area < 20:
-            yield SmallShapeWarning(self.shape.centroid)
+            label = self.node.get(INKSCAPE_LABEL) or self.node.get("id")
+            yield SmallShapeWarning(self.shape.centroid, label)
 
         if self.shrink_or_grow_shape(self.expand, True).is_empty:
             yield ExpandWarning(self.shape.centroid)

--- a/lib/elements/empty_d_object.py
+++ b/lib/elements/empty_d_object.py
@@ -4,6 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from ..i18n import _
+from ..svg.tags import INKSCAPE_LABEL
 from .element import EmbroideryElement
 from .validation import ObjectTypeWarning
 
@@ -19,7 +20,8 @@ class EmptyD(ObjectTypeWarning):
 class EmptyDObject(EmbroideryElement):
 
     def validation_warnings(self):
-        yield EmptyD((0, 0))
+        label = self.node.get(INKSCAPE_LABEL) or self.node.get("id")
+        yield EmptyD((0, 0), label)
 
     def to_patches(self, last_patch):
         return []

--- a/lib/elements/validation.py
+++ b/lib/elements/validation.py
@@ -25,11 +25,12 @@ class ValidationMessage(object):
     description = None
     steps_to_solve = []
 
-    def __init__(self, position=None):
+    def __init__(self, position=None, label=""):
         if isinstance(position, ShapelyPoint):
             position = (position.x, position.y)
 
         self.position = InkstitchPoint(*position)
+        self.label = label
 
 
 class ValidationError(ValidationMessage):

--- a/lib/extensions/troubleshoot.py
+++ b/lib/extensions/troubleshoot.py
@@ -93,6 +93,8 @@ class Troubleshoot(InkstitchExtension):
 
         tspan = etree.Element(SVG_TSPAN_TAG)
         tspan.text = problem.name
+        if problem.label:
+            tspan.text += " (%s)" % problem.label
         text.append(tspan)
 
     def create_troubleshoot_layer(self):


### PR DESCRIPTION
I was told it is sometimes hard to select objects that are marked as too small in order to delete them. It would be nice to know their name so they can be found in the objects panel. This PR will display the label (if not existent the id) of the object behind the error description below the object pointer.

E.g. `Empty d-attribute (path64)`