### PR TITLE
Option to drop short stitches

### DIFF
--- a/lib/api/stitch_plan.py
+++ b/lib/api/stitch_plan.py
@@ -18,7 +18,8 @@ def get_stitch_plan():
 
     metadata = g.extension.get_inkstitch_metadata()
     collapse_len = metadata['collapse_len_mm']
+    min_stitch_len = metadata['min_stitch_len_mm']
     patches = g.extension.elements_to_stitch_groups(g.extension.elements)
-    stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len)
+    stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
 
     return jsonify(stitch_plan)

--- a/lib/extensions/embroider_settings.py
+++ b/lib/extensions/embroider_settings.py
@@ -16,7 +16,12 @@ class EmbroiderSettings(InkstitchExtension):
                                      action="store", type=float,
                                      dest="collapse_length_mm", default=3.0,
                                      help="max collapse length (mm)")
+        self.arg_parser.add_argument("-l", "--min_stitch_len_mm",
+                                     action="store", type=float,
+                                     dest="min_stitch_len_mm", default=0,
+                                     help="minimum stitch length (mm)")
 
     def effect(self):
         self.metadata = self.get_inkstitch_metadata()
         self.metadata['collapse_len_mm'] = self.options.collapse_length_mm
+        self.metadata['min_stitch_len_mm'] = self.options.min_stitch_len_mm

--- a/lib/extensions/generate_palette.py
+++ b/lib/extensions/generate_palette.py
@@ -73,7 +73,7 @@ class GeneratePalette(InkstitchExtension):
             else:
                 number = 0
                 name = ' '.join(color_name)
-            color = "\n%s\t%s\t%s\t%s   %s" % (str(color[0]).rjust(3), str(color[1]).rjust(3), str(color[2]).rjust(3), name.rjust(30), number)
+            color = "\n%s\t%s\t%s\t%s    %s" % (str(color[0]).rjust(3), str(color[1]).rjust(3), str(color[2]).rjust(3), name.rjust(30), number)
             colors.append(color)
 
         return colors

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -52,8 +52,10 @@ class Output(InkstitchExtension):
 
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
+        min_stitch_len = self.metadata['min_stitch_len_mm']
         patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, disable_ties=self.settings.get('laser_mode', False))
+        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, disable_ties=self.settings.get('laser_mode', False),
+                                                   min_stitch_len=min_stitch_len)
 
         temp_file = tempfile.NamedTemporaryFile(suffix=".%s" % self.file_extension, delete=False)
 

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -308,8 +308,9 @@ class Print(InkstitchExtension):
 
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
+        min_stitch_len = self.metadata['min_stitch_len_mm']
         patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len)
+        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         palette = ThreadCatalog().match_and_apply_palette(stitch_plan, self.get_inkstitch_metadata()['thread-palette'])
 
         overview_svg, color_block_svgs = self.render_svgs(stitch_plan, realistic=False)

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -35,8 +35,9 @@ class StitchPlanPreview(InkstitchExtension):
         visual_commands = True
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
+        min_stitch_len = self.metadata['min_stitch_len_mm']
         patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len)
+        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         render_stitch_plan(svg, stitch_plan, realistic, visual_commands)
 
         # apply options

--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -43,8 +43,9 @@ class Zip(InkstitchExtension):
 
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
+        min_stitch_len = self.metadata['min_stitch_len_mm']
         patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len)
+        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
 
         base_file_name = self.get_base_file_name()
         path = tempfile.mkdtemp()

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -142,6 +142,18 @@ class ColorBlock(object):
     def replace_stitches(self, stitches):
         self.stitches = stitches
 
+    def drop_short_stitches(self, min_stitch_len):
+        stitches = [self.stitches[0]]
+        dropped_length = 0
+        for stitch1, stitch2 in zip(self.stitches[:-1], self.stitches[1:]):
+            length = Point(stitch1.x, stitch1.y).distance(Point(stitch2.x, stitch2.y))
+            if length + dropped_length >= min_stitch_len:
+                stitches.append(stitch2)
+                dropped_length = 0
+            else:
+                dropped_length += length
+        self.replace_stitches(stitches)
+
     @property
     def bounding_box(self):
         minx = min(stitch.x for stitch in self)

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -98,19 +98,21 @@ class ColorBlock(object):
 
         return False
 
-    def filter_duplicate_stitches(self):
+    def filter_duplicate_stitches(self, min_stitch_len=0.1):
         if not self.stitches:
             return
 
-        stitches = [self.stitches[0]]
+        if min_stitch_len is None:
+            min_stitch_len = 0.1
 
+        stitches = [self.stitches[0]]
         for stitch in self.stitches[1:]:
             if stitches[-1].jump or stitch.stop or stitch.trim or stitch.color_change:
                 # Don't consider jumps, stops, color changes, or trims as candidates for filtering
                 pass
             else:
                 length = (stitch - stitches[-1]).length()
-                if length <= 0.1 * PIXELS_PER_MM:
+                if length <= min_stitch_len * PIXELS_PER_MM:
                     # duplicate stitch, skip this one
                     continue
 
@@ -141,18 +143,6 @@ class ColorBlock(object):
 
     def replace_stitches(self, stitches):
         self.stitches = stitches
-
-    def drop_short_stitches(self, min_stitch_len):
-        stitches = [self.stitches[0]]
-        dropped_length = 0
-        for stitch1, stitch2 in zip(self.stitches[:-1], self.stitches[1:]):
-            length = Point(stitch1.x, stitch1.y).distance(Point(stitch2.x, stitch2.y))
-            if length + dropped_length >= min_stitch_len:
-                stitches.append(stitch2)
-                dropped_length = 0
-            else:
-                dropped_length += length
-        self.replace_stitches(stitches)
 
     @property
     def bounding_box(self):

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -13,7 +13,7 @@ from .color_block import ColorBlock
 from .ties import add_ties
 
 
-def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_len=0, disable_ties=False):  # noqa: C901
+def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_len=0.1, disable_ties=False):  # noqa: C901
 
     """Convert a collection of StitchGroups to a StitchPlan.
 
@@ -30,7 +30,6 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
     if collapse_len is None:
         collapse_len = 3.0
     collapse_len = collapse_len * PIXELS_PER_MM
-
     stitch_plan = StitchPlan()
     color_block = stitch_plan.new_color_block(color=stitch_groups[0].color)
 
@@ -61,10 +60,6 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
         color_block.add_stitches(stitches=stitch_group.stitches, tie_modus=stitch_group.tie_modus,
                                  force_lock_stitches=stitch_group.force_lock_stitches, no_ties=stitch_group.stitch_as_is)
 
-        if min_stitch_len and min_stitch_len > 0:
-            min_len = min_stitch_len * PIXELS_PER_MM
-            color_block.drop_short_stitches(min_len)
-
         if stitch_group.trim_after:
             color_block.add_stitch(trim=True)
 
@@ -76,7 +71,7 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
         # last block ended in a stop, so now we have an empty block
         del stitch_plan.color_blocks[-1]
 
-    stitch_plan.filter_duplicate_stitches()
+    stitch_plan.filter_duplicate_stitches(min_stitch_len)
 
     if not disable_ties:
         stitch_plan.add_ties()
@@ -106,9 +101,9 @@ class StitchPlan(object):
     def add_color_block(self, color_block):
         self.color_blocks.append(color_block)
 
-    def filter_duplicate_stitches(self):
+    def filter_duplicate_stitches(self, min_stitch_len):
         for color_block in self:
-            color_block.filter_duplicate_stitches()
+            color_block.filter_duplicate_stitches(min_stitch_len)
 
     def add_ties(self):
         # see ties.py

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -61,7 +61,7 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
         color_block.add_stitches(stitches=stitch_group.stitches, tie_modus=stitch_group.tie_modus,
                                  force_lock_stitches=stitch_group.force_lock_stitches, no_ties=stitch_group.stitch_as_is)
 
-        if min_stitch_len > 0:
+        if min_stitch_len and min_stitch_len > 0:
             min_len = min_stitch_len * PIXELS_PER_MM
             color_block.drop_short_stitches(min_len)
 

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -13,7 +13,7 @@ from .color_block import ColorBlock
 from .ties import add_ties
 
 
-def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, disable_ties=False):  # noqa: C901
+def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_len=0, disable_ties=False):  # noqa: C901
 
     """Convert a collection of StitchGroups to a StitchPlan.
 
@@ -30,6 +30,7 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, disable_ties=
     if collapse_len is None:
         collapse_len = 3.0
     collapse_len = collapse_len * PIXELS_PER_MM
+
     stitch_plan = StitchPlan()
     color_block = stitch_plan.new_color_block(color=stitch_groups[0].color)
 
@@ -59,6 +60,10 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, disable_ties=
 
         color_block.add_stitches(stitches=stitch_group.stitches, tie_modus=stitch_group.tie_modus,
                                  force_lock_stitches=stitch_group.force_lock_stitches, no_ties=stitch_group.stitch_as_is)
+
+        if min_stitch_len > 0:
+            min_len = min_stitch_len * PIXELS_PER_MM
+            color_block.drop_short_stitches(min_len)
 
         if stitch_group.trim_after:
             color_block.add_stitch(trim=True)

--- a/templates/embroider_settings.xml
+++ b/templates/embroider_settings.xml
@@ -15,6 +15,9 @@
     <param name="collapse_len_mm" type="float" precision="1" min="0" max="10"
            gui-text="Collapse length (mm)"
            gui-description="Jump stitches smaller than this will be treated as normal stitches.">3</param>
+    <param name="min_stitch_len_mm" type="float" precision="1" min="0" max="10"
+           gui-text="Minimal stitch length (mm)"
+           gui-description="Drop stitches smaller than this value.">0</param>
     <script>
         {{ command_tag | safe }}
     </script>

--- a/templates/embroider_settings.xml
+++ b/templates/embroider_settings.xml
@@ -17,7 +17,7 @@
            gui-description="Jump stitches smaller than this will be treated as normal stitches.">3</param>
     <param name="min_stitch_len_mm" type="float" precision="1" min="0" max="10"
            gui-text="Minimal stitch length (mm)"
-           gui-description="Drop stitches smaller than this value.">0</param>
+           gui-description="Drop stitches smaller than this value.">0.1</param>
     <script>
         {{ command_tag | safe }}
     </script>


### PR DESCRIPTION
This will drop short stitches on export.

Background: A reported issue about an embroidery machine which was dropping stitches has been a riddle to me, since the dst file embroidered well on other machines. Thanks to tatarize there is now a strong guess, that the issue has been caused by the machines firmware, which was trying to remove short stitches, but then removed the following stitch instead. For owners of those embroidery machines (reportedly a lot of them in Germany) it is essential to have an option to remove small stitches.

I'll try to get some feedback if this really has been the cause. But this could be a nice feature anyway.

_Edit_: It solves the issue.

Fixes #1455