### PR TITLE
Scale marker symbols as well

### DIFF
--- a/lib/extensions/commands_scale_symbols.py
+++ b/lib/extensions/commands_scale_symbols.py
@@ -21,3 +21,8 @@ class CommandsScaleSymbols(InkstitchExtension):
         for symbol in command_symbols:
             transform = Transform(symbol.get('transform')).add_scale(size)
             symbol.set('transform', str(transform))
+
+        markers = svg.xpath(".//svg:marker[starts-with(@id, 'inkstitch')]", namespaces=NSS)
+        for marker in markers:
+            marker_size = float(marker.get('markerWidth', 0.5)) * size
+            marker.set('markerWidth', marker_size)

--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -66,7 +66,7 @@ class ThreadColor(object):
         return hash(self.rgb)
 
     def __ne__(self, other):
-        return not(self == other)
+        return not (self == other)
 
     def __repr__(self):
         return "ThreadColor" + repr(self.rgb)

--- a/symbols/marker.svg
+++ b/symbols/marker.svg
@@ -20,7 +20,10 @@
        refX="10"
        refY="5"
        orient="auto"
-       id="inkstitch-pattern-marker">
+       id="inkstitch-pattern-marker"
+       markerUnits="userSpaceOnUse"
+       markerWidth="0.5"
+       viewBox="0 0 1 1">
       <g
          id="inkstitch-pattern-group">
         <path
@@ -37,7 +40,10 @@
       refX="10"
       refY="5"
       orient="auto"
-      id="inkstitch-guide-line-marker">
+      id="inkstitch-guide-line-marker"
+      markerUnits="userSpaceOnUse"
+      markerWidth="0.5"
+      viewBox="0 0 1 1">
      <g
         id="inkstitch-guide-line-group">
        <path


### PR DESCRIPTION
There is one thing that I felt was very annoying about markers. The way we implemented them, they were growing with the stroke width - or even worse when used on a filled object. This sets the markers to an equal size, plus it allows them to be scaled along with the scale commands extension. So every symbol and marker will be scaled the same way.