### PR TITLE
One Version for all Languages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - "v*"
 jobs:
   linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,9 +24,9 @@ jobs:
         id: pip-cache
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-16.04-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-18.04-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-16.04-pip-
+            ${{ runner.os }}-18.04-pip-
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,14 @@ inx: version locales
 .PHONY: messages.po
 messages.po:
 	rm -f messages.po
+	xgettext inx/*.inx --its=its/inx.its -o messages-inx.po
 	bin/pyembroidery-gettext > pyembroidery-format-descriptions.py
 	bin/inkstitch-fonts-gettext > inkstitch-fonts-metadata.py
 	pybabel extract -o messages-babel.po -F babel.conf --add-location=full --add-comments=l10n,L10n,L10N --sort-by-file --strip-comments -k N_ -k '$$gettext' .
 	rm pyembroidery-format-descriptions.py inkstitch-fonts-metadata.py
 	cd electron && yarn --link-duplicates --pure-lockfile
 	find electron/src -name '*.html' -o -name '*.js' -o -name '*.vue' | xargs electron/node_modules/.bin/gettext-extract --quiet --attribute v-translate --output messages-vue.po
-	msgcat -o messages.po messages-babel.po messages-vue.po
+	msgcat -o messages.po messages-babel.po messages-vue.po messages-inx.po
 
 electron/src/renderer/assets/translations.json: $(wildcard translations/messages_*.po)
 	find translations -name '*.po' -a ! -empty | \
@@ -36,18 +37,7 @@ clean:
 
 .PHONY: locales
 locales:
-	# message files will look like this:
-	#   translations/messages_en_US.po
-	if ls translations/*.po > /dev/null 2>&1; then \
-		for po in translations/*.po; do \
-			lang=$${po%.*}; \
-			lang=$${lang#*_}; \
-			mkdir -p locales/$$lang/LC_MESSAGES/; \
-			msgfmt $$po -o locales/$$lang/LC_MESSAGES/inkstitch.mo; \
-		done; \
-	else \
-		mkdir -p locales; \
-	fi
+	bash bin/generate-translation-files
 
 .PHONY: version
 version:

--- a/bin/build-distribution-archives
+++ b/bin/build-distribution-archives
@@ -5,30 +5,23 @@ OS="${BUILD:-$(uname)}"
 ARCH="$(uname -m)"
 
 if [ "$BUILD" = "osx" ]; then
-    cp -a images/examples palettes symbols fonts LICENSE VERSION dist/inkstitch.app/Contents
+    cp -a images/examples palettes symbols fonts inx LICENSE VERSION dist/inkstitch.app/Contents
     cp -a icons locales print dist/inkstitch.app/Contents/MacOS
     cp -a electron/build/mac dist/inkstitch.app/Contents/electron
     rm -rf dist/inkstitch/
 else
-    cp -a images/examples palettes symbols fonts LICENSE VERSION dist/inkstitch
+    cp -a images/examples palettes symbols fonts inx LICENSE VERSION dist/inkstitch
     cp -a icons locales print dist/inkstitch/bin
     cp -a electron/build/*-unpacked dist/inkstitch/electron
 fi
 
 mkdir artifacts
+cd dist
 
-for d in inx/*; do
-	lang=${d%.*}
-	lang=${lang#*/}
-	cp $d/*.inx dist
-
-    cd dist
-    if [ "$BUILD" = "windows" ]; then
-      # The python zipfile command line utility can't handle directories
-      # containing files with UTF-8 names on Windows, so we use 7-zip instead.
-      7z a ../artifacts/inkstitch-${VERSION}-${OS}-${lang}.zip *
-    else
-      python -m zipfile -c ../artifacts/inkstitch-${VERSION}-${OS}-${lang}.zip *
-    fi
-    cd ..
-done
+if [ "$$BUILD" = "windows" ]; then
+    # The python zipfile command line utility can't handle directories
+    # containing files with UTF-8 names on Windows, so we use 7-zip instead.
+    7z a ../artifacts/inkstitch-${VERSION}-${OS}.zip *;
+else
+	  python -m zipfile -c ../artifacts/inkstitch-${VERSION}-${OS}.zip *;
+fi

--- a/bin/generate-translation-files
+++ b/bin/generate-translation-files
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# message files will look like this:
+#   translations/messages_en_US.po
+if ls translations/*.po > /dev/null 2>&1; then
+	for po in translations/*.po; do
+		lang=${po%.*};
+		lang=${lang#*_};
+		mkdir -p locales/$lang/LC_MESSAGES/;
+		msgfmt $po -o locales/$lang/LC_MESSAGES/inkstitch.mo;
+	done;
+else
+	mkdir -p locales;
+fi;
+
+# copy locales also into the inx folder, inkscape needs
+# them to be in exactly that place
+mkdir -p inx;
+cp -r locales/ inx/locale/;
+# for some reason inkscape requires the language folder names
+# as a two letter code ("en" instead of "en_US")
+cd inx/locale;
+for language in */; do
+	if [ ! -d ${language:0:2} ]; then
+		mv -- $language ${language:0:2};
+	fi;
+done;

--- a/its/inx.its
+++ b/its/inx.its
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!-- This is a copy of: https://gitlab.com/inkscape/inkscape/-/raw/master/po/its/inx.its -->
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           xmlns:inx="http://www.inkscape.org/namespace/inkscape/extension"
+           xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+           version="1.0">
+
+    <!-- common extraction preferences -->
+    <its:preserveSpaceRule selector="//*[contains(@xml:space, 'preserve')]" space="preserve"/>
+
+    <its:escapeRule selector="//*" escape="no"/>
+    <its:escapeRule selector="//*/@*" escape="no"/>
+
+    <its:contextRule selector="//*" contextPointer="@context"/>
+    <its:contextRule selector="//*/@*" contextPointer="../@context"/>
+
+
+    <!-- element-specific extraction rules -->
+    <its:translateRule selector="/inx:inkscape-extension" translate="no"/>
+
+    <its:translateRule selector="//inx:name" translate="yes"/>
+
+    <its:translateRule selector="//*[not(@translatable='no')]/@gui-text" translate="yes"/>
+    <its:translateRule selector="//*[not(@translatable='no')]/@gui-description" translate="yes"/>
+
+    <its:translateRule selector="//inx:label[not(@translatable='no')]" translate="yes"/>
+    <its:translateRule selector="//inx:option[not(@translatable='no')]" translate="yes"/>
+
+    <its:translateRule selector="//inx:param[@type='string'][@translatable='yes']" translate="yes"/>
+
+    <its:translateRule selector="//inx:submenu/@name" translate="yes"/>
+
+    <its:translateRule selector="//inx:filetypename" translate="yes"/>
+    <its:translateRule selector="//inx:filetypetooltip" translate="yes"/>
+
+    <its:translateRule selector="//inkscape:templateinfo/inkscape:name" translate="yes"/>
+    <its:translateRule selector="//inkscape:templateinfo/inkscape:shortdesc" translate="yes"/>
+    <its:translateRule selector="//inkscape:templateinfo/inkscape:keywords" translate="yes"/>
+
+</its:rules>

--- a/lib/inx/generate.py
+++ b/lib/inx/generate.py
@@ -7,12 +7,10 @@ from .info import generate_info_inx_files
 from .extensions import generate_extension_inx_files
 from .inputs import generate_input_inx_files
 from .outputs import generate_output_inx_files
-from .utils import iterate_inx_locales
 
 
 def generate_inx_files():
-    for locale in iterate_inx_locales():
-        generate_input_inx_files()
-        generate_output_inx_files()
-        generate_extension_inx_files()
-        generate_info_inx_files()
+    generate_input_inx_files()
+    generate_output_inx_files()
+    generate_extension_inx_files()
+    generate_info_inx_files()

--- a/templates/about.xml
+++ b/templates/about.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}About{% endtrans %}</name>
-    <id>org.inkstitch.about.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>About</name>
+    <id>org.inkstitch.about</id>
     <param type="notebook" name="about-tabs" indent="1">
-      <page name="about" gui-text="{% trans %}About{% endtrans %}">
+      <page name="about" gui-text="About">
           <image>{{ image_path }}inkstitch_colour_logo.svg</image>
           <label indent="1" appearance="header">Ink/Stitch - {{ inkstitch_version }}</label>
           <separator/>
-          <label indent="1">{% trans %}An open-source machine embroidery design platform based on Inkscape.{% endtrans %}</label>
+          <label indent="1">An open-source machine embroidery design platform based on Inkscape.</label>
           <separator/>
           <spacer/>
           <label indent="1" appearance="url">https://inkstitch.org</label>
       </page>
-      <page name="license" gui-text="{%trans %}License{% endtrans %}">
+      <page name="license" gui-text="License">
           <param name="license-text" gui-text=" " type="string" appearance="multiline">
 {{ inkstitch_license }}
           </param>

--- a/templates/auto_satin.xml
+++ b/templates/auto_satin.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Auto-Route Satin Columns{% endtrans %}</name>
-    <id>org.inkstitch.auto_satin.{{ locale }}</id>
-    <param name="trim" type="boolean" _gui-text="{% trans %}Trim jump stitches{% endtrans %}">true</param>
-    <param name="preserve_order" type="boolean" _gui-text="{% trans %}Preserve order of satin columns{% endtrans %}">false</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Auto-Route Satin Columns</name>
+    <id>org.inkstitch.auto_satin</id>
+    <param name="trim" type="boolean" _gui-text="Trim jump stitches">true</param>
+    <param name="preserve_order" type="boolean" _gui-text="Preserve order of satin columns">false</param>
     <param name="extension" type="string" gui-hidden="true">auto_satin</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+                <submenu name="Satin Tools" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/break_apart.xml
+++ b/templates/break_apart.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Break Apart Fill Objects{% endtrans %}</name>
-    <id>org.inkstitch.break_apart.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Break Apart Fill Objects</name>
+    <id>org.inkstitch.break_apart</id>
     <param name="extension" type="string" gui-hidden="true">break_apart</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Fill Tools{% endtrans %}" />
+                <submenu name="Fill Tools" />
             </submenu>
         </effects-menu>
     </effect>
     <param name="description" type="description">
-        {% trans %}This extension will try to repair fill shapes and break them apart if necessary. Holes will be retained. Use on simple or overlapping shapes.{% endtrans %}
+        This extension will try to repair fill shapes and break them apart if necessary. Holes will be retained. Use on simple or overlapping shapes.
     </param>
     <param name="method" type="optiongroup" _gui-text="Method">
        <option value="0">Simple</option>

--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Cleanup Document{% endtrans %}</name>
-    <id>org.inkstitch.cleanup.{{ locale }}</id>
-    <param name="description" type="description">{% trans %}Use this extension to remove small objects from the document.{% endtrans %}</param>
-    <param name="rm_fill" type="boolean" _gui-text="{% trans %}Remove Small Fill Areas{% endtrans %}"
-           _gui-description="{% trans %}Removes areas smaller than dedined by threshold.{% endtrans %}">true</param>
-    <param name="fill_threshold" type="int" _gui-text="{% trans %}Fill area threshold (px²){% endtrans %}" min="1" max="800">20</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Cleanup Document</name>
+    <id>org.inkstitch.cleanup</id>
+    <param name="description" type="description">Use this extension to remove small objects from the document.</param>
+    <param name="rm_fill" type="boolean" _gui-text="Remove Small Fill Areas"
+           _gui-description="Removes areas smaller than dedined by threshold.">true</param>
+    <param name="fill_threshold" type="int" _gui-text="Fill area threshold (px²)" min="1" max="800">20</param>
     <param name="rm_stroke" type="boolean" _gui-text="Remove Small strokes"
-           _gui-description="{% trans %}Removes small strokes shorter than defined by threshold.{% endtrans %}">true</param>
-    <param name="stroke_threshold" type="int" _gui-text="{% trans %}Stroke threshold (px){% endtrans %}" min="2" max="800">5</param>
+           _gui-description="Removes small strokes shorter than defined by threshold.">true</param>
+    <param name="stroke_threshold" type="int" _gui-text="Stroke threshold (px)" min="2" max="800">5</param>
     <param name="extension" type="string" gui-hidden="true">cleanup</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Troubleshoot{% endtrans %}" />
+                <submenu name="Troubleshoot" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/convert_to_satin.xml
+++ b/templates/convert_to_satin.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Convert Line to Satin{% endtrans %}</name>
-    <id>org.inkstitch.convert_to_satin.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Convert Line to Satin</name>
+    <id>org.inkstitch.convert_to_satin</id>
     <param name="extension" type="string" gui-hidden="true">convert_to_satin</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+                <submenu name="Satin Tools" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/convert_to_stroke.xml
+++ b/templates/convert_to_stroke.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Convert Satin to Stroke{% endtrans %}</name>
-    <id>org.inkstitch.convert_to_stroke.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Convert Satin to Stroke</name>
+    <id>org.inkstitch.convert_to_stroke</id>
     <param name="extension" type="string" gui-hidden="true">convert_to_stroke</param>
-    <param name="description" type="description">{% trans %}Converts a satin column into a running stitch.{% endtrans %}</param>
+    <param name="description" type="description">Converts a satin column into a running stitch.</param>
     <param name="keep_satin" type="boolean" _gui-text="Keep satin column"
-       _gui-description="{% trans %}Do not delete original satin column.{% endtrans %}">false</param>
+       _gui-description="Do not delete original satin column.">false</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+                <submenu name="Satin Tools" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/cut_satin.xml
+++ b/templates/cut_satin.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Cut Satin Column{% endtrans %}</name>
-    <id>org.inkstitch.cut_satin.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Cut Satin Column</name>
+    <id>org.inkstitch.cut_satin</id>
     <param name="extension" type="string" gui-hidden="true">cut_satin</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+                <submenu name="Satin Tools" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/duplicate_params.xml
+++ b/templates/duplicate_params.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Duplicate Params{% endtrans %}</name>
-    <id>org.inkstitch.duplicate_params.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Duplicate Params</name>
+    <id>org.inkstitch.duplicate_params</id>
     <param name="extension" type="string" gui-hidden="true">duplicate_params</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
         <submenu name="Ink/Stitch">
-            <submenu name="{% trans %}Edit{% endtrans %}" />
+            <submenu name="Edit" />
         </submenu>
         </effects-menu>
     </effect>

--- a/templates/embroider.xml
+++ b/templates/embroider.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Embroider{% endtrans %}</name>
-    <id>org.inkstitch.embroider.{{ locale }}</id>
-    <param name="title" type="description" appearance="header">{% trans %}Create a stitch file{% endtrans %}</param>
-    <param name="howto" type="description">{% trans %}Save your embroidery file through | File > Save a Copy ... |{% endtrans %}</param>
-    <param name="howto_detail" type="description">{% trans %}Choose from listed embroidery file formats and save.{% endtrans %}</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Embroider</name>
+    <id>org.inkstitch.embroider</id>
+    <param name="title" type="description" appearance="header">Create a stitch file</param>
+    <param name="howto" type="description">Save your embroidery file through | File > Save a Copy ... |</param>
+    <param name="howto_detail" type="description">Choose from listed embroidery file formats and save.</param>
     <spacer />
-    <param name="info_zip" type="description">{% trans %}Multiple file formats can be saved by choosing the zip file format.{% endtrans %}</param>
+    <param name="info_zip" type="description">Multiple file formats can be saved by choosing the zip file format.</param>
     <effect needs-live-preview="false" needs-document="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Visualise and Export{% endtrans %}" />
+                <submenu name="Visualise and Export" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/embroider_settings.xml
+++ b/templates/embroider_settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Preferences{% endtrans %}</name>
-    <id>org.inkstitch.embroider_settings.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Preferences</name>
+    <id>org.inkstitch.embroider_settings</id>
     <param name="extension" type="string" gui-hidden="true">embroider_settings</param>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
@@ -10,11 +10,11 @@
         </effects-menu>
     </effect>
     <param name="output_settings" type="description" appearance="header">
-        {% trans %}Output Settings{% endtrans %}
+        Output Settings
     </param>
     <param name="collapse_len_mm" type="float" precision="1" min="0" max="10" 
-           _gui-text="{% trans %}Collapse length (mm){% endtrans %}" 
-           _gui-description="{% trans %}Jump stitches smaller than this will be treated as normal stitches.{% endtrans %}">3</param>
+           _gui-text="Collapse length (mm)" 
+           _gui-description="Jump stitches smaller than this will be treated as normal stitches.">3</param>
     <script>
         {{ command_tag | safe }}
     </script>

--- a/templates/flip.xml
+++ b/templates/flip.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Flip Satin Column Rails{% endtrans %}</name>
-    <id>org.inkstitch.flip_satins.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Flip Satin Column Rails</name>
+    <id>org.inkstitch.flip_satins</id>
     <param name="extension" type="string" gui-hidden="true">flip</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Satin Tools{% endtrans %}" />
+                <submenu name="Satin Tools" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/global_commands.xml
+++ b/templates/global_commands.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Add Commands{% endtrans %}</name>
-    <id>org.inkstitch.global_commands.{{ locale }}</id>
-    <param name="description" type="description">{% trans %}These commands affect the entire embroidery design.{% endtrans %}</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Add Commands</name>
+    <id>org.inkstitch.global_commands</id>
+    <param name="description" type="description">These commands affect the entire embroidery design.</param>
     {% for command, description in global_commands %}
     <param name="{{ command }}" type="boolean" _gui-text="{{ _(description) }}">false</param>
     {% endfor %}
@@ -12,7 +12,7 @@
         <effects-menu>
             <submenu name="Ink/Stitch">
                 {# L10N Inkscape submenu under Extensions -> Ink/Stitch #}
-                <submenu name="{% trans %}Commands{% endtrans %}" />
+                <submenu name="Commands" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/import_threadlist.xml
+++ b/templates/import_threadlist.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Import Threadlist{% endtrans %}</name>
-    <id>org.inkstitch.import_threadlist.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Import Threadlist</name>
+    <id>org.inkstitch.import_threadlist</id>
     <param name="extension" type="string" gui-hidden="true">import_threadlist</param>
     <param name="filepath" type="path" gui-text="{{ _('Choose file') }}" mode="file" filetypes="txt"/>
     <param name="method" type="optiongroup" _gui-text="Choose method">
@@ -17,7 +17,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Thread Color Management{% endtrans %}" />
+                <submenu name="Thread Color Management" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/input.xml
+++ b/templates/input.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <name>{{ format | upper }} file input</name>
-    <id>org.inkstitch.input.{{ format }}.{{ locale }}</id>
+    <id>org.inkstitch.input.{{ format }}</id>
     <input>
         <extension>.{{ format }}</extension>
         <mimetype>application/x-embroidery-{{ format }}</mimetype>

--- a/templates/install.xml
+++ b/templates/install.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Install thread color palettes for Inkscape{% endtrans %}</name>
-    <id>org.inkstitch.install.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Install thread color palettes for Inkscape</name>
+    <id>org.inkstitch.install</id>
     <param name="extension" type="string" gui-hidden="true">install</param>
     <effect implements-custom-gui="true">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Thread Color Management{% endtrans %}" />
+                <submenu name="Thread Color Management" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/install_custom_palette.xml
+++ b/templates/install_custom_palette.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Install custom palette{% endtrans %}</name>
-    <id>org.inkstitch.install_custom_palette.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Install custom palette</name>
+    <id>org.inkstitch.install_custom_palette</id>
     <param name="extension" type="string" gui-hidden="true">install_custom_palette</param>
-    <label indent="1">{% trans %}Choose a .gpl color palette file to install into Inkscape.{% endtrans %}</label>
-    <label indent="1">{% trans %}Restart Inkscape to use.{% endtrans %}</label>
+    <label indent="1">Choose a .gpl color palette file to install into Inkscape.</label>
+    <label indent="1">Restart Inkscape to use.</label>
     <param indent="1" name="filepath" type="path" gui-text="{{ _('Choose file') }}" mode="file" filetypes="gpl"/>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Thread Color Management{% endtrans %}" />
+                <submenu name="Thread Color Management" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/layer_commands.xml
+++ b/templates/layer_commands.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Add Layer Commands{% endtrans %}</name>
-    <id>org.inkstitch.layer_commands.{{ locale }}</id>
-    <param name="description" type="description">{% trans %}Commands will be added to the currently-selected layer.{% endtrans %}</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Add Layer Commands</name>
+    <id>org.inkstitch.layer_commands</id>
+    <param name="description" type="description">Commands will be added to the currently-selected layer.</param>
     {% for command, description in layer_commands %}
     <param name="{{ command }}" type="boolean" _gui-text="{{ _(description) }}">false</param>
     {% endfor %}
@@ -11,7 +11,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Commands{% endtrans %}" />
+                <submenu name="Commands" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/lettering.xml
+++ b/templates/lettering.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Lettering{% endtrans %}</name>
-    <id>org.inkstitch.lettering.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Lettering</name>
+    <id>org.inkstitch.lettering</id>
     <param name="extension" type="string" gui-hidden="true">lettering</param>
     <effect implements-custom-gui="true">
         <object-type>all</object-type>

--- a/templates/lettering_custom_font_dir.xml
+++ b/templates/lettering_custom_font_dir.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Custom font directory{% endtrans %}</name>
-    <id>org.inkstitch.lettering_custom_font_dir.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Custom font directory</name>
+    <id>org.inkstitch.lettering_custom_font_dir</id>
     <param name="extension" type="string" gui-hidden="true">lettering_custom_font_dir</param>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Font Management{% endtrans %}" />
+                <submenu name="Font Management" />
             </submenu>
         </effects-menu>
     </effect>
     <param name="file-description" type="description" indent="1" >
-        {% trans %}Set a custom directory for additional fonts to be used with the lettering tool.{% endtrans %}
+        Set a custom directory for additional fonts to be used with the lettering tool.
     </param>
     <spacer />
-    <param name="path" type="path" mode="folder" gui-text="{% trans %}Custom font directory{% endtrans %}"  indent="1"></param>
+    <param name="path" type="path" mode="folder" gui-text="Custom font directory"  indent="1"></param>
     <spacer />
     <param name="file-description" type="description" indent="1" >
-        {% trans %}Usage: The custom font directory must contain a subdirectory for each font.{% endtrans %}
+        Usage: The custom font directory must contain a subdirectory for each font.
     </param>
     <script>
         {{ command_tag | safe }}

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Generate JSON{% endtrans %}</name>
-    <id>org.inkstitch.lettering_generate_json.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Generate JSON</name>
+    <id>org.inkstitch.lettering_generate_json</id>
     <param name="extension" type="string" gui-hidden="true">lettering_generate_json</param>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Font Management{% endtrans %}" />
+                <submenu name="Font Management" />
             </submenu>
         </effects-menu>
     </effect>
     <param name="header" type="description" appearance="header" indent="1" >
-        {% trans %}Generates font.json which can be used by the lettering tool.{% endtrans %}
+        Generates font.json which can be used by the lettering tool.
     </param>
-    <param name="file-description" type="description" indent="1" >{% trans %}The generated file can be viewed and updated with a standard text editor tool.{% endtrans %}</param>
+    <param name="file-description" type="description" indent="1" >The generated file can be viewed and updated with a standard text editor tool.</param>
     <spacer />
     <separator indent="1"/>
     <spacer />
-    <param type="path" name="font-file" gui-text="{% trans %}SVG Font File{% endtrans %}" indent="1" mode="file" filetypes="svg"/>
+    <param type="path" name="font-file" gui-text="SVG Font File" indent="1" mode="file" filetypes="svg"/>
     <spacer />
     <separator indent="1"/>
     <spacer />
-    <param type="string" name="font-name" gui-text="{% trans %}Name{% endtrans %}" indent="1" />
-    <param type="string" name="font-description" gui-text="{% trans %}Description{% endtrans %}" indent="1" />
+    <param type="string" name="font-name" gui-text="Name" indent="1" />
+    <param type="string" name="font-description" gui-text="Description" indent="1" />
     <spacer />
     <separator indent="1"/>
     <spacer />
     <hbox>
     <vbox>
-    <param type="bool" name="auto-satin" gui-text="{% trans %}Autoroute Satin{% endtrans %}"
-           gui-description="{% trans %}Disable if you defined manual routing in your font.{% endtrans %}" indent="1">true</param>
-    <param type="bool" name="reversible" gui-text="{% trans %}Reversible{% endtrans %}"
-          gui-description='{% trans %}If disabled back and forth stitching will not be possile for this font.{% endtrans %}' indent="1">true</param>
-    <param name="letter-case" type="optiongroup" appearance="combo" gui-text="{% trans %}Force letter case{% endtrans %}" indent="1">
-             <option value="">{% trans %}No{% endtrans %}</option>
-             <option value="upper">{% trans %}Upper{% endtrans %}</option>
-             <option value="lower">{% trans %}Lower{% endtrans %}</option>
+    <param type="bool" name="auto-satin" gui-text="Autoroute Satin"
+           gui-description="Disable if you defined manual routing in your font." indent="1">true</param>
+    <param type="bool" name="reversible" gui-text="Reversible"
+          gui-description='If disabled back and forth stitching will not be possile for this font.' indent="1">true</param>
+    <param name="letter-case" type="optiongroup" appearance="combo" gui-text="Force letter case" indent="1">
+             <option value="">No</option>
+             <option value="upper">Upper</option>
+             <option value="lower">Lower</option>
     </param>
     </vbox>
     <vbox indent="20">
-    <param name="min-scale" type="float" precision="1" min="0.1" max="1" gui-text="{% trans %}Min Scale{% endtrans %}" indent="1">1</param>
-    <param name="max-scale" type="float" precision="1" min="1" max="10" gui-text="{% trans %}Max Scale{% endtrans %}" indent="1">1</param>
+    <param name="min-scale" type="float" precision="1" min="0.1" max="1" gui-text="Min Scale" indent="1">1</param>
+    <param name="max-scale" type="float" precision="1" min="1" max="10" gui-text="Max Scale" indent="1">1</param>
     </vbox>
     </hbox>
     <spacer />
-    <param type="string" name="default-glyph" gui-text="{% trans %}Default Glyph{% endtrans %}" indent="1">&#65533;</param>
+    <param type="string" name="default-glyph" gui-text="Default Glyph" indent="1">&#65533;</param>
     <spacer />
     <separator indent="1"/>
     <spacer />
-    <param name="header" type="description" appearance="header" indent="1" >{% trans %}Kerning{% endtrans %}</param>
+    <param name="header" type="description" appearance="header" indent="1" >Kerning</param>
     <param name="kering-info" type="description" indent="1" >
-        {% trans %}If your font file contains kerning information, you can completely ignore the following settings (unless you want to overwrite them).
-                   If the kerning information cannot be found, these values will apply automatically.{% endtrans %}
+        If your font file contains kerning information, you can completely ignore the following settings (unless you want to overwrite them).
+        If the kerning information cannot be found, these values will apply automatically.
     </param>
     <spacer />
     <hbox indent="1">
-    <param name="use-custom-leading" type="bool" gui-text="{% trans %}Force{% endtrans %}" indent="1"
-           gui-description="{% trans %}Overwrite leading information from font file.{% endtrans %}">false</param>
-    <param name="leading" type="int" precision="1" min="-100" max="500" gui-text="{% trans %}Leading (px){% endtrans %}"
-           gui-description="{% trans %}Line height (default: 100){% endtrans %}" indent="1">100</param>
+    <param name="use-custom-leading" type="bool" gui-text="Force" indent="1"
+           gui-description="Overwrite leading information from font file.">false</param>
+    <param name="leading" type="int" precision="1" min="-100" max="500" gui-text="Leading (px)"
+           gui-description="Line height (default: 100)" indent="1">100</param>
     </hbox>
     <spacer />
     <hbox indent="1">
-    <param name="use-custom-spacing" type="bool" gui-text="{% trans %}Force{% endtrans %}" indent="1"
-           gui-description="{% trans %}Overwrite word spacing information from font file.{% endtrans %}">false</param>    
-    <param name="word-spacing" type="int" precision="1" min="-100" max="500" gui-text="{% trans %}Word spacing (px){% endtrans %}"
-           gui-description="{% trans %}Space character width (default: 20){% endtrans %}" indent="1">20</param>
+    <param name="use-custom-spacing" type="bool" gui-text="Force" indent="1"
+           gui-description="Overwrite word spacing information from font file.">false</param>    
+    <param name="word-spacing" type="int" precision="1" min="-100" max="500" gui-text="Word spacing (px)"
+           gui-description="Space character width (default: 20)" indent="1">20</param>
      </hbox>
      <spacer />
     <separator indent="1"/>

--- a/templates/lettering_remove_kerning.xml
+++ b/templates/lettering_remove_kerning.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Remove Kerning{% endtrans %}</name>
-    <id>org.inkstitch.lettering_remove_kerning.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Remove Kerning</name>
+    <id>org.inkstitch.lettering_remove_kerning</id>
     <param name="extension" type="string" gui-hidden="true">lettering_remove_kerning</param>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Font Management{% endtrans %}" />
+                <submenu name="Font Management" />
             </submenu>
         </effects-menu>
     </effect>
     <param name="header" type="description" appearance="header" indent="1" >
-        {% trans %}Removes Kerning information from given SVG files{% endtrans %}
+        Removes Kerning information from given SVG files
     </param>
     <separator />
     <param name="file-description" type="description" indent="1" >
-        &#9888; {% trans %}Make sure you keep a copy of the original file. After running this extension kerning information will be lost unrevertably from these files.{% endtrans %}
+        &#9888; Make sure you keep a copy of the original file. After running this extension kerning information will be lost unrevertably from these files.
     </param>
     <separator />
     <spacer />
-    <param type="path" name="font-files" gui-text="{% trans %}Select Font Files{% endtrans %}" indent="1" mode="files" filetypes="svg"/>
+    <param type="path" name="font-files" gui-text="Select Font Files" indent="1" mode="files" filetypes="svg"/>
     <spacer />
     <script>
         {{ command_tag | safe }}

--- a/templates/object_commands.xml
+++ b/templates/object_commands.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Attach Commands to Selected Objects{% endtrans %}</name>
-    <id>org.inkstitch.commands.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Attach Commands to Selected Objects</name>
+    <id>org.inkstitch.commands</id>
     {% for command, description in object_commands %}
     <param name="{{ command }}" type="boolean" _gui-text="{{ _(description ) }}">false</param>
     {% endfor %}
@@ -10,7 +10,7 @@
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Commands{% endtrans %}" />
+                <submenu name="Commands" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/output.xml
+++ b/templates/output.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <name>{{ format | upper }} file output</name>
-    <id>org.inkstitch.output.{{ format }}.{{ locale }}</id>
+    <id>org.inkstitch.output.{{ format }}</id>
     <output>
         <extension>.{{ format }}</extension>
         <mimetype>{{ mimetype }}</mimetype>

--- a/templates/params.xml
+++ b/templates/params.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Params{% endtrans %}</name>
-    <id>org.inkstitch.params.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Params</name>
+    <id>org.inkstitch.params</id>
     <param name="extension" type="string" gui-hidden="true">params</param>
     <effect implements-custom-gui="true">
         <object-type>all</object-type>

--- a/templates/print.xml
+++ b/templates/print.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}PDF Export{% endtrans %}</name>
-    <id>org.inkstitch.print.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>PDF Export</name>
+    <id>org.inkstitch.print</id>
     <param name="extension" type="string" gui-hidden="true">print</param>
     <effect implements-custom-gui="true">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Visualise and Export{% endtrans %}" />
+                <submenu name="Visualise and Export" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/remove_embroidery_settings.xml
+++ b/templates/remove_embroidery_settings.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Remove embroidery settings{% endtrans %}</name>
-    <id>org.inkstitch.remove_embroidery_settings.{{ locale }}</id>
-    <param name="description" type="description">{% trans %}Use this extension to remove the information Ink/Stitch has stored in your document.  This can be especially useful if you copy and paste objects from an embroidery design into another document.{% endtrans %}</param>
-    <param name="del_params" type="boolean" _gui-text="{% trans %}Remove Params{% endtrans %}"
-           _gui-description="{% trans %}Removes params from selected objects or all objects if nothing is selected.{% endtrans %}">true</param>
-    <param name="del_commands" type="boolean" _gui-text="{% trans %}Remove Commands{% endtrans %}"
-           _gui-description="{% trans %}Removes visual commands from selected objects or all objects if nothing is selected.{% endtrans %}">false</param>
-    <param name="del_print" type="boolean" _gui-text="{% trans %}Remove Print Settings from SVG metadata{% endtrans %}">false</param>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Remove embroidery settings</name>
+    <id>org.inkstitch.remove_embroidery_settings</id>
+    <param name="description" type="description">Use this extension to remove the information Ink/Stitch has stored in your document.  This can be especially useful if you copy and paste objects from an embroidery design into another document.</param>
+    <param name="del_params" type="boolean" _gui-text="Remove Params"
+           _gui-description="Removes params from selected objects or all objects if nothing is selected.">true</param>
+    <param name="del_commands" type="boolean" _gui-text="Remove Commands"
+           _gui-description="Removes visual commands from selected objects or all objects if nothing is selected.">false</param>
+    <param name="del_print" type="boolean" _gui-text="Remove Print Settings from SVG metadata">false</param>
     <param name="extension" type="string" gui-hidden="true">remove_embroidery_settings</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Troubleshoot{% endtrans %}" />
+                <submenu name="Troubleshoot" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/reorder.xml
+++ b/templates/reorder.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Re-stack objects in order of selection{% endtrans %}</name>
-    <id>org.inkstitch.reorder.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Re-stack objects in order of selection</name>
+    <id>org.inkstitch.reorder</id>
     <param name="extension" type="string" gui-hidden="true">reorder</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Edit{% endtrans %}" />
+                <submenu name="Edit" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/selection_to_pattern.xml
+++ b/templates/selection_to_pattern.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Selection to pattern{% endtrans %}</name>
-    <id>org.inkstitch.selection_to_pattern.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Selection to pattern</name>
+    <id>org.inkstitch.selection_to_pattern</id>
     <param name="extension" type="string" gui-hidden="true">selection_to_pattern</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Edit{% endtrans %}" />
+                <submenu name="Edit" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/simulator.xml
+++ b/templates/simulator.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Simulator / Realistic Preview{% endtrans %}</name>
-    <id>org.inkstitch.simulator.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Simulator / Realistic Preview</name>
+    <id>org.inkstitch.simulator</id>
     <param name="extension" type="string" gui-hidden="true">simulator</param>
     <effect implements-custom-gui="true">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Visualise and Export{% endtrans %}" />
+                <submenu name="Visualise and Export" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Stitch Plan Preview{% endtrans %}</name>
-    <id>org.inkstitch.stitch_plan_preview.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Stitch Plan Preview</name>
+    <id>org.inkstitch.stitch_plan_preview</id>
     <param name="extension" type="string" gui-hidden="true">stitch_plan_preview</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Visualise and Export{% endtrans %}" />
+                <submenu name="Visualise and Export" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/troubleshoot.xml
+++ b/templates/troubleshoot.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>{% trans %}Troubleshoot Objects{% endtrans %}</name>
-    <id>org.inkstitch.troubleshoot.{{ locale }}</id>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Troubleshoot Objects</name>
+    <id>org.inkstitch.troubleshoot</id>
     <param name="extension" type="string" gui-hidden="true">troubleshoot</param>
     <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch">
-                <submenu name="{% trans %}Troubleshoot{% endtrans %}" />
+                <submenu name="Troubleshoot" />
             </submenu>
         </effects-menu>
     </effect>

--- a/templates/zip.xml
+++ b/templates/zip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <name>embroidery ZIP file output</name>
-    <id>org.inkstitch.output.zip.{{ locale }}</id>
+    <id>org.inkstitch.output.zip</id>
     <output>
         <extension>.zip</extension>
         <mimetype>application/zip</mimetype>


### PR DESCRIPTION
Inkscape 1.0 comes with a great opportunity for us. We do not have to release various versions with translated inx files anymore.
Inkscape will accept custom translation files now. It is still undocumented, so I wasn't aware of it during the Inkscape 1.0 update.

This is a bit of a lazy edit. I simply copied the locales into the inx folder (where Inkscape needs them to be) and left the old version untouched. So we have a duplication of the translation files in the release. I don't know if this should be improved?!? Inkscape will not allow us to use e.g. "de_DE" but requires the folder name "de" instead.