### PR TITLE
Releases: suppress warnings

### DIFF
--- a/inkstitch.py
+++ b/inkstitch.py
@@ -29,6 +29,11 @@ from lib import extensions
 from lib.i18n import _
 from lib.utils import restore_stderr, save_stderr, version
 
+# ignore warnings in releases
+if getattr(sys, 'frozen', None):
+    import warnings
+    warnings.filterwarnings('ignore')
+
 logger = logging.getLogger('shapely.geos')
 logger.setLevel(logging.DEBUG)
 shapely_errors = StringIO()


### PR DESCRIPTION
There is this wxpython warning for the scrolledpanel showing up in macOS releases.
Releases should not be showing warnings.
@lexelby is that how we do it? You can update this branch if you like.