### PR TITLE
Marker recognition

### DIFF
--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -346,9 +346,7 @@ class Font(object):
             if marked_elements:
                 ensure_marker(group.getroottree().getroot(), marker)
                 for element in marked_elements:
-                    marker_style = element.style['marker-start']
-                    if marker_style != marker:
-                        element.style['marker-start'] = "url(#inkstitch-%s-marker)" % marker
+                    element.style['marker-start'] = "url(#inkstitch-%s-marker)" % marker
 
     def _apply_auto_satin(self, group, trim):
         """Apply Auto-Satin to an SVG XML node tree with an svg:g at its root.

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -341,9 +341,14 @@ class Font(object):
 
     def _ensure_marker_symbols(self, group):
         for marker in MARKER:
-            xpath = ".//*[contains(@style, 'marker-start:url(#inkstitch-%s-marker)')]" % marker
+            xpath = ".//*[contains(@style, 'marker-start:url(#inkstitch-%s-marker')]" % marker
+            marked_elements = group.xpath(xpath, namespaces=inkex.NSS)
             if group.xpath(xpath, namespaces=inkex.NSS):
                 ensure_marker(group.getroottree().getroot(), marker)
+                for element in marked_elements:
+                    marker_style = element.style['marker-start']
+                    if marker_style != marker:
+                        element.style['marker-start'] = "url(#inkstitch-%s-marker)" % marker
 
     def _apply_auto_satin(self, group, trim):
         """Apply Auto-Satin to an SVG XML node tree with an svg:g at its root.

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -343,7 +343,7 @@ class Font(object):
         for marker in MARKER:
             xpath = ".//*[contains(@style, 'marker-start:url(#inkstitch-%s-marker')]" % marker
             marked_elements = group.xpath(xpath, namespaces=inkex.NSS)
-            if group.xpath(xpath, namespaces=inkex.NSS):
+            if marked_elements:
                 ensure_marker(group.getroottree().getroot(), marker)
                 for element in marked_elements:
                     marker_style = element.style['marker-start']

--- a/lib/marker.py
+++ b/lib/marker.py
@@ -48,7 +48,9 @@ def get_marker_elements(node, marker, get_fills=True, get_strokes=True, get_sati
     fills = []
     strokes = []
     satins = []
-    xpath = "./parent::svg:g/*[contains(@style, 'marker-start:url(#inkstitch-%s-marker)')]" % marker
+    # do not close marker-start:url(
+    # if the marker group has been copied and pasted in Inkscape it may have been duplicated with an updated id (e.g. -4)
+    xpath = "./parent::svg:g/*[contains(@style, 'marker-start:url(#inkstitch-%s-marker')]" % marker
     markers = node.xpath(xpath, namespaces=inkex.NSS)
     for marker in markers:
         if marker.tag not in EMBROIDERABLE_TAGS:
@@ -82,6 +84,6 @@ def has_marker(node, marker=list()):
         marker = MARKER
     for m in marker:
         style = node.get('style') or ''
-        if "marker-start:url(#inkstitch-%s-marker)" % m in style:
+        if "marker-start:url(#inkstitch-%s-marker" % m in style:
             return True
     return False


### PR DESCRIPTION
Duplicating commands isn't a good idea, when we copy & paste them, we are good.
Copy & paste markers isn't a good idea, but duplicating works well.

Using commands and markers on the same element and then double it? Hm ...

Let's at least try to fix one of the options. Easier fix: markers.