### PR TITLE
Tie info got lost

### DIFF
--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -119,7 +119,10 @@ class ColorBlock(object):
                 raise ValueError("internal error: can't add a command to an empty stitch block")
             self.stitches.append(Stitch(*args, **kwargs))
         if isinstance(args[0], Stitch):
-            self.stitches.append(args[0])
+            stitch = args[0]
+            stitch.tie_modus = kwargs.get('tie_modus', 0)
+            stitch.no_ties = kwargs.get('no_ties', False)
+            self.stitches.append(stitch)
         elif isinstance(args[0], Point):
             self.stitches.append(Stitch(args[0].x, args[0].y, *args[1:], **kwargs))
 

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -119,10 +119,7 @@ class ColorBlock(object):
                 raise ValueError("internal error: can't add a command to an empty stitch block")
             self.stitches.append(Stitch(*args, **kwargs))
         if isinstance(args[0], Stitch):
-            stitch = args[0]
-            stitch.tie_modus = kwargs.get('tie_modus', 0)
-            stitch.no_ties = kwargs.get('no_ties', False)
-            self.stitches.append(stitch)
+            self.stitches.append(Stitch(*args, **kwargs))
         elif isinstance(args[0], Point):
             self.stitches.append(Stitch(args[0].x, args[0].y, *args[1:], **kwargs))
 


### PR DESCRIPTION
As mentioned in https://github.com/inkstitch/inkstitch/pull/1312#issuecomment-931353034 it wasn't possible to turn off the ties anymore. This should fix it. I am not sure, if this is the right way to do it - or if there is a more automatic way, so we don't have to care about this piece of code when we add more "kwargs" at a later time @lexelby ?