### PR TITLE
Fixed bug where STOP command would cause colours to apply to the wrong stitches after the STOP in exported files

### DIFF
--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -44,25 +44,17 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
             continue
 
         if color_block.color != stitch_group.color:
-            if len(color_block) == 0:
-                # We just processed a stop, which created a new color block.
-                # end the previous block with a color change
-                stitch_plan.color_blocks[-2].add_stitch(color_change=True)
+            # add a lock stitch to the last element of the previous group
+            lock_stitches = previous_stitch_group.get_lock_stitches("end", disable_ties)
+            if lock_stitches:
+                color_block.add_stitches(stitches=lock_stitches)
+            need_tie_in = True
 
-                # We'll just claim this new block as ours:
-                color_block.color = stitch_group.color
-            else:
-                # add a lock stitch to the last element of the previous group
-                lock_stitches = previous_stitch_group.get_lock_stitches("end", disable_ties)
-                if lock_stitches:
-                    color_block.add_stitches(stitches=lock_stitches)
-                need_tie_in = True
+            # end the previous block with a color change
+            color_block.add_stitch(color_change=True)
 
-                # end the previous block with a color change
-                color_block.add_stitch(color_change=True)
-
-                # make a new block of our color
-                color_block = stitch_plan.new_color_block(color=stitch_group.color)
+            # make a new block of our color
+            color_block = stitch_plan.new_color_block(color=stitch_group.color)
         else:
             if (len(color_block) and not need_tie_in and
                     ((stitch_group.stitches[0] - color_block.stitches[-1]).length() > collapse_len or
@@ -94,7 +86,6 @@ def stitch_groups_to_stitch_plan(stitch_groups, collapse_len=None, min_stitch_le
 
         if stitch_group.stop_after:
             color_block.add_stitch(stop=True)
-            color_block = stitch_plan.new_color_block(color_block.color)
 
         previous_stitch_group = stitch_group
 


### PR DESCRIPTION
I was trying to export a file that used the ‘Stop (pause machine) after sewing this object’ command. The result was that all colours after the `STOP` command in the output file were mismatched. After a bit of digging I found that the `STOP` command generates a new `color_block` in the `stitch_plan`, but it doesn't output a `COLOR_CHANGE` command, so the thread list gets out of sync with the `COLOR_CHANGE` commands.

This commit fixes this by only adding a thread to the pyembroidery pattern when a stitch is attempted after a `COLOR_CHANGE` command.

An alternative fix would be to change the creation of the `stitch_plan` so that `STOP` doesn't create a new `color_block`, but I didn't investigate whether that would have any other side effects. In any case, this fix should guarantee that the one new thread gets added for each `COLOR_CHANGE` command.

This may possibly be related to #1105 and/or #1286 but I'm not certain.