### PR TITLE
fix requirements.txt, move CI version pins to CI file (moved), fix wx simulator closing paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.x'
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
@@ -68,9 +68,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject
 
-          # colormath - last official release: 3.0.0
-          # we need already submitted fixes - so let's grab them from the github repository
-          python -m pip install git+https://github.com/gtaylor/python-colormath
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.1.1-cp38-cp38-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
@@ -108,11 +106,10 @@ jobs:
       - name: install dependencies
         shell: bash
         run: |
+          git config --system core.longpaths true
           python -m pip install --upgrade pip
           python -m pip install wheel
-
-          python -m pip install git+https://github.com/gtaylor/python-colormath
-
+          python -m pip install wxpython==4.1.1
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 
@@ -171,7 +168,7 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
-          pip install git+https://github.com/gtaylor/python-colormath
+          pip install wxpython==4.1.1
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
           git config --system core.longpaths true
           python -m pip install --upgrade pip
           python -m pip install wheel
+          # scipy 1.9.1 is the last version to support 32-bit windows
+          python -m pip install scipy==1.9.1
           python -m pip install wxpython==4.1.1
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -381,13 +381,13 @@ class DrawingPanel(wx.Panel):
             if stitch + len(stitches) < self.current_stitch:
                 stitch += len(stitches)
                 if len(stitches) > 1:
-                    canvas.DrawLines(stitches)
+                    canvas.StrokeLines(stitches)
                     self.draw_needle_penetration_points(canvas, pen, stitches)
                 last_stitch = stitches[-1]
             else:
                 stitches = stitches[:self.current_stitch - stitch]
                 if len(stitches) > 1:
-                    canvas.DrawLines(stitches)
+                    canvas.StrokeLines(stitches)
                     self.draw_needle_penetration_points(canvas, pen, stitches)
                 last_stitch = stitches[-1]
                 break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,13 @@
 ./pyembroidery
 
-# This installs inkex, the Inkscape python extension library.
-# We need the new style handling that was added after the inkex version bundled
-# with Inkscape 1.1.  That's why we're installing from Git.
--e git+https://gitlab.com/inkscape/extensions.git@e44fdcbe6bcc917ef3a2164eb0c130f7276fb83f#egg=inkex
+# inkex is not currently uploaded to pypi, the version there is extremely out of date
+inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.1
+
+# lower bound to allow for the use of system packages on Debian and distros that have updated to 4.2
+# CI adds an == 4.1.1 constraint for prebuilt packages
+wxPython>=4.1.1
 
 backports.functools_lru_cache
-https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.1.1-cp38-cp38-linux_x86_64.whl ; sys_platform == 'linux'
-wxPython==4.1.1 ; sys_platform == 'darwin'
-wxPython==4.1.1 ; sys_platform == 'win32'
 networkx
 shapely
 lxml
@@ -16,12 +15,16 @@ appdirs
 numpy
 jinja2>2.9
 requests
-colormath
+
+# colormath - last official release: 3.0.0
+# we need already submitted fixes - so let's grab them from the github repository
+colormath @ git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f685aa7143db81eba27b2cd19a
+
 stringcase
 tinycss2
 flask
 fonttools
-trimesh
+trimesh>=3.15.2
 scipy
 
 pywinutils ; sys_platform == 'win32'


### PR DESCRIPTION
Squashed version of #1843 punning from a branch of this repo. Moved from a fork so that I can test on CI.

Restores the ability to manually install.

- Move colormath version requirement from CI build files to `requirements.txt` so that pip sees it outside of CI.
- Replace inkex commit hash with a version tag now that the commit in question has been released.
- Add version bound to trimesh as insurance against the outdated Manjaro package.
- Move wxpython version pin (4.1.1) and wheel URL to CI and change to lower bound in requirements.txt to allow for use of system packages in distros that have updated to 4.2 (Debian, etc).
- Change stitch path drawing in wx simulator from `DrawLines` (for polygons) to `StrokeLines`(for non-closed paths).
- Add version pin for scipy 1.9.1 to windows builds as scipy just dropped 32-bit support.
