### PR TITLE
shapely 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 backports.functools_lru_cache
 wxPython
 networkx
-shapely<=1.7.1
+shapely<=1.7.0
 lxml
 appdirs
 numpy<=1.17.4


### PR DESCRIPTION
Turns out the break apart function needs in its current state shapely 1.7.0 not 1.7.1