### PR TITLE
Documentation: Localize page Code of Conduct hyperlink corrected

### DIFF
--- a/collections/_developers/de/005-001-localize.md
+++ b/collections/_developers/de/005-001-localize.md
@@ -2,7 +2,7 @@
 title: "Übersetzungen"
 permalink: /de/developers/localize/
 excerpt: ""
-last_modified_at: 2021-01-31
+last_modified_at: 2021-10-03
 toc: true
 ---
 Das Ziel des Ink/Stitch-Projektes ist es, hochwertige Werkzeuge zur Erstellung von Stickdesigns in die Hände von Menschen zu geben, die sonst keinen Zugriff auf solche Werkzeuge hätten.
@@ -26,7 +26,7 @@ Um mit dem Übersetzen zu beginnen, besuche unsere [Projektseite bei CrowdIn](ht
 
 Bestätigte Teammitglieder können deine Übersetzung dann akzeptieren, womit sie dann innerhalb von 24 Stunden in das Ink/Stitch GitHub Repository übernommen werden.  Wenn du gerne vorhandene Übersetzungen bestätigen willst, wende dich an uns über [GitHub](https://github.com/inkstitch/inkstitch/issues/).
 
-**Bitte beachte, dass unsere [Verhaltensregeln](CODE_OF_CONDUCT.md) auch für Interaktionen auf unserer CrowdIn Seite gelten.**
+**Bitte beachte, dass unsere [Verhaltensregeln](https://github.com/inkstitch/inkstitch/blob/main/CODE_OF_CONDUCT.md) auch für Interaktionen auf unserer CrowdIn Seite gelten.**
 
 ### Kontinuierliche Übersetzungen
 

--- a/collections/_developers/en/005-001-localize.md
+++ b/collections/_developers/en/005-001-localize.md
@@ -2,7 +2,7 @@
 title: "Localization"
 permalink: /developers/localize/
 excerpt: ""
-last_modified_at: 2021-01-31
+last_modified_at: 2021-10-03
 toc: true
 ---
 The goal of the Ink/Stitch project is to put free, high-quality embroidery design tools in the hands of folks that might normally not have access to such tools.  To further that goal, we seek to support as many languages and locales as possible.
@@ -25,7 +25,7 @@ To start translating, visit our [project page on Crowdin](https://translate.inks
 
 Approved contributors can accept your translations, which causes them to be committed to this repository within 24 hours.  If you'd like to become an approver, please contact us on [GitHub](https://github.com/inkstitch/inkstitch/issues).
 
-**Please note that our [code of conduct](CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
+**Please note that our [code of conduct](https://github.com/inkstitch/inkstitch/blob/main/CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
 
 ### Continuous Translation
 

--- a/collections/_developers/fr/005-001-localize.md
+++ b/collections/_developers/fr/005-001-localize.md
@@ -2,7 +2,7 @@
 title: "Localization"
 permalink: /fr/developers/localize/
 excerpt: ""
-last_modified_at: 2019-08-19
+last_modified_at: 2021-10-03
 toc: true
 ---
 The goal of the Ink/Stitch project is to put free, high-quality embroidery design tools in the hands of folks that might normally not have access to such tools.  To further that goal, we seek to support as many languages and locales as possible.
@@ -25,7 +25,7 @@ To start translating, visit our [project page on Crowdin](https://translate.inks
 
 Approved contributors can accept your translations, which causes them to be committed to this repository within 24 hours.  If you'd like to become an approver, please contact us on [GitHub](https://github.com/inkstitch/inkstitch/issues).
 
-**Please note that our [code of conduct](CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
+**Please note that our [code of conduct](https://github.com/inkstitch/inkstitch/blob/main/CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
 
 ### Continuous Translation
 

--- a/collections/_developers/ru/005-001-localize.md
+++ b/collections/_developers/ru/005-001-localize.md
@@ -2,7 +2,7 @@
 title: "Localization"
 permalink: /ru/developers/localize/
 excerpt: ""
-last_modified_at: 2021-01-31
+last_modified_at: 2021-10-03
 toc: true
 ---
 The goal of the Ink/Stitch project is to put free, high-quality embroidery design tools in the hands of folks that might normally not have access to such tools.  To further that goal, we seek to support as many languages and locales as possible.
@@ -25,7 +25,7 @@ To start translating, visit our [project page on Crowdin](https://translate.inks
 
 Approved contributors can accept your translations, which causes them to be committed to this repository within 24 hours.  If you'd like to become an approver, please contact us on [GitHub](https://github.com/inkstitch/inkstitch/issues).
 
-**Please note that our [code of conduct](CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
+**Please note that our [code of conduct](https://github.com/inkstitch/inkstitch/blob/main/CODE_OF_CONDUCT.md) also covers contributions and interactions on our Crowdin page.**
 
 ### Continuous Translation
 


### PR DESCRIPTION
Hello,

I was looking through the documentation for Ink/Stitch and found out the Code of Conduct hyperlink on the Localize page went to a 404, so I changed it to point to the copy located in the main branch of the Ink/Stitch.

Let me know if any modifications are needed.