### PR TITLE
Add support for fractional-length stagger cycles in fills

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -216,13 +216,13 @@ class FillStitch(EmbroideryElement):
     @property
     @param('staggers',
            _('Stagger rows this many times before repeating'),
-           tooltip=_('Setting this dictates how many rows apart the stitches will be before they fall in the same column position.'),
+           tooltip=_('Length of the cycle by which successive stitch rows are staggered. Fractional values are allowed and can have less visible diagonals than integer values.'),
            type='int',
            sort_index=6,
            select_items=[('fill_method', 0), ('fill_method', 2), ('fill_method', 3)],
            default=4)
     def staggers(self):
-        return max(self.get_int_param("staggers", 4), 1)
+        return self.get_float_param("staggers", 4)
 
     @property
     @cache

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -37,9 +37,11 @@ def row_num(point, angle, row_spacing):
 
 
 def adjust_stagger(stitch, angle, row_spacing, max_stitch_length, staggers):
+    if staggers == 0:
+        staggers = 1 # sanity check to avoid division by zero.
     this_row_num = row_num(stitch, angle, row_spacing)
-    row_stagger = this_row_num % staggers
-    stagger_offset = (float(row_stagger) / staggers) * max_stitch_length
+    stagger_phase = (this_row_num / staggers) % 1
+    stagger_offset = stagger_phase * max_stitch_length
     offset = ((stitch * east(angle)) - stagger_offset) % max_stitch_length
 
     return stitch - offset * east(angle)

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -148,7 +148,9 @@ def take_only_line_strings(thing):
 
 
 def apply_stitches(line, max_stitch_length, num_staggers, row_spacing, row_num):
-    start = (float(row_num % num_staggers) / num_staggers) * max_stitch_length
+    if num_staggers == 0:
+        num_staggers = 1 # sanity check to avoid division by zero.
+    start = ((row_num / num_staggers) % 1) * max_stitch_length
     projections = np.arange(start, line.length, max_stitch_length)
     points = np.array([line.interpolate(projection).coords[0] for projection in projections])
     stitched_line = shgeo.LineString(points)


### PR DESCRIPTION
As fractional length stagger cycles can have less-strongly-visible diagonals than integer stagger cycles, remove the restriction that the cycle length needs to be an integer. Existing stagger behavior for integer-length cycles is unchanged.

Example:
```
Stagger 5:
---*--------------*-------------
------*--------------*----------
---------*--------------*-------
------------*--------------*----
---------------*--------------*-
---*--------------*-------------

Stagger 2.5:
---*--------------*-------------
---------*--------------*-------
---------------*--------------*-
------*--------------*----------
------------*--------------*----
---*--------------*-------------
```