### PR TITLE
Letters to font extension

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -297,7 +297,7 @@ def add_connector(document, symbol, element):
 
     # Make sure the element's XML node has an id so that we can reference it.
     if element.node.get('id') is None:
-        element.node.set('id', generate_unique_id(document, "object"))
+        element.node.set('id', document.get_unique_id("object"))
 
     path = inkex.PathElement(attrib={
         "id": generate_unique_id(document, "command_connector"),
@@ -316,7 +316,7 @@ def add_connector(document, symbol, element):
 
 def add_symbol(document, group, command, pos):
     symbol = inkex.Use(attrib={
-        "id": generate_unique_id(document, "command_use"),
+        "id": document.get_unique_id("command_use"),
         XLINK_HREF: "#inkstitch_%s" % command,
         "height": "100%",
         "width": "100%",

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -24,6 +24,7 @@ from .lettering import Lettering
 from .lettering_custom_font_dir import LetteringCustomFontDir
 from .lettering_generate_json import LetteringGenerateJson
 from .lettering_remove_kerning import LetteringRemoveKerning
+from .letters_to_font import LettersToFont
 from .object_commands import ObjectCommands
 from .output import Output
 from .params import Params
@@ -53,6 +54,7 @@ __all__ = extensions = [StitchPlanPreview,
                         LetteringGenerateJson,
                         LetteringRemoveKerning,
                         LetteringCustomFontDir,
+                        LettersToFont,
                         Troubleshoot,
                         RemoveEmbroiderySettings,
                         Cleanup,

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -20,8 +20,11 @@ from ..svg.tags import INKSCAPE_LABEL
 class Input(object):
     def run(self, args):
         embroidery_file = args[0]
-        self.validate_file_path(embroidery_file)
+        stitch_plan = self.generate_stitch_plan(embroidery_file)
+        print(etree.tostring(stitch_plan).decode('utf-8'))
 
+    def generate_stitch_plan(self, embroidery_file):
+        self.validate_file_path(embroidery_file)
         pattern = pyembroidery.read(embroidery_file)
         stitch_plan = StitchPlan()
         color_block = None
@@ -63,7 +66,7 @@ class Input(object):
         # Note: this is NOT the same as centering the design in the canvas!
         layer.set('transform', 'translate(%s,%s)' % (extents[0], extents[1]))
 
-        print(etree.tostring(svg).decode('utf-8'))
+        return svg
 
     def validate_file_path(self, path):
         # Check if the file exists

--- a/lib/extensions/letters_to_font.py
+++ b/lib/extensions/letters_to_font.py
@@ -1,0 +1,72 @@
+# Authors: see git history
+#
+# Copyright (c) 2021 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import os
+from pathlib import Path
+
+import inkex
+from inkex import errormsg
+
+from ..commands import ensure_symbol
+from ..i18n import _
+from ..svg import get_correction_transform
+from ..svg.tags import INKSCAPE_GROUPMODE, INKSCAPE_LABEL
+from .base import InkstitchExtension
+from .input import Input
+
+
+class LettersToFont(InkstitchExtension):
+    '''
+    This extension will create a json file to store a custom directory path for additional user fonts
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-d", "--font-dir", type=str, default="", dest="font_dir")
+        self.arg_parser.add_argument("-f", "--file-format", type=str, default="", dest="file_format")
+
+    def effect(self):
+        font_dir = self.options.font_dir
+        file_format = self.options.file_format
+
+        if not os.path.isdir(font_dir):
+            errormsg(_("Font directory not found. Please specify an existing directory."))
+
+        glyphs = list(Path(font_dir).rglob(file_format))
+        if not glyphs:
+            glyphs = list(Path(font_dir).rglob(file_format.lower()))
+
+        document = self.document.getroot()
+        for glyph in glyphs:
+            letter = self.get_glyph_element(glyph)
+            label = "GlyphLayer-%s" % letter.get(INKSCAPE_LABEL, ' ').split('.')[0][-1]
+
+            group = inkex.Group(attrib={
+                INKSCAPE_LABEL: label,
+                INKSCAPE_GROUPMODE: "layer",
+                "transform": get_correction_transform(document, child=True)
+            })
+            group.insert(0, letter[-1])
+            document.insert(0, group)
+            group.set('style', 'display:none')
+
+        # users may be confused if they get an empty document
+        # make last letter visible again
+        group.set('style', None)
+
+        # In most cases trims are inserted with the imported letters.
+        # Let's make sure the trim symbol exists in the defs section
+        ensure_symbol(document, 'trim')
+
+        self.insert_baseline(document)
+
+    def get_glyph_element(self, glyph):
+        stitch_plan = Input()
+        test = stitch_plan.generate_stitch_plan(str(glyph))
+        # we received a stitch plan wrapped in an svg document, we only need the last group
+        test = test.getchildren()
+        return test[-1]
+
+    def insert_baseline(self, document):
+        document.namedview.new_guide(position=0.0, name="baseline")

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -197,8 +197,8 @@ def color_block_to_paths(color_block, svg, destination, visual_commands):
             add_commands(Stroke(destination[-1]), ["trim"])
 
         color = color_block.color.visible_on_white.to_hex_str()
-
         path = inkex.PathElement(attrib={
+            'id': svg.get_unique_id("object"),
             'style': "stroke: %s; stroke-width: 0.4; fill: none;" % color,
             'd': "M" + " ".join(" ".join(str(coord) for coord in point) for point in point_list),
             'transform': get_correction_transform(svg),

--- a/templates/letters_to_font.xml
+++ b/templates/letters_to_font.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>{% trans %}Letters to font{% endtrans %}</name>
+    <id>org.inkstitch.letters_to_font.{{ locale }}</id>
+    <param name="extension" type="string" gui-hidden="true">letters_to_font</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch">
+                <submenu name="{% trans %}Font Management{% endtrans %}" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <param name="header" type="description" appearance="header" indent="1" >
+        {% trans %}Includes all letters of an existing embroidery font (one file for each letter) into the document in order to make it available for the Ink/Stitch lettering system.{% endtrans %}
+    </param>
+    <param name="file-description" type="description" indent="1" >
+        {% trans %}Embroidery files need to have the name of the letter right before the file extension. E.g. A.dst or Example_Font_A.dst will be recognized as the letter A.{% endtrans %}
+    </param>
+    <separator />
+    <spacer />
+    <param name="file-format" type="optiongroup" appearance="combo" gui-text="File format" indent="1">
+         {% for format, description, mimetype, category in formats %}
+         <option value="*.{{ format | upper }}">{{ format | upper }}</option>
+         {% endfor %}
+    </param>
+    <param type="path" name="font-dir" gui-text="{% trans %}Font directory{% endtrans %}" indent="1" mode="folder" filetypes="svg"/>
+    <spacer />
+    <param name="file-description" type="description" indent="1" >
+        &#9888; {% trans %}After running this function, put the baseline into the desired position and place the letters accordingly.
+                           Save your font in a separate folder. Then generate the json file (with "Autoroute Satin" unchecked).{% endtrans %}
+    </param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Bought embroidery fonts often come in multiple files which need to be inserted one by one into the document.
They also often come in multiple file formats.
This extension allows users to pick the prefered fileformat and the main folder of the font and then pulls all the files into the document as glyph layers. For the file name it seems common, that they have the letter name right in front of the extension. E.g. A.pes or Font-name-A.pes, that's how the extension will try to grab the letter names.
The extension also inserts a guide named baseline which can be used for positioning after the import.
The user will then need to position the glyphs correctly and apply the transforms. Save the file as `→.svg` and generate the json file. Since we are working with manual stitch, they should turn off the Autoroute satin. In my tests it broke some letters otherwise (need to investigate this issue).