### PR TITLE
Generate color palette

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -15,6 +15,7 @@ from .cutwork_segmentation import CutworkSegmentation
 from .duplicate_params import DuplicateParams
 from .embroider_settings import EmbroiderSettings
 from .flip import Flip
+from .generate_palette import GeneratePalette
 from .global_commands import GlobalCommands
 from .import_threadlist import ImportThreadlist
 from .input import Input
@@ -23,9 +24,9 @@ from .install_custom_palette import InstallCustomPalette
 from .layer_commands import LayerCommands
 from .lettering import Lettering
 from .lettering_custom_font_dir import LetteringCustomFontDir
+from .lettering_force_lock_stitches import LetteringForceLockStitches
 from .lettering_generate_json import LetteringGenerateJson
 from .lettering_remove_kerning import LetteringRemoveKerning
-from .lettering_force_lock_stitches import LetteringForceLockStitches
 from .letters_to_font import LettersToFont
 from .object_commands import ObjectCommands
 from .output import Output
@@ -66,6 +67,7 @@ __all__ = extensions = [StitchPlanPreview,
                         BreakApart,
                         ImportThreadlist,
                         InstallCustomPalette,
+                        GeneratePalette,
                         Simulator,
                         Reorder,
                         DuplicateParams,

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -30,6 +30,7 @@ from .lettering_remove_kerning import LetteringRemoveKerning
 from .letters_to_font import LettersToFont
 from .object_commands import ObjectCommands
 from .output import Output
+from .palette_split_text import PaletteSplitText
 from .params import Params
 from .print_pdf import Print
 from .remove_embroidery_settings import RemoveEmbroiderySettings
@@ -68,6 +69,7 @@ __all__ = extensions = [StitchPlanPreview,
                         ImportThreadlist,
                         InstallCustomPalette,
                         GeneratePalette,
+                        PaletteSplitText,
                         Simulator,
                         Reorder,
                         DuplicateParams,

--- a/lib/extensions/generate_palette.py
+++ b/lib/extensions/generate_palette.py
@@ -1,0 +1,95 @@
+# Authors: see git history
+#
+# Copyright (c) 2022 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import os
+import sys
+
+import inkex
+
+from ..i18n import _
+from ..svg.tags import XLINK_HREF
+from ..utils import guess_inkscape_config_path
+from .base import InkstitchExtension
+
+
+class GeneratePalette(InkstitchExtension):
+    # Generate a custom color palette in object related order
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-n", "--palette_name", type=str, default=None, dest="palette_name")
+        self.arg_parser.add_argument("-f", "--palette_folder", type=str, default=None, dest="palette_folder")
+        self.arg_parser.add_argument("-o", "--options", type=str, default=None, dest="page_options")
+        self.arg_parser.add_argument("-i", "--info", type=str, default=None, dest="page_help")
+
+    def effect(self):
+        path = self.options.palette_folder
+        brand = self.options.palette_name
+        file_name = "InkStitch %s.gpl" % brand
+        color_palette_name = '\nName: Ink/Stitch: %s' % brand
+
+        if not brand:
+            inkex.errormsg(_("Please specify a name for your color palette."))
+            sys.exit()
+
+        if path:
+            if not os.path.isdir(path):
+                inkex.errormsg(_("Unkown directory path."))
+                sys.exit()
+        else:
+            path = os.path.join(guess_inkscape_config_path(), 'palettes')
+            if not os.path.isdir(path):
+                inkex.errormsg(_("Ink/Stitch cannot find your palette folder automatically. Please install your palette manually."))
+                sys.exit()
+
+        elements = self.svg.selected
+
+        if not elements:
+            inkex.errormsg(_("No element selected.\n\nPlease select at least one element with a color swatch fill."))
+            sys.exit()
+
+        colors = self._get_swatch_color_from_elements(elements)
+
+        if not colors:
+            inkex.errormsg(_("We couldn't find any colors in the Inkscape auto-color palette. Please read the instructions on our website."))
+            sys.exit()
+
+        colors = ['GIMP Palette', color_palette_name, '\nColumns: 4', '\n# RGB Value\t\tColor Name   Number'] + colors
+
+        file_path = os.path.join(path, file_name)
+        with open(file_path, 'w', encoding='utf-8') as gpl:
+            gpl.writelines(colors)
+
+    def _get_swatch_color_from_elements(self, elements):
+        colors = []
+        for element in elements:
+            fill = element.style['fill']
+            if not fill.startswith("url"):
+                continue
+
+            # I hope there will be a better way, but for now we seem to have to
+            # grab the first gradient element, which contains a link to the next gradient element
+            # which contains a stop element which reveals the actual color info
+            linear_gradient = inkex.properties.match_url_and_return_element(fill, self.svg)
+            color_name = linear_gradient.get(XLINK_HREF)[1:]
+            xpath = "(.//svg:linearGradient[@id='%s']/svg:stop)[1]" % color_name
+            color = self.document.xpath(xpath, namespaces=inkex.NSS)
+            if color:
+                color = inkex.Color(color[0].style["stop-color"]).to_rgb()
+                color_name = color_name.split("_")
+                if len(color_name) > 1 and color_name[-1].isdigit():
+                    number = color_name[-1]
+                    name = ' '.join(color_name[:-1])
+                else:
+                    name = color_name[0]
+                    number = 0
+                color = "\n%s\t%s\t%s\t%s   %s" % (color[0], color[1], color[2], name, number)
+                colors.append(color)
+
+        return colors
+
+
+if __name__ == '__main__':
+    e = GeneratePalette()
+    e.affect()

--- a/lib/extensions/palette_split_text.py
+++ b/lib/extensions/palette_split_text.py
@@ -1,0 +1,43 @@
+# Authors: see git history
+#
+# Copyright (c) 2022 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import inkex
+
+from ..i18n import _
+from .base import InkstitchExtension
+
+
+class PaletteSplitText(InkstitchExtension):
+    # Splits sublines of text into it's own text elements in order to color them with the color picker
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-l", "--line-height", type=int, default=6, dest="line_height")
+
+    def effect(self):
+        if not self.svg.selected:
+            inkex.errormsg(_("Please select one or more text elements to split lines."))
+            return
+
+        line_height = self.options.line_height
+
+        for text in self.svg.selected:
+            if type(text) == inkex.elements.TextElement:
+                parent = text.getparent()
+                content = text.get_text()
+                lines = content.split('\n')
+                lines.reverse()
+                style = text.get('style')
+                x = text.get('x')
+                y = text.get('y')
+                y = float(y) + (len(lines) - 1) * line_height
+                for line in lines:
+                    element = inkex.TextElement()
+                    element.text = line
+                    element.set('style', style)
+                    element.set('x', x)
+                    element.set('y', str(y))
+                    y = float(y) - line_height
+                    parent.insert(0, element)
+                parent.remove(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # This installs inkex, the Inkscape python extension library.
 # We need the new style handling that was added after the inkex version bundled
 # with Inkscape 1.1.  That's why we're installing from Git.
--e git+https://gitlab.com/inkscape/extensions.git@3796f912f666a0981917839c77eb94fdd6fc6a94#egg=inkscape-core-extensions
+-e git+https://gitlab.com/inkscape/extensions.git@e44fdcbe6bcc917ef3a2164eb0c130f7276fb83f#egg=inkex
 
 backports.functools_lru_cache
 wxPython

--- a/templates/generate_palette.xml
+++ b/templates/generate_palette.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Generate Color Palette</name>
+    <id>org.inkstitch.generate_palette</id>
+    <param name="extension" type="string" gui-hidden="true">generate_palette</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+          <submenu name="Ink/Stitch" translatable="no">
+            <submenu name="Thread Color Management" />
+          </submenu>
+        </effects-menu>
+    </effect>
+    <param name="options" type="notebook">
+      <page name="options" gui-text="Generate Palette Options">
+        <param name="palette_name" type="string" gui-text="Palette name"></param>
+        <spacer />
+        <param name="palette_folder" type="path" mode="folder" gui-text="Folder (optional):"></param>
+        <spacer />
+        <label appearance="header">⚠ Restart Inkscape to use your color palette.</label>
+      </page>
+      <page name="info" gui-text="Help">
+        <label appearance="header">Generate a custom color palette for Ink/Stitch</label>
+        <label>Sadly we can not sort color swatches in Inkscape. With this extension color
+        swatches will be exported in the stacking order of selected objects.</label>
+        <separator />
+        <label>On our website we describe all necessaty steps to generate a color palette for Ink/Stitch.</label>
+        <label appearance="url">https://inkstitch.org/docs/generate-color-palette/</label>
+      </page>
+    </param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>

--- a/templates/generate_palette.xml
+++ b/templates/generate_palette.xml
@@ -7,7 +7,9 @@
         <object-type>all</object-type>
         <effects-menu>
           <submenu name="Ink/Stitch" translatable="no">
-            <submenu name="Thread Color Management" />
+            <submenu name="Thread Color Management">
+              <submenu name="Generate Palette"/>
+            </submenu>
           </submenu>
         </effects-menu>
     </effect>
@@ -21,11 +23,12 @@
       </page>
       <page name="info" gui-text="Help">
         <label appearance="header">Generate a custom color palette for Ink/Stitch</label>
-        <label>Sadly we can not sort color swatches in Inkscape. With this extension color
-        swatches will be exported in the stacking order of selected objects.</label>
+        <label>Sadly we can not sort color swatches in Inkscape.
+               With this extension you can export colors from text elements in their stacking order.
+               The text will be used as the color name and number.</label>
         <separator />
         <label>On our website we describe all necessaty steps to generate a color palette for Ink/Stitch.</label>
-        <label appearance="url">https://inkstitch.org/docs/generate-color-palette/</label>
+        <label appearance="url">https://inkstitch.org/docs/thread-color#generate-color-palette</label>
       </page>
     </param>
     <script>

--- a/templates/palette_split_text.xml
+++ b/templates/palette_split_text.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Split text</name>
+    <id>org.inkstitch.palette_split_text</id>
+    <param name="extension" type="string" gui-hidden="true">palette_split_text</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+          <submenu name="Ink/Stitch" translatable="no">
+            <submenu name="Thread Color Management">
+              <submenu name="Generate Palette"/>
+            </submenu>
+          </submenu>
+        </effects-menu>
+    </effect>
+    <param name="line-height" type="int" min="1" max="100" gui-text="Line Height">6</param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Adds a feature to generate an Ink/Stitch color palette.

* Write the color names into a text element
* Split the text element into single text elements to prepare them for coloring
* Tab through the text elements and color them with the color picker tool
* Export palette directly into the inkscape palette folder ready to be used with Ink/Stitch
* Restart Inkscape

Other than originally planed this tool doesn't use the color swatch system from Inkscape, but normal fill colors on the text elements.
The text will be used to name the colors, if there is a number behind the color name it will be used as the catalog number.