### PR TITLE
Add some limited type checking and a unit test of intersect_region_with_grating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ locales/
 /PROFILE
 /profile_stats
 /profile_stats.prof
+
+# installed as a submodule
+pyembroidery/

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,67 @@
+[mypy]
+files = lib/stitches/**/*.py
+python_version = 3.8
+
+# error: "None" not callable  [misc] shows up a lot, disabling to start
+disable_error_code = misc
+
+[mypy-lib.stitches.*]
+disable_error_code = import
+ignore_missing_imports = True
+
+[mypy-.svg.*]
+ignore_missing_imports = True
+
+[mypy-inkex.*]
+ignore_missing_imports = True
+
+[mypy-lxml.*]
+ignore_missing_imports = True
+
+[mypy-shapely.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-tinycss2.*]
+ignore_missing_imports = True
+
+[mypy-pyembroidery.*]
+ignore_missing_imports = True
+
+[mypy-networkx.*]
+ignore_missing_imports = True
+
+[mypy-colormath.*]
+ignore_missing_imports = True
+
+[mypy-pydevd.*]
+ignore_missing_imports = True
+
+[mypy-trimesh.*]
+ignore_missing_imports = True
+
+[mypy-wx.*]
+ignore_missing_imports = True
+
+[mypy-appdirs.*]
+ignore_missing_imports = True
+
+[mypy-flask.*]
+ignore_missing_imports = True
+
+[mypy-jinja2.*]
+ignore_missing_imports = True
+
+[mypy-werkzeug.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-stringcase.*]
+ignore_missing_imports = True
+
+[mypy-fontTools.*]
+ignore_missing_imports = True

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,38 @@ Feel free to find something that interests you.  If you're looking for ideas, co
 * documentation (see [gh-pages branch](https://github.com/inkstitch/inkstitch/tree/gh-pages))
 
 There's never any time commitment, we're all here to have fun.  If you want to contribute, let us know and we'll add you as a collaborator.
+
+
+## Additional requirements for development
+
+The following system requirements may be necessary to install before running `pip install -r requirements.txt`.
+
+# Python development headers
+
+```
+sudo apt install python3.8-dev  # or python3.9-dev, depending on your version
+```
+
+### [Cairo](https://www.cairographics.org/)
+
+On Ubuntu:
+
+```
+sudo apt install libcairo2-dev
+```
+
+### [libgirepository](https://gi.readthedocs.io/en/latest/writingbindings/libgirepository.html)
+
+On Ubuntu:
+
+```
+sudo apt install libgirepository1.0-dev
+```
+
+### [GTK+](https://www.gtk.org/)
+
+On Ubuntu:
+
+```
+sudo apt-get install libgtk-3-dev
+```

--- a/lib/elements/validation.py
+++ b/lib/elements/validation.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+from typing import List, Any
 
 from shapely.geometry import Point as ShapelyPoint
 
@@ -23,7 +24,7 @@ class ValidationMessage(object):
     # Subclasses will fill these in.
     name = None
     description = None
-    steps_to_solve = []
+    steps_to_solve: List[Any] = []
 
     def __init__(self, position=None, label=""):
         if isinstance(position, ShapelyPoint):

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -3,10 +3,12 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from typing import List
 import math
 
 import shapely
 
+from lib.types import Shape, GratingSegments
 from ..stitch_plan import Stitch
 from ..svg import PIXELS_PER_MM
 from ..utils import Point as InkstitchPoint
@@ -90,7 +92,20 @@ def stitch_row(stitches, beg, end, angle, row_spacing, max_stitch_length, stagge
         stitches.append(end)
 
 
-def intersect_region_with_grating(shape, angle, row_spacing, end_row_spacing=None, flip=False):
+def intersect_region_with_grating(shape: Shape,
+                                  angle: float,
+                                  row_spacing: int,
+                                  end_row_spacing: int = None,
+                                  flip=False) -> List[GratingSegments]:
+    """Intersects the given region with a grating.
+
+    :param shape: The shape to intersect (a multipolygon)
+    :param angle: The angle of the grating
+    :param row_spacing: The spacing of the rows
+    :param end_row_spacing: ???  FIXME: interpret
+    :param flip: Whether to the reverse the orientation of each returned segment.
+    :returns: A list of grating segments, one for each polygon in the input multipolygon.
+    """
     # the max line length I'll need to intersect the whole shape is the diagonal
     (minx, miny, maxx, maxy) = shape.bounds
     upper_left = InkstitchPoint(minx, miny)

--- a/lib/stitches/fill_test.py
+++ b/lib/stitches/fill_test.py
@@ -1,0 +1,46 @@
+from shapely import geometry as shgeo
+
+from lib.stitches import fill
+from lib.stitches.utils import testing
+from lib.utils.geometry import Point
+
+
+TOL = 1e-08
+
+
+def test_intserect_region_with_grating():
+    # a box with side length 10 and lower-left corner at (10, 10)
+    shape = shgeo.box(10, 10, 20, 20, ccw=True)
+    angle = 0
+    row_spacing = 1
+
+    actual = fill.intersect_region_with_grating(
+        shape=shape,
+        angle=angle,
+        row_spacing=row_spacing,
+    )
+    actual = testing.as_point_list(actual)
+
+    # The grating segments produced as output start from the
+    # bottom of the box, and are oriented from right to left.
+    # The very bottom edge is not included as a stitch.
+    expected = [
+        (Point(20, 11), Point(10, 11)),
+        (Point(20, 12), Point(10, 12)),
+        (Point(20, 13), Point(10, 13)),
+        (Point(20, 14), Point(10, 14)),
+        (Point(20, 15), Point(10, 15)),
+        (Point(20, 16), Point(10, 16)),
+        (Point(20, 17), Point(10, 17)),
+        (Point(20, 18), Point(10, 18)),
+        (Point(20, 19), Point(10, 19)),
+        (Point(20, 20), Point(10, 20)),
+    ]
+
+    assert len(actual) == len(expected)
+    for (expected_seg, actual_seg) in zip(expected, actual):
+        assert len(actual_seg) == 2
+        expected_start, expected_end = expected_seg
+        actual_start, actual_end = actual_seg
+        assert expected_start.isclose(actual_start, rel_tol=TOL)
+        assert expected_end.isclose(actual_end, rel_tol=TOL)

--- a/lib/stitches/utils/testing.py
+++ b/lib/stitches/utils/testing.py
@@ -1,0 +1,16 @@
+from typing import List, Tuple
+
+from lib.types import GratingSegments
+from lib.utils.geometry import Point
+
+
+def as_point_list(grating_segments: GratingSegments) -> List[Tuple[Point, Point]]:
+    point_list: List[Tuple[Point, Point]] = []
+
+    for grating_segment in grating_segments:
+        # for some reason the segment is a list with one entry?
+        grating_segment = grating_segment[0]
+        start, end = grating_segment
+        point_list.append((Point.from_tuple(start), Point.from_tuple(end)))
+
+    return point_list

--- a/lib/types.py
+++ b/lib/types.py
@@ -1,4 +1,7 @@
-from shapely import geometry
+from typing import List
+import shapely
 
 """The datatype representing a 2D shape in the plane."""
-Shape = geometry.MultiPolygon
+Shape = shapely.geometry.MultiPolygon
+
+GratingSegments = List[List[shapely.coords.CoordinateSequence]]

--- a/lib/types.py
+++ b/lib/types.py
@@ -1,0 +1,4 @@
+from shapely import geometry
+
+"""The datatype representing a 2D shape in the plane."""
+Shape = geometry.MultiPolygon

--- a/lib/utils/cache.py
+++ b/lib/utils/cache.py
@@ -6,7 +6,7 @@
 try:
     from functools import lru_cache
 except ImportError:
-    from backports.functools_lru_cache import lru_cache
+    from backports.functools_lru_cache import lru_cache  # type: ignore[no-redef]
 
 # simplify use of lru_cache decorator
 

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -133,6 +133,13 @@ class Point:
     def from_tuple(cls, point):
         return cls(point[0], point[1])
 
+    @classmethod
+    def from_iterable(cls, point):
+        tuple_ = (x for x in point)
+        if len(tuple_) != 2:
+            raise ValueError(f"Expected iterable of length 2, got {tuple_}")
+        return cls.from_tuple(tuple_)
+
     def __json__(self):
         return vars(self)
 
@@ -201,6 +208,10 @@ class Point:
 
     def __len__(self):
         return 2
+
+    def isclose(self, other: "Point", rel_tol: float) -> bool:
+        return (math.isclose(self.x, other.x, rel_tol=rel_tol)
+                and math.isclose(self.y, other.y, rel_tol=rel_tol))
 
 
 def line_string_to_point_list(line_string):

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,9 @@ scipy
 
 pywinutils ; sys_platform == 'win32'
 pywin32 ; sys_platform == 'win32'
+
+pytest==7.2.0
+pytest-mypy==0.10.0
+types-backports==0.1.3
+types-requests==2.28.11.2
+types-urllib3==1.26.25.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+addopts = --mypy lib/
+norecursedirs = venv __pycache__ node_modules .git

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[pycodestyle]
+max-line-length = 120
+exclude = venv,__pycache__,node_modules
 [tool:pytest]
 addopts = --mypy lib/
 norecursedirs = venv __pycache__ node_modules .git


### PR DESCRIPTION
Hi Lex,

While I was studying the codebase I found my lack of intuition for the types of the objects involved was a limiting factor, and there were also no unit tests of the lib/stitch algorithms. I figure as I explore it doesn't hurt to add a few unit tests.

Some things I ran into that could use your guidance:

- No existing pytest (or other test harness) appears to be in the CI for this repo. A vanilla call to "pytest" should suffice. Should I add it to the workflow?
- It was unclear to me why the output of intersect_region_with_grating is a list of _lists of length 1_, where the member of that length-1 list is itself the coordinate list of the grating segment. Should it instead be a doubly-nested list instead of a triply-nested list?
- My distro (Ubuntu 22.04.1 LTS "Jammy") doesn't have Python 3.8 packages. Is it OK that I'm working with Python3.9? What Python versions are officially supported by this project?
- I restricted the testing to only occur in `lib/` for now, but that also pre-supposes that you are OK with test files living right next to the source files---as opposed to being in a `tests/` directory, which I see exists but only has an SVG file in it. I defaulted to having the tests live next to the srcs, but let me know if you prefer otherwise.