### PR TITLE
Use shapely version 1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 backports.functools_lru_cache
 wxPython
 networkx
-shapely
+shapely<=1.7.1
 lxml
 appdirs
 numpy<=1.17.4


### PR DESCRIPTION
With shapely 1.8.0 we will be facing a lot of deprecation warnings. There are a lot of files being worked on in other branches. So I think it would be best to stay with shapely 1.7.1 until we are done with those.