### PR TITLE
Fix commands on multiple import

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -297,7 +297,7 @@ def add_connector(document, symbol, element):
 
     # Make sure the element's XML node has an id so that we can reference it.
     if element.node.get('id') is None:
-        element.node.set('id', generate_unique_id(document, "object"))
+        element.node.set('id', document.get_unique_id("object"))
 
     path = inkex.PathElement(attrib={
         "id": generate_unique_id(document, "command_connector"),
@@ -316,7 +316,7 @@ def add_connector(document, symbol, element):
 
 def add_symbol(document, group, command, pos):
     symbol = inkex.Use(attrib={
-        "id": generate_unique_id(document, "command_use"),
+        "id": document.get_unique_id("command_use"),
         XLINK_HREF: "#inkstitch_%s" % command,
         "height": "100%",
         "width": "100%",

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -197,8 +197,8 @@ def color_block_to_paths(color_block, svg, destination, visual_commands):
             add_commands(Stroke(destination[-1]), ["trim"])
 
         color = color_block.color.visible_on_white.to_hex_str()
-
         path = inkex.PathElement(attrib={
+            'id': svg.get_unique_id("object"),
             'style': "stroke: %s; stroke-width: 0.4; fill: none;" % color,
             'd': "M" + " ".join(" ".join(str(coord) for coord in point) for point in point_list),
             'transform': get_correction_transform(svg),


### PR DESCRIPTION
I came across this issue, when I tried to automatically import multiple embroidery files into Ink/Stitch.
Commands have beendisconnected from the objects. This was caused by wrongly given duplicated id's which then have been updated by Inkscape to be unique (as they should be). The inkex function to generate unique ids seems to work well. Maybe some more testing is needed.

Maybe also connected to #1264 and an other issue where it has been reported, that commands are strangely spread on the canvas and disconnected from the objects, whenever a second embroidery file has been imported to an existing document (while the first import has been working correctly).