### PR TITLE
Shapely update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml
-          pip uninstall shapely
+          pip uninstall --yes shapely
           pip install -U Shapely==1.8.0 --no-binary Shapely
           pip install pyinstaller
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,8 @@ jobs:
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml
-          pip install -U Shapely==1.7.1 --no-binary Shapely
+          pip uninstall shapely
+          pip install -U Shapely==1.8.0 --no-binary Shapely
           pip install pyinstaller
 
           echo "${{ env.pythonLocation }}/bin" >> $GITHUB_PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 backports.functools_lru_cache
 wxPython
 networkx
-shapely<=1.7.0
+shapely==1.8.0
 lxml
 appdirs
 numpy<=1.17.4


### PR DESCRIPTION
Update shapely to 1.8.0
This will throw a lot of deprecation warning, but since we suppress them in the release it should work.
This is the only version that we can get to work properly on all operating systems.