### PR TITLE
Add stitch plan options

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -3,12 +3,23 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from inkex import Boolean
+from lxml import etree
+
 from ..stitch_plan import stitch_groups_to_stitch_plan
 from ..svg import render_stitch_plan
+from ..svg.tags import (INKSCAPE_GROUPMODE, SVG_DEFS_TAG, SVG_GROUP_TAG,
+                        SVG_PATH_TAG)
 from .base import InkstitchExtension
 
 
 class StitchPlanPreview(InkstitchExtension):
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-s", "--move-to-side", type=Boolean, default=True, dest="move_to_side")
+        self.arg_parser.add_argument("-v", "--layer-visibility", type=int, default=0, dest="layer_visibility")
+        self.arg_parser.add_argument("-n", "--needle-points", type=Boolean, default=False, dest="needle_points")
+
     def effect(self):
         # delete old stitch plan
         svg = self.document.getroot()
@@ -27,6 +38,49 @@ class StitchPlanPreview(InkstitchExtension):
         stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len)
         render_stitch_plan(svg, stitch_plan, realistic)
 
-        # translate stitch plan to the right side of the canvas
+        # apply options
         layer = svg.find(".//*[@id='__inkstitch_stitch_plan__']")
-        layer.set('transform', 'translate(%s)' % svg.get('viewBox', '0 0 800 0').split(' ')[2])
+
+        # update layer visibilty 0 = unchanged, 1 = hidden, 2 = lower opacity
+        if self.options.layer_visibility == 1:
+            self.hide_all_layers()
+            layer.set('style', None)
+
+        if self.options.layer_visibility == 2:
+            for g in self.document.getroot().findall(SVG_GROUP_TAG):
+                if g.get(INKSCAPE_GROUPMODE) == "layer" and not g == layer:
+                    g.set("style", "opacity:0.4")
+
+        # translate stitch plan to the right side of the canvas
+        if self.options.move_to_side:
+            layer.set('transform', 'translate(%s)' % svg.get('viewBox', '0 0 800 0').split(' ')[2])
+        else:
+            layer.set('transform', None)
+
+        # display needle points
+        if self.options.needle_points:
+            markers = 'marker-mid:url(#inkstitch-needle-point);marker-start:url(#inkstitch-needle-point);marker-end:url(#inkstitch-needle-point)'
+            for element in layer.iterdescendants(SVG_PATH_TAG):
+                style = ';'.join([element.get('style'), markers])
+                element.set('style', style)
+            self.ensure_marker()
+
+    def ensure_marker(self):
+        xpath = ".//svg:marker[@id='inkstitch-needle-point']"
+        point_marker = self.document.getroot().xpath(xpath)
+
+        if not point_marker:
+            # get or create def element
+            defs = self.document.find(SVG_DEFS_TAG)
+            if defs is None:
+                defs = etree.SubElement(self.document, SVG_DEFS_TAG)
+
+            # insert marker
+            marker = """<marker
+                      orient="auto"
+                      id="inkstitch-needle-point">
+                         <circle
+                                 cx="0" cy="0" r="1.5"
+                                 style="fill:context-stroke;opacity:0.8;" />
+                     </marker>"""
+            defs.append(etree.fromstring(marker))

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -11,6 +11,15 @@
             </submenu>
         </effects-menu>
     </effect>
+    <param name="move-to-side" type="boolean" gui-text="Move stitch plan beside the canvas">true</param>
+    <param name="layer-visibility" type="optiongroup" appearance="combo" gui-text="Design layer visibity">
+        <option value="0">Unchanged</option>
+        <option value="1">Hidden</option>
+        <option value="2">Lower opacity</option>
+    </param>
+    <param name="needle-points" type="boolean" gui-text="Needle points">false</param>
+    <separator />
+    <label>Hit Ctrl+Z to undo this action after inspection.</label>
     <script>
         {{ command_tag | safe }}
     </script>


### PR DESCRIPTION
Adds the following options to the stitch plan output:

* move stitch plan to the side of the canvas (or not)
* layer visibility: unchanged / hidden / lower opacity
* display needle points

I've heard not everyone likes it to have to scroll over to the side of the canvas. Some would like to render it in place. But we cannot just put it on top of the visible design, therefore the other options. Shortcut key combination can be used to always call it directly with the prefered options without having to click through the options everytime (when set to "no preferences") in the Inkscape settings, so these options don't necessary slow down the process of quickly having a look at the design outcome.

It will not just hide/lower opacity for selected objects, but the whole design, I think that is ok (plus I have been a little bit lazy about it) since users will have to undo this action afterwards anyway. Also it is easier to distinguish the original design from the output this way.