### PR TITLE
fix requirements.txt, move CI version pins to CI file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.10.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -102,7 +102,7 @@ jobs:
           node-version: '16.x'
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.x'
+          python-version: '3.10.x'
           architecture: 'x86'
       - uses: microsoft/setup-msbuild@v1.0.2
       - name: install dependencies
@@ -110,9 +110,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-
-          python -m pip install git+https://github.com/gtaylor/python-colormath
-
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 
@@ -148,7 +145,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.x'
+          python-version: '3.10.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -171,7 +168,6 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
-          pip install git+https://github.com/gtaylor/python-colormath
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject
 
-          # colormath - last official release: 3.0.0
-          # we need already submitted fixes - so let's grab them from the github repository
-          python -m pip install git+https://github.com/gtaylor/python-colormath
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.0-cp310-cp310-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10.x'
+          python-version: '3.8.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -68,7 +68,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.0-cp310-cp310-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.1.1-cp38-cp38-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
@@ -100,7 +100,7 @@ jobs:
           node-version: '16.x'
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10.x'
+          python-version: '3.8.x'
           architecture: 'x86'
       - uses: microsoft/setup-msbuild@v1.0.2
       - name: install dependencies
@@ -108,6 +108,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
+          python -m pip install wxpython==4.1.1
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 
@@ -143,7 +144,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10.x'
+          python-version: '3.8.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -166,6 +167,7 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
+          pip install wxpython==4.1.1
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,12 @@
 
 # inkex is not currently uploaded to pypi, the version there is extremely out of date
 inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.1
-backports.functools_lru_cache
+
+# lower bound to allow for the use of system packages on Debian and distros that have updated to 4.2
+# CI adds an == 4.1.1 constraint for prebuilt packages
 wxPython>=4.1.1
+
+backports.functools_lru_cache
 networkx
 shapely
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,8 @@
 ./pyembroidery
 
-# This installs inkex, the Inkscape python extension library.
-# We need the new style handling that was added after the inkex version bundled
-# with Inkscape 1.1.  That's why we're installing from Git.
--e git+https://gitlab.com/inkscape/extensions.git@e44fdcbe6bcc917ef3a2164eb0c130f7276fb83f#egg=inkex
-
+inkex>=1.2.0
 backports.functools_lru_cache
-https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.1.1-cp38-cp38-linux_x86_64.whl ; sys_platform == 'linux'
-wxPython==4.1.1 ; sys_platform == 'darwin'
-wxPython==4.1.1 ; sys_platform == 'win32'
+wxPython==4.1.1
 networkx
 shapely
 lxml
@@ -16,12 +10,16 @@ appdirs
 numpy
 jinja2>2.9
 requests
-colormath
+
+# colormath - last official release: 3.0.0
+# we need already submitted fixes - so let's grab them from the github repository
+-e git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f685aa7143db81eba27b2cd19a#egg=colormath
+
 stringcase
 tinycss2
 flask
 fonttools
-trimesh
+trimesh>=3.15.2
 scipy
 
 pywinutils ; sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # inkex is not currently uploaded to pypi, the version there is extremely out of date
 inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.1
 backports.functools_lru_cache
-wxPython==4.1.1
+wxPython>=4.1.1
 networkx
 shapely
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ./pyembroidery
 
-inkex>=1.2.0
+# inkex is not currently uploaded to pypi, the version there is extremely out of date
+inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.1
 backports.functools_lru_cache
 wxPython==4.1.1
 networkx
@@ -13,7 +14,7 @@ requests
 
 # colormath - last official release: 3.0.0
 # we need already submitted fixes - so let's grab them from the github repository
--e git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f685aa7143db81eba27b2cd19a#egg=colormath
+colormath @ git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f685aa7143db81eba27b2cd19a
 
 stringcase
 tinycss2


### PR DESCRIPTION
Restores the ability to manually install.

- Move colormath version requirement from CI build files to `requirements.txt` so that pip sees it outside of CI.
- Replace inkex commit hash with a version tag now that the commit in question has been released.
- Add version bound to trimesh as insurance against the outdated Manjaro package.
- Update the python version in CI to 3.10 and restore wxpython in requirements.txt to the current version (4.1.1). Remove the python3.8-specific version pin on linux.