### PR TITLE
No error on color gradients

### DIFF
--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -15,6 +15,10 @@ class ThreadColor(object):
     hex_str_re = re.compile('#([0-9a-z]{3}|[0-9a-z]{6})', re.I)
 
     def __init__(self, color, name=None, number=None, manufacturer=None):
+        # set colors with a gradient to black (avoiding an error message)
+        if type(color) == str and color.startswith('url'):
+            color = None
+
         if color is None:
             self.rgb = (0, 0, 0)
         elif isinstance(color, EmbThread):


### PR DESCRIPTION
If a color gradient is set to any object Ink/Stitch puts out a traceback. On our track to avoid as many error messages and tracebacks as possible, this PR will simply set color gradients to a black color.

In a next step we could give a color warning in troubleshoot objects, but this should better be done after the electron params are finished.