### PR TITLE
Troubleshoot: small zigzag warning

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -216,7 +216,8 @@ class FillStitch(EmbroideryElement):
     @property
     @param('staggers',
            _('Stagger rows this many times before repeating'),
-           tooltip=_('Length of the cycle by which successive stitch rows are staggered. Fractional values are allowed and can have less visible diagonals than integer values.'),
+           tooltip=_('Length of the cycle by which successive stitch rows are staggered.'
+                     'Fractional values are allowed and can have less visible diagonals than integer values.'),
            type='int',
            sort_index=6,
            select_items=[('fill_method', 0), ('fill_method', 2), ('fill_method', 3)],

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -38,7 +38,7 @@ def row_num(point, angle, row_spacing):
 
 def adjust_stagger(stitch, angle, row_spacing, max_stitch_length, staggers):
     if staggers == 0:
-        staggers = 1 # sanity check to avoid division by zero.
+        staggers = 1  # sanity check to avoid division by zero.
     this_row_num = row_num(stitch, angle, row_spacing)
     stagger_phase = (this_row_num / staggers) % 1
     stagger_offset = stagger_phase * max_stitch_length

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -149,7 +149,7 @@ def take_only_line_strings(thing):
 
 def apply_stitches(line, max_stitch_length, num_staggers, row_spacing, row_num):
     if num_staggers == 0:
-        num_staggers = 1 # sanity check to avoid division by zero.
+        num_staggers = 1  # sanity check to avoid division by zero.
     start = ((row_num / num_staggers) % 1) * max_stitch_length
     projections = np.arange(start, line.length, max_stitch_length)
     points = np.array([line.interpolate(projection).coords[0] for projection in projections])


### PR DESCRIPTION
Integrate the small zig zag warning into the troubleshoot extension. They may wanted to use a dashed line instead.