### PR TITLE
Markers to lettering

### DIFF
--- a/lib/extensions/selection_to_pattern.py
+++ b/lib/extensions/selection_to_pattern.py
@@ -4,10 +4,10 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import inkex
-from lxml import etree
 
 from ..i18n import _
-from ..svg.tags import EMBROIDERABLE_TAGS, SVG_DEFS_TAG
+from ..marker import set_marker
+from ..svg.tags import EMBROIDERABLE_TAGS
 from .base import InkstitchExtension
 
 
@@ -23,41 +23,4 @@ class SelectionToPattern(InkstitchExtension):
 
         for pattern in self.get_nodes():
             if pattern.tag in EMBROIDERABLE_TAGS:
-                self.set_marker(pattern)
-
-    def set_marker(self, node):
-        xpath = ".//marker[@id='inkstitch-pattern-marker']"
-        pattern_marker = self.document.xpath(xpath)
-
-        if not pattern_marker:
-            # get or create def element
-            defs = self.document.find(SVG_DEFS_TAG)
-            if defs is None:
-                defs = etree.SubElement(self.document, SVG_DEFS_TAG)
-
-            # insert marker
-            marker = """<marker
-                      refX="10"
-                      refY="5"
-                      orient="auto"
-                      id="inkstitch-pattern-marker">
-                     <g
-                        id="inkstitch-pattern-group">
-                       <path
-                          style="fill:#fafafa;stroke:#ff5500;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1;fill-opacity:0.8;"
-                          d="M 10.12911,5.2916678 A 4.8374424,4.8374426 0 0 1 5.2916656,10.12911 4.8374424,4.8374426 0 0 1 0.45422399,5.2916678 4.8374424,4.8374426 0 0 1 5.2916656,0.45422399 4.8374424,4.8374426 0 0 1 10.12911,5.2916678 Z"
-                          id="inkstitch-pattern-marker-circle" />
-                       <path
-                          style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-miterlimit:4;"
-                          id="inkstitch-pattern-marker-spiral"
-                          d="M 4.9673651,5.7245662 C 4.7549848,5.7646159 4.6247356,5.522384 4.6430021,5.3419847 4.6765851,5.0103151 5.036231,4.835347 5.3381858,4.8987426 5.7863901,4.9928495 6.0126802,5.4853625 5.9002872,5.9065088 5.7495249,6.4714237 5.1195537,6.7504036 4.5799191,6.5874894 3.898118,6.3816539 3.5659013,5.6122905 3.7800789,4.9545192 4.0402258,4.1556558 4.9498996,3.7699484 5.7256318,4.035839 6.6416744,4.3498087 7.0810483,5.4003986 6.7631909,6.2939744 6.395633,7.3272552 5.2038143,7.8204128 4.1924535,7.4503931 3.0418762,7.0294421 2.4948761,5.6961604 2.9171752,4.567073 3.3914021,3.2991406 4.8663228,2.6982592 6.1130974,3.1729158 7.4983851,3.7003207 8.1531869,5.3169977 7.6260947,6.6814205 7.0456093,8.1841025 5.2870784,8.8928844 3.8050073,8.3132966 2.1849115,7.6797506 1.4221671,5.7793073 2.0542715,4.1796074 2.7408201,2.4420977 4.7832541,1.6253548 6.5005435,2.310012 8.3554869,3.0495434 9.2262638,5.2339874 8.4890181,7.0688861 8.4256397,7.2266036 8.3515789,7.379984 8.2675333,7.5277183" />
-                     </g>
-                     </marker>"""  # noqa: E501
-            defs.append(etree.fromstring(marker))
-
-        # attach marker to node
-        style = node.get('style') or ''
-        style = style.split(";")
-        style = [i for i in style if not i.startswith('marker-start')]
-        style.append('marker-start:url(#inkstitch-pattern-marker)')
-        node.set('style', ";".join(style))
+                set_marker(pattern, 'start', 'pattern')

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -15,6 +15,7 @@ from ..elements import nodes_to_elements
 from ..exceptions import InkstitchException
 from ..extensions.lettering_custom_font_dir import get_custom_font_dir
 from ..i18n import _, get_languages
+from ..marker import MARKER, ensure_marker
 from ..stitches.auto_satin import auto_satin
 from ..svg.tags import (CONNECTION_END, CONNECTION_START, INKSCAPE_LABEL,
                         SVG_PATH_TAG, SVG_USE_TAG, XLINK_HREF)
@@ -218,7 +219,9 @@ class Font(object):
                         style += inkex.Style("stroke-width:0.5px")
                 element.set('style', '%s' % style.to_str())
 
+        # make sure necessary marker and command symbols are in the defs section
         self._ensure_command_symbols(destination_group)
+        self._ensure_marker_symbols(destination_group)
 
         return destination_group
 
@@ -335,6 +338,12 @@ class Font(object):
         # make sure all necessary command symbols are in the document
         for command in commands:
             ensure_symbol(group.getroottree().getroot(), command)
+
+    def _ensure_marker_symbols(self, group):
+        for marker in MARKER:
+            xpath = ".//*[contains(@style, 'marker-start:url(#inkstitch-%s-marker)')]" % marker
+            if group.xpath(xpath, namespaces=inkex.NSS):
+                ensure_marker(group.getroottree().getroot(), marker)
 
     def _apply_auto_satin(self, group, trim):
         """Apply Auto-Satin to an SVG XML node tree with an svg:g at its root.

--- a/lib/marker.py
+++ b/lib/marker.py
@@ -1,6 +1,6 @@
 # Authors: see git history
 #
-# Copyright (c) 2010 Authors
+# Copyright (c) 2022 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from copy import deepcopy

--- a/lib/marker.py
+++ b/lib/marker.py
@@ -1,0 +1,37 @@
+# Authors: see git history
+#
+# Copyright (c) 2010 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from copy import deepcopy
+from os import path
+
+import inkex
+
+from .utils import cache, get_bundled_dir
+
+MARKER = ['pattern']
+
+
+def ensure_marker(svg, marker):
+    marker_path = ".//*[@id='inkstitch-%s-marker']" % marker
+    if svg.defs.find(marker_path) is None:
+        svg.defs.append(deepcopy(_marker_svg().defs.find(marker_path)))
+
+
+@cache
+def _marker_svg():
+    marker_path = path.join(get_bundled_dir("symbols"), "marker.svg")
+    with open(marker_path) as marker_file:
+        return inkex.load_svg(marker_file).getroot()
+
+
+def set_marker(node, position, marker):
+    ensure_marker(node.getroottree().getroot(), marker)
+
+    # attach marker to node
+    style = node.get('style') or ''
+    style = style.split(";")
+    style = [i for i in style if not i.startswith('marker-%s' % position)]
+    style.append('marker-%s:url(#inkstitch-pattern-marker)' % position)
+    node.set('style', ";".join(style))

--- a/symbols/marker.svg
+++ b/symbols/marker.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 210 297"
    height="297mm"
    width="210mm"
-   sodipodi:docname="marker-test.svg"
+   sodipodi:docname="marker.svg"
    inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"

--- a/symbols/marker.svg
+++ b/symbols/marker.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   id="svg"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm"
+   sodipodi:docname="marker-test.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:inkstitch="http://inkstitch.org/namespace">
+  <defs
+     id="defs1">
+    <marker
+       refX="10"
+       refY="5"
+       orient="auto"
+       id="inkstitch-pattern-marker">
+      <g
+         id="inkstitch-pattern-group">
+        <path
+           style="fill:#fafafa;stroke:#ff5500;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1, 1;stroke-dashoffset:0;stroke-opacity:1;fill-opacity:0.8;"
+           d="M 10.12911,5.2916678 A 4.8374424,4.8374426 0 0 1 5.2916656,10.12911 4.8374424,4.8374426 0 0 1 0.45422399,5.2916678 4.8374424,4.8374426 0 0 1 5.2916656,0.45422399 4.8374424,4.8374426 0 0 1 10.12911,5.2916678 Z"
+           id="inkstitch-pattern-marker-circle" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.4;stroke-linecap:round;stroke-miterlimit:4;"
+           id="inkstitch-pattern-marker-spiral"
+           d="M 4.9673651,5.7245662 C 4.7549848,5.7646159 4.6247356,5.522384 4.6430021,5.3419847 4.6765851,5.0103151 5.036231,4.835347 5.3381858,4.8987426 5.7863901,4.9928495 6.0126802,5.4853625 5.9002872,5.9065088 5.7495249,6.4714237 5.1195537,6.7504036 4.5799191,6.5874894 3.898118,6.3816539 3.5659013,5.6122905 3.7800789,4.9545192 4.0402258,4.1556558 4.9498996,3.7699484 5.7256318,4.035839 6.6416744,4.3498087 7.0810483,5.4003986 6.7631909,6.2939744 6.395633,7.3272552 5.2038143,7.8204128 4.1924535,7.4503931 3.0418762,7.0294421 2.4948761,5.6961604 2.9171752,4.567073 3.3914021,3.2991406 4.8663228,2.6982592 6.1130974,3.1729158 7.4983851,3.7003207 8.1531869,5.3169977 7.6260947,6.6814205 7.0456093,8.1841025 5.2870784,8.8928844 3.8050073,8.3132966 2.1849115,7.6797506 1.4221671,5.7793073 2.0542715,4.1796074 2.7408201,2.4420977 4.7832541,1.6253548 6.5005435,2.310012 8.3554869,3.0495434 9.2262638,5.2339874 8.4890181,7.0688861 8.4256397,7.2266036 8.3515789,7.379984 8.2675333,7.5277183" />
+      </g>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
This is supposed to take patterns into account when importing letters with the lettering tool.
It should also work for other markers that we may add later (e.g. guide line markers for new fill options)