### PR TITLE
Convert Satin to Stroke

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -9,6 +9,7 @@ from .auto_satin import AutoSatin
 from .break_apart import BreakApart
 from .cleanup import Cleanup
 from .convert_to_satin import ConvertToSatin
+from .convert_to_stroke import ConvertToStroke
 from .cut_satin import CutSatin
 from .duplicate_params import DuplicateParams
 from .embroider_settings import EmbroiderSettings
@@ -44,6 +45,7 @@ __all__ = extensions = [StitchPlanPreview,
                         LayerCommands,
                         GlobalCommands,
                         ConvertToSatin,
+                        ConvertToStroke,
                         CutSatin,
                         AutoSatin,
                         Lettering,

--- a/lib/extensions/convert_to_stroke.py
+++ b/lib/extensions/convert_to_stroke.py
@@ -1,0 +1,58 @@
+# Authors: see git history
+#
+# Copyright (c) 2010 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import inkex
+from lxml import etree
+
+from ..elements import SatinColumn
+from ..i18n import _
+from ..svg import get_correction_transform
+from ..svg.tags import SVG_PATH_TAG
+from .base import InkstitchExtension
+
+
+class ConvertToStroke(InkstitchExtension):
+    """Convert a satin column into a running stitch."""
+
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-k", "--keep_satin", type=inkex.Boolean, default=False, dest="keep_satin")
+
+    def effect(self):
+        if not self.svg.selected or not self.get_elements():
+            inkex.errormsg(_("Please select at least one satin column to convert to a running stitch."))
+            return
+
+        if not any(isinstance(item, SatinColumn) for item in self.elements):
+            # L10N: Convert To Satin extension, user selected one or more objects that were not lines.
+            inkex.errormsg(_("Please select at least one satin column to convert to a running stitch."))
+            return
+
+        for element in self.elements:
+            if not isinstance(element, SatinColumn):
+                continue
+
+            parent = element.node.getparent()
+            center_line = element.center_line.simplify(0.05)
+
+            d = "M"
+            for x, y in center_line.coords:
+                d += "%s,%s " % (x, y)
+                d += " "
+
+            stroke_element = etree.Element(SVG_PATH_TAG,
+                                           {
+                                            "id": self.uniqueId("path"),
+                                            "style": self.path_style(element),
+                                            "transform": get_correction_transform(element.node),
+                                            "d": d
+                                           })
+            parent.insert(parent.index(element.node), stroke_element)
+            if not self.options.keep_satin:
+                parent.remove(element.node)
+
+    def path_style(self, element):
+        color = element.get_style('stroke', '#000000')
+        return "stroke:%s;stroke-width:1px;stroke-dasharray:3, 1;fill:none" % (color)

--- a/templates/convert_to_stroke.xml
+++ b/templates/convert_to_stroke.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Convert Satin to Stroke{% endtrans %}</name>
+    <id>org.inkstitch.convert_to_stroke.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">convert_to_stroke</param>
+    <param name="description" type="description">{% trans %}Converts a satin column into a running stitch.{% endtrans %}</param>
+    <param name="keep_satin" type="boolean" _gui-text="Keep satin column"
+       _gui-description="{% trans %}Do not delete original satin column.{% endtrans %}">false</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
This extension turns a satin column setup (back?) into a running stitch. This may be helpful, when you resize a design and need a running stitch instead of a satin.