### PR TITLE
Split font files

### DIFF
--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -160,6 +160,9 @@ class Font(object):
         for variant in FontVariant.VARIANT_TYPES:
             if os.path.isfile(os.path.join(self.path, "%s.svg" % variant)):
                 font_variants.append(variant)
+            elif (os.path.isdir(os.path.join(self.path, "%s" % variant)) and
+                    [svg for svg in os.listdir(os.path.join(self.path, "%s" % variant)) if svg.endswith('.svg')]):
+                font_variants.append(variant)
         if not font_variants:
             raise FontError(_("The font '%s' has no variants.") % self.name)
         return font_variants


### PR DESCRIPTION
I made this a while ago and totally forgot about it. Well, here it is.

Enables font creators to create folders with those arrows and place multiple font files in them.
So e.g. if they work at the same font at the same time, they can split up the font file and still have it all running.