### PR TITLE
Estimated thread

### DIFF
--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -281,7 +281,7 @@ class Print(InkstitchExtension):
                 'num_trims': stitch_plan.num_trims,
                 'dimensions': stitch_plan.dimensions_mm,
                 'num_stitches': stitch_plan.num_stitches,
-                'estimated_thread': '',  # TODO
+                'estimated_thread': stitch_plan.estimated_thread
             },
             svg_overview=overview_svg,
             color_blocks=stitch_plan.color_blocks,

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -63,6 +63,15 @@ class ColorBlock(object):
         return len(self.stitches)
 
     @property
+    def estimated_thread(self):
+        previous_stitch = self.stitches[0]
+        length = 0
+        for stitch in self.stitches[1:]:
+            length += (stitch - previous_stitch).length()
+            previous_stitch = stitch
+        return length
+
+    @property
     def num_trims(self):
         """Number of trims in this color block."""
 

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -110,7 +110,8 @@ class StitchPlan(object):
                     num_stops=self.num_stops,
                     num_trims=self.num_trims,
                     num_stitches=self.num_stitches,
-                    bounding_box=self.bounding_box
+                    bounding_box=self.bounding_box,
+                    estimated_thread=self.estimated_thread
                     )
 
     @property
@@ -143,6 +144,11 @@ class StitchPlan(object):
         maxy = max(bb[3] for bb in color_block_bounding_boxes)
 
         return minx, miny, maxx, maxy
+
+    @property
+    def estimated_thread(self):
+        thread_meter = sum(block.estimated_thread for block in self) / PIXELS_PER_MM / 1000
+        return round(thread_meter, 2)
 
     @property
     def dimensions(self):

--- a/print/resources/inkstitch.js
+++ b/print/resources/inkstitch.js
@@ -147,7 +147,7 @@ function writeEstimatedTime( selector, estimatedTime ) {
 }
 
 function setEstimatedThread() {
-  var multiplyThread = ($('#multiply-thread').val() == '') ? 0 : parseInt($('#multiply-thread').val());
+  var multiplyThread = ($('#multiply-thread').val() == '') ? 2 : parseInt($('#multiply-thread').val());
   var estimatedThread = (parseFloat($('#estimated-thread').text()) * multiplyThread).toFixed(2);
   $('.total-estimated-thread').each(function(index, item) {
     $(this).text(estimatedThread + "m");
@@ -700,6 +700,7 @@ $(function() {
 
   setTimeout(function() {
     setEstimatedTime();
+    setEstimatedThread();
   }, 100);
 
   $('button.svg-realistic').click(function(e){
@@ -744,6 +745,8 @@ $(function() {
     settings["time-cld"] = $("[data-field-name='time-cld']").val();
     settings["time-opo"] = $("[data-field-name='time-opo']").val();
     settings["time-opd"] = $("[data-field-name='time-opd']").val();
+
+    settings["multiply-thread"] = $("[data-field-name='multiply-thread']").val();
 
     $.postJSON('/defaults', {'value': settings});
   });

--- a/print/resources/inkstitch.js
+++ b/print/resources/inkstitch.js
@@ -146,6 +146,14 @@ function writeEstimatedTime( selector, estimatedTime ) {
   $(selector).text( hours + ':' + minutes + ':' + seconds );
 }
 
+function setEstimatedThread() {
+  var multiplyThread = ($('#multiply-thread').val() == '') ? 0 : parseInt($('#multiply-thread').val());
+  var estimatedThread = (parseFloat($('#estimated-thread').text()) * multiplyThread).toFixed(2);
+  $('.total-estimated-thread').each(function(index, item) {
+    $(this).text(estimatedThread + "m");
+  })
+}
+
 // Scale SVG (fit || full size)
 function scaleSVG(element, scale = 'fit') {
 
@@ -594,6 +602,14 @@ $(function() {
     var select = $("select#thread-palette");
     select.find('[value="' + select.data('current-value') + '"]').prop('selected', true);
     $('.modal').hide();
+  });
+
+  // Estimated Thread
+  $('#multiply-thread').on('input initialize', function() {
+    setEstimatedThread();
+  }).on('change', function() {
+    var field_name = $(this).attr('data-field-name');
+    $.postJSON('/settings/' + field_name, {value: $(this).val()});
   });
 
   // View selection checkboxes

--- a/print/resources/inkstitch.js
+++ b/print/resources/inkstitch.js
@@ -149,8 +149,10 @@ function writeEstimatedTime( selector, estimatedTime ) {
 function setEstimatedThread() {
   var multiplyThread = ($('#multiply-thread').val() == '') ? 2 : parseInt($('#multiply-thread').val());
   var estimatedThread = (parseFloat($('#estimated-thread').text()) * multiplyThread).toFixed(2);
+  var multiplyBobbin = ($('#multiply-bobbin').val() == '') ? 1 : parseInt($('#multiply-bobbin').val());
+  var estimatedBobbin = (parseFloat($('#estimated-thread').text()) * multiplyBobbin).toFixed(2);
   $('.total-estimated-thread').each(function(index, item) {
-    $(this).text(estimatedThread + "m");
+    $(this).text(estimatedThread + "m / " + estimatedBobbin + "m");
   })
 }
 
@@ -604,8 +606,14 @@ $(function() {
     $('.modal').hide();
   });
 
-  // Estimated Thread
+  // Estimated thread and bobbin
   $('#multiply-thread').on('input initialize', function() {
+    setEstimatedThread();
+  }).on('change', function() {
+    var field_name = $(this).attr('data-field-name');
+    $.postJSON('/settings/' + field_name, {value: $(this).val()});
+  });
+  $('#multiply-bobbin').on('input initialize', function() {
     setEstimatedThread();
   }).on('change', function() {
     var field_name = $(this).attr('data-field-name');

--- a/print/templates/operator_overview.html
+++ b/print/templates/operator_overview.html
@@ -12,8 +12,9 @@
                 <div>
                     <div class="table">
                       <p><span>{{ _('Design box size') }}:</span><span>{{ "%0.1fmm X %0.1fmm" | format(*job.dimensions) }}</span></p>
-                      <p><span>{{ _('Total stitch count') }}:</span><span>{{job.num_stitches }}</span></p>
-                      <p><span>{{ _('Total thread used') }}:</span><span>{{job.total_thread_used }}</span></p>
+                      <p><span>{{ _('Total stitch count') }}:</span><span>{{ job.num_stitches }}</span></p>
+                      <p><span>{{ _('Total thread used') }}:</span><span class="total-estimated-thread"></span></p>
+                      <p style="display:none;" id="estimated-thread">{{ job.estimated_thread }}</p>
                     </div>
                 </div>
                 <div>

--- a/print/templates/print_overview.html
+++ b/print/templates/print_overview.html
@@ -13,7 +13,7 @@
                     <div class="table">
                       <p><span>{{ _('Design box size') }}:</span><span>{{ "%0.1fmm X %0.1fmm" | format(*job.dimensions) }}</span></p>
                       <p><span>{{ _('Total stitch count') }}:</span><span>{{job.num_stitches }}</span></p>
-                      <p><span>{{ _('Total thread used') }}:</span><span>{{job.estimated_thread }}</span></p>
+                      <p><span>{{ _('Total thread used') }}:</span><span class="total-estimated-thread"></span></p>
                     </div>
                 </div>
                 <div>

--- a/print/templates/ui.html
+++ b/print/templates/ui.html
@@ -151,7 +151,7 @@
              Ink/Stitch simply calculates the path length, so the factor of 1 will always be much, much less than the real thread consumption.') }}</p>
           <p>{{ _('Set a factor to multiply the path length with, depending on your standard setup or adapt it to your current design (tension, thread, fabric, stitch count, etc.).') }}</p>
           <p>
-              <input type="number" id="multiply-thread" data-field-name="multiply-thread" min="1" value="1" />
+              <input type="number" id="multiply-thread" data-field-name="multiply-thread" min="1" value="2" />
               <label for="multiply-thread" title="{{ _('Factor to multiply with thread length') }}">{{ _('* path length') }}</label>
           </p>
         </fieldset>

--- a/print/templates/ui.html
+++ b/print/templates/ui.html
@@ -19,6 +19,7 @@
         <button class="tab active">{{ _('Page Setup') }}</button>
         <button class="tab" id="branding-tab">{{ _('Branding') }}</button>
         <button class="tab">{{ _('Estimated Time') }}</button>
+        <button class="tab">{{ _('Estimated Thread') }}</button>
         <button class="tab">{{ _('Design') }}</button>
       </div>
 
@@ -138,6 +139,21 @@
             <p><input type="checkbox" class="time-display" id="time-opo" data-field-name="time-opo" CHECKED /><label for="time-opo">{{ _('Operator Overview') }}</label></p>
             <p><input type="checkbox" class="time-display" id="time-opd" data-field-name="time-opd" CHECKED /><label for="time-opd">{{ _('Operator Detailed View') }}</label></p>
           </div>
+        </fieldset>
+        <button class="save-settings" title="{{ _('Includes page setup, estimated time and also the branding.') }}">{{ _("Save as defaults") }}</button>
+      </fieldset>
+
+      <fieldset id="ui-time" class="ui-tab">
+        <legend>{{ _('Estimated Thread') }}</legend>
+        <fieldset>
+          <legend>{{ _('Factors') }}</legend>
+          <p>{{ _('The thread length calculation depends on a lot of factors in embroidery designs. We will only get a very inacurate approximation.
+             Ink/Stitch simply calculates the path length, so the factor of 1 will always be much, much less than the real thread consumption.') }}</p>
+          <p>{{ _('Set a factor to multiply the path length with, depending on your standard setup or adapt it to your current design (tension, thread, fabric, stitch count, etc.).') }}</p>
+          <p>
+              <input type="number" id="multiply-thread" data-field-name="multiply-thread" min="1" value="1" />
+              <label for="multiply-thread" title="{{ _('Factor to multiply with thread length') }}">{{ _('* path length') }}</label>
+          </p>
         </fieldset>
         <button class="save-settings" title="{{ _('Includes page setup, estimated time and also the branding.') }}">{{ _("Save as defaults") }}</button>
       </fieldset>

--- a/print/templates/ui.html
+++ b/print/templates/ui.html
@@ -150,9 +150,15 @@
           <p>{{ _('The thread length calculation depends on a lot of factors in embroidery designs. We will only get a very inacurate approximation.
              Ink/Stitch simply calculates the path length, so the factor of 1 will always be much, much less than the real thread consumption.') }}</p>
           <p>{{ _('Set a factor to multiply the path length with, depending on your standard setup or adapt it to your current design (tension, thread, fabric, stitch count, etc.).') }}</p>
+          <p><b>Upper thread</b></p>
           <p>
               <input type="number" id="multiply-thread" data-field-name="multiply-thread" min="1" value="2" />
               <label for="multiply-thread" title="{{ _('Factor to multiply with thread length') }}">{{ _('* path length') }}</label>
+          </p>
+          <p><b>Bobbin</b></p>
+          <p>
+              <input type="number" id="multiply-bobbin" data-field-name="multiply-bobbin" min="1" value="1" />
+              <label for="multiply-bobbin" title="{{ _('Factor to multiply with thread length') }}">{{ _('* path length') }}</label>
           </p>
         </fieldset>
         <button class="save-settings" title="{{ _('Includes page setup, estimated time and also the branding.') }}">{{ _("Save as defaults") }}</button>


### PR DESCRIPTION
Targets #340 and #1326

This is a first attempt to include the thread length into the print pdf output.
For now it is as simple as calculating the path length. It is also possible to set a multiply factor in the settings.
I don't think leaving the factor at 1 is a good standard. But I am uncertain which number to use instead.
Also I am not sure if we should add just a little more math. E.g. the stitch count is accessible.

@lexelby @wwderw @Nitrama