### PR TITLE
AutoRun: Keep attribs of original elements

### DIFF
--- a/lib/stitches/auto_run.py
+++ b/lib/stitches/auto_run.py
@@ -202,6 +202,12 @@ def path_to_elements(graph, path, trim):  # noqa: C901
         element = graph[start][end].get('element')
         start_coord = graph.nodes[start]['point']
         end_coord = graph.nodes[end]['point']
+        # create a new element if we hit an other original element to keep it's properties
+        if el and element and el != element and d and not direction == 'underpath':
+            element_list.append(create_element(d, position, path_direction, el))
+            original_parents.append(el.node.getparent())
+            d = ""
+            position += 1
         if element:
             el = element
 
@@ -248,8 +254,6 @@ def create_element(path, position, direction, element):
     if not path:
         return
 
-    style = inkex.Style(element.node.get("style"))
-    style = style + inkex.Style("stroke-dasharray:0.5,0.5;fill:none;")
     el_id = "%s_%s_" % (direction, position)
 
     index = position + 1
@@ -262,7 +266,7 @@ def create_element(path, position, direction, element):
     node.set("id", generate_unique_id(element.node, el_id))
     node.set(INKSCAPE_LABEL, label)
     node.set("d", path)
-    node.set("style", str(style))
+    node.set("style", element.node.style)
 
     # Set Ink/Stitch attributes
     stitch_length = element.node.get(INKSTITCH_ATTRIBS['running_stitch_length_mm'], '')
@@ -280,6 +284,7 @@ def create_element(path, position, direction, element):
     else:
         if stitch_length:
             node.set(INKSTITCH_ATTRIBS['running_stitch_length_mm'], stitch_length)
+        node.set("style", element.node.style + inkex.Style("stroke-dasharray:0.5,0.5;fill:none;"))
     return Stroke(node)
 
 


### PR DESCRIPTION
In former AutoRun versions we only created new elements if there has been a switch in direction (underpath versus autorun top stitch layer). If there has been a original element with 7 repeats and an other one following with only 5 we would apply 5 to both of them (that in case there is no directional change). This can lead to even more confusing behaviour when the original shapes are split up and one part still has 7 repeats and the next only 5.

We should assume, that users very well thought about how many repeats they want for the original shapes (while repeats is only an example for all the other attributes applied). So let's try to keep these settings by not joining the parts of different elements together.