### PR TITLE
Fix satin offset_points

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -113,8 +113,8 @@ class FillStitch(EmbroideryElement):
     @property
     @param('guided_fill_strategy', _('Guided Fill Strategy'), type='dropdown', default=0,
            options=[_("Copy"), _("Parallel Offset")], select_items=[('fill_method', 2)], sort_index=3,
-           tooltip=_('Copy (the default) will fill the shape with shifted copies of the line.' +
-                     'Parallel offset will ensure that each line is always a consistent distance from its neighbor.' +
+           tooltip=_('Copy (the default) will fill the shape with shifted copies of the line. '
+                     'Parallel offset will ensure that each line is always a consistent distance from its neighbor. '
                      'Sharp corners may be introduced.'))
     def guided_fill_strategy(self):
         return self.get_int_param('guided_fill_strategy', 0)
@@ -216,7 +216,7 @@ class FillStitch(EmbroideryElement):
     @property
     @param('staggers',
            _('Stagger rows this many times before repeating'),
-           tooltip=_('Length of the cycle by which successive stitch rows are staggered.'
+           tooltip=_('Length of the cycle by which successive stitch rows are staggered. '
                      'Fractional values are allowed and can have less visible diagonals than integer values.'),
            type='int',
            sort_index=6,

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -124,7 +124,7 @@ class SatinColumn(EmbroideryElement):
     @param(
         'pull_compensation_percent',
         _('Pull compensation percentage'),
-        tooltip=_('Additional pull compensation which varries as a percentage of stitch width. '
+        tooltip=_('Additional pull compensation which varies as a percentage of stitch width. '
                   'Two values separated by a space may be used for an aysmmetric effect.'),
         unit='% (each side)',
         type='float',
@@ -654,7 +654,7 @@ class SatinColumn(EmbroideryElement):
 
         # don't contract beyond the midpoint, or we'll start expanding
         if offset_total < -distance:
-            scale = distance / offset_total
+            scale = -distance / offset_total
             offset_a = offset_a * scale
             offset_b = offset_b * scale
 
@@ -799,6 +799,7 @@ class SatinColumn(EmbroideryElement):
         # center line between the bezier curves.
 
         inset_prop = -np.array([self.center_walk_underlay_position, 100-self.center_walk_underlay_position]) / 100
+
         # Do it like contour underlay, but inset all the way to the center.
         forward, back = self.plot_points_on_rails(
             self.center_walk_underlay_stitch_length,

--- a/lib/stitches/ripple_stitch.py
+++ b/lib/stitches/ripple_stitch.py
@@ -220,7 +220,7 @@ def _get_start_rotation(line):
 
 def _generate_satin_guide_helper_lines(stroke, outline, guide_line):
     spacing = guide_line.center_line.length / (stroke.get_line_count() - 1)
-    rail_points = guide_line.plot_points_on_rails(spacing, 0)
+    rail_points = guide_line.plot_points_on_rails(spacing)
 
     point0 = rail_points[0][0]
     point1 = rail_points[1][0]


### PR DESCRIPTION
@george-steel When using position offset for centerline underlay, I noticed strange behaviour.

![satin_centerline_position](https://user-images.githubusercontent.com/36401965/204128039-0e9f0fe5-b578-4618-a8fa-841d77930de3.png)

I believe this is due to a missing minus sign in the scale calculation. This branch here should fix the issue.