### PR TITLE
Fix typos

### DIFF
--- a/images/examples/Bfly FSL.svg
+++ b/images/examples/Bfly FSL.svg
@@ -214,7 +214,7 @@
          x="0"
          y="244.13913"
          style="stroke-width:0.26458332px"
-         id="tspan4781">have to experiement to find out what is</tspan><tspan
+         id="tspan4781">have to experiment to find out what is</tspan><tspan
          sodipodi:role="line"
          x="0"
          y="250.31274"

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -93,7 +93,7 @@ class EmbroideryElement(object):
         elif legacy_tie == "False":
             self.set_param('ties', 3)
 
-        # defaut setting for fill_underlay has changed
+        # default setting for fill_underlay has changed
         if legacy_attribs and not self.get_param('fill_underlay', ""):
             self.set_param('fill_underlay', False)
 

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -779,7 +779,7 @@ class SatinColumn(EmbroideryElement):
         sides = self.plot_points_on_rails(self.zigzag_spacing, self.pull_compensation)
 
         # "left" and "right" here are kind of arbitrary designations meaning
-        # a point from the first and second rail repectively
+        # a point from the first and second rail respectively
         for left, right in zip(*sides):
             patch.add_stitch(left)
             patch.add_stitch(right)

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -132,7 +132,7 @@ class Stroke(EmbroideryElement):
             # want to see if they set a running stitch length at all, and the property will apply
             # a default value.
             #
-            # Thsi is so tricky, and and intricate that's a major reason that we deprecated the
+            # This is so tricky, and and intricate that's a major reason that we deprecated the
             # 0.5 units rule.
 
             # Warn them the first time.

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -114,7 +114,7 @@ class Font(object):
     min_scale = font_metadata('min_scale', 1.0)
     max_scale = font_metadata('max_scale', 1.0)
 
-    # use values from SVG Font, exemple:
+    # use values from SVG Font, example:
     # <font horiz-adv-x="45" ...  <glyph .... horiz-adv-x="49" glyph-name="A" /> ... <hkern ... k="3"g1="A" g2="B" /> .... />
 
     # Example font.json : "horiz_adv_x": {"A":49},

--- a/lib/threads/catalog.py
+++ b/lib/threads/catalog.py
@@ -75,7 +75,7 @@ class _ThreadCatalog(Sequence):
 
         Scans the catalog of color palettes and chooses one that seems most
         likely to be the one that the user used.  A palette will only be
-        chosen if more tha 80% of the thread colors in the stitch plan are
+        chosen if more than 80% of the thread colors in the stitch plan are
         exact matches for threads in the palette.
         """
         if not self.palettes:

--- a/lib/utils/version.py
+++ b/lib/utils/version.py
@@ -18,5 +18,5 @@ def get_inkstitch_version():
         with open(version, 'r') as v:
             inkstitch_version = _("Ink/Stitch Version: %s") % v.readline()
     else:
-        inkstitch_version = _("Ink/Stitch Version: unkown")
+        inkstitch_version = _("Ink/Stitch Version: unknown")
     return inkstitch_version

--- a/print/resources/style.css
+++ b/print/resources/style.css
@@ -1089,13 +1089,13 @@ body {
     width: calc(100% / 10);
   }
 
-  /* fourty items */
+  /* forty items */
     .color-swatch:first-child:nth-last-child(n+40),
     .color-swatch:first-child:nth-last-child(n+40) ~ .color-swatch {
       width: calc(100% / 12);
   }
 
-  /* fourty-nine items */
+  /* forty-nine items */
     .color-swatch:first-child:nth-last-child(n+49),
     .color-swatch:first-child:nth-last-child(n+40) ~ .color-swatch {
       height: calc(100% / 5);


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po`