### PR TITLE
Update of manual to include dependency for debugging

### DIFF
--- a/collections/_developers/en/002-002-003-windows-manual-build.md
+++ b/collections/_developers/en/002-002-003-windows-manual-build.md
@@ -110,6 +110,10 @@ The bash environment needs some paths for the installed software. So let's set i
   python -m pip install -r requirements.txt
   python -m pip install pyinstaller
   ```
+* For debugging with pydevd also run:
+  ```
+  python -m pip install pydevd
+  ```
 
 ## Setup yarn
 


### PR DESCRIPTION
Suggestion to add pydevd as optional step to the build manual, as it has to be done before running `make dist`. Knowing this would have saved me an afternoon of frustrated googling