### PR TITLE
Do not render clipPath and mask

### DIFF
--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -147,12 +147,9 @@ class InkstitchExtension(inkex.Effect):
         if (node.tag in EMBROIDERABLE_TAGS or node.tag == SVG_GROUP_TAG) and element.get_style('display', 'inline') is None:
             return []
 
-        if node.tag == SVG_DEFS_TAG:
-            return []
-
-        # masks and clippaths contain embroiderable elements
-        # but should never be rendered directly
-        if node.tag == SVG_MASK_TAG or node.tag == SVG_CLIPPATH_TAG:
+        # defs, masks and clippaths can contain embroiderable elements
+        # but should never be rendered directly.
+        if node.tag in [SVG_DEFS_TAG, SVG_MASK_TAG, SVG_CLIPPATH_TAG]:
             return []
 
         # command connectors with a fill color set, will glitch into the elements list

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -11,6 +11,7 @@ inkex.NSS['inkstitch'] = 'http://inkstitch.org/namespace'
 
 SVG_PATH_TAG = inkex.addNS('path', 'svg')
 SVG_POLYLINE_TAG = inkex.addNS('polyline', 'svg')
+SVG_POLYGON_TAG = inkex.addNS('polygon', 'svg')
 SVG_RECT_TAG = inkex.addNS('rect', 'svg')
 SVG_ELLIPSE_TAG = inkex.addNS('ellipse', 'svg')
 SVG_CIRCLE_TAG = inkex.addNS('circle', 'svg')
@@ -39,7 +40,8 @@ SODIPODI_ROLE = inkex.addNS('role', 'sodipodi')
 
 INKSTITCH_LETTERING = inkex.addNS('lettering', 'inkstitch')
 
-EMBROIDERABLE_TAGS = (SVG_PATH_TAG, SVG_POLYLINE_TAG, SVG_RECT_TAG, SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG)
+EMBROIDERABLE_TAGS = (SVG_PATH_TAG, SVG_POLYLINE_TAG, SVG_POLYGON_TAG,
+                      SVG_RECT_TAG, SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG)
 NOT_EMBROIDERABLE_TAGS = (SVG_IMAGE_TAG, SVG_TEXT_TAG)
 SVG_OBJECT_TAGS = (SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG, SVG_RECT_TAG)
 


### PR DESCRIPTION
Fixes #1338

In the mentioned issue we noticed, that Ink/Stitch also renders clipPath elements. This is not wanted behaviour, since they should never be rendered. This PR will make Ink/Stitch ignore clipPath and masks. It will not apply them to the elements as they should. This can be part of an other pull request at a later time. The clipPath can be easily accessed via node.clip. But we need to handle the path and transforms correctly etc. So I'd say let's save it for an other day.