### PR TITLE
Add extension: Lettering along path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
           sudo apt-get install gettext
 
           # for wxPython
+          sudo apt install libnotify4
           sudo apt install glib-networking libsdl2-dev libsdl2-2.0-0
 
           # for PyGObject

--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -48,6 +48,8 @@ from .stitch_plan_preview import StitchPlanPreview
 from .stitch_plan_preview_undo import StitchPlanPreviewUndo
 from .zip import Zip
 
+from.lettering_along_path import LetteringAlongPath
+
 __all__ = extensions = [StitchPlanPreview,
                         StitchPlanPreviewUndo,
                         DensityMap,
@@ -75,6 +77,7 @@ __all__ = extensions = [StitchPlanPreview,
                         LetteringRemoveKerning,
                         LetteringCustomFontDir,
                         LetteringForceLockStitches,
+                        LetteringAlongPath,
                         LettersToFont,
                         Troubleshoot,
                         RemoveEmbroiderySettings,

--- a/lib/extensions/lettering_along_path.py
+++ b/lib/extensions/lettering_along_path.py
@@ -1,0 +1,136 @@
+# Authors: see git history
+#
+# Copyright (c) 2021 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import json
+import sys
+from math import atan2, degrees
+
+from inkex import Transform, errormsg
+from inkex.units import convert_unit
+from shapely.ops import substring
+
+from ..elements import Stroke
+from ..i18n import _
+from ..svg.tags import EMBROIDERABLE_TAGS, INKSTITCH_LETTERING, SVG_GROUP_TAG
+from ..utils import DotDict
+from ..utils import Point as InkstitchPoint
+from .base import InkstitchExtension
+
+
+class LetteringAlongPath(InkstitchExtension):
+    '''
+    This extension aligns an Ink/Stitch Lettering group along a path
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-o", "--options", type=str, default=None, dest="page_1")
+        self.arg_parser.add_argument("-i", "--info", type=str, default=None, dest="page_2")
+        self.arg_parser.add_argument("-s", "--stretch-spaces", type=int, default="", dest="stretch_spaces")
+
+    def effect(self):
+        text, path = self.get_selection()
+
+        # we ignore everything but the first path/text
+        text_bbox = text.bounding_box()
+        text_y = text_bbox.bottom
+        glyphs = [glyph for glyph in text.iterdescendants(SVG_GROUP_TAG) if len(glyph.label) == 1]
+
+        path = Stroke(path).as_multi_line_string().geoms[0]
+        path_length = path.length
+
+        if self.options.stretch_spaces:
+            self.load_settings(text)
+            text = self.settings["text"]
+            space_indices = [i for i, t in enumerate(text) if t == " "]
+            text_width = convert_unit(text_bbox.width, "px", self.svg.unit)
+
+            if len(text) - 1 != 0:
+                stretch_space = (path_length - text_width) / (len(text) - 1)
+            else:
+                stretch_space = 0
+        else:
+            stretch_space = 0
+            space_indices = []
+
+        self.transform_glyphs(glyphs, path, stretch_space, space_indices, text_y)
+
+    def transform_glyphs(self, glyphs, path, stretch_space, space_indices, text_y):
+        distance = 0
+        old_bbox = None
+        i = 0
+
+        for glyph in glyphs:
+            # dimensions
+            bbox = glyph.bounding_box()
+            width = bbox.width
+            x = bbox.left
+
+            # adjust position
+            if old_bbox:
+                distance += bbox.left - old_bbox.right + stretch_space
+
+            if self.options.stretch_spaces and i in space_indices:
+                distance += stretch_space
+                i += 1
+
+            new_distance = distance + width
+
+            # calculate and apply transform
+            first = substring(path, distance, distance)
+            last = substring(path, new_distance, new_distance)
+
+            angle = degrees(atan2(last.y - first.y, last.x - first.x)) % 360
+            translate = InkstitchPoint(first.x, first.y) - InkstitchPoint(x, text_y)
+
+            transform = Transform(f"rotate({angle}, {first.x}, {first.y}) translate({translate.x} {translate.y})")
+            glyph.transform = transform @ glyph.transform
+
+            # set values for next iteration
+            distance = new_distance
+            old_bbox = bbox
+            i += 1
+
+    def load_settings(self, text):
+        """Load the settings saved into the text element"""
+
+        self.settings = DotDict({
+            "text": "",
+            "back_and_forth": False,
+            "font": None,
+            "scale": 100,
+            "trim_option": 0
+        })
+
+        if INKSTITCH_LETTERING in text.attrib:
+            try:
+                self.settings.update(json.loads(text.get(INKSTITCH_LETTERING)))
+            except (TypeError, ValueError):
+                pass
+
+    def get_selection(self):
+        groups = list()
+        paths = list()
+
+        for node in self.svg.selection:
+            lettering = False
+            if node.tag == SVG_GROUP_TAG and INKSTITCH_LETTERING in node.attrib:
+                groups.append(node)
+                lettering = True
+                continue
+
+            for group in node.iterancestors(SVG_GROUP_TAG):
+                if INKSTITCH_LETTERING in group.attrib:
+                    groups.append(group)
+                    lettering = True
+                    break
+
+            if not lettering and node.tag in EMBROIDERABLE_TAGS:
+                paths.append(node)
+
+        if not groups or not paths:
+            errormsg(_("Please select one path and one Ink/Stitch lettering group."))
+            sys.exit(1)
+
+        return [groups[0], paths[0]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ./pyembroidery
 
 # inkex is not currently uploaded to pypi, the version there is extremely out of date
-inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.1
+inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.2.2
 
 # lower bound to allow for the use of system packages on Debian and distros that have updated to 4.2
 # CI adds an == 4.1.1 constraint for prebuilt packages

--- a/templates/lettering_along_path.xml
+++ b/templates/lettering_along_path.xml
@@ -11,20 +11,17 @@
     </effect>
     <param name="options" type="notebook">
       <page name="options" gui-text="Options">
-        <param name="stretch-spaces" type="optiongroup" appearance="combo" gui-text="Stretch"
-               gui-description="Expand glyph and word spacing to stretch lettering over the entire path" indent="1">
-             <option value="0">No</option>
-             <option value="1">Yes</option>
-        </param>
+        <param name="stretch-spaces" type="bool" gui-text="Stretch"
+               gui-description="Expand glyph and word spacing to stretch lettering over the entire path">false</param>
       </page>
       <page name="info" gui-text="Help">
         <label appearance="header">This extension bends an Ink/Stitch text to a path.</label>
         <label>Select Ink/Stitch text and a path before running this extension.</label>
         <spacer />
         <label>The text needs to meet these conditions:</label>
-        <label indent="1">* The text hasn't been transformed</label>
         <label indent="1">* The text consists of only one line of text</label>
         <label indent="1">* The text should not be too large for the given path</label>
+        <label indent="1">* Text text should not contain trim symbols</label>
         <spacer />
         <label>The stretch option defines whether the spaces between glyphs should be expanded so that the text stretches over the entire path.</label>
       </page>

--- a/templates/lettering_along_path.xml
+++ b/templates/lettering_along_path.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Lettering along path</name>
+    <id>org.inkstitch.lettering_along_path</id>
+    <param name="extension" type="string" gui-hidden="true">lettering_along_path</param>
+    <effect needs-live-preview="false">
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch" translatable="no" />
+        </effects-menu>
+    </effect>
+    <param name="options" type="notebook">
+      <page name="options" gui-text="Options">
+        <param name="stretch-spaces" type="optiongroup" appearance="combo" gui-text="Stretch"
+               gui-description="Expand glyph and word spacing to stretch lettering over the entire path" indent="1">
+             <option value="0">No</option>
+             <option value="1">Yes</option>
+        </param>
+      </page>
+      <page name="info" gui-text="Help">
+        <label appearance="header">This extension bends an Ink/Stitch text to a path.</label>
+        <label>Select Ink/Stitch text and a path before running this extension.</label>
+        <spacer />
+        <label>The text needs to meet these conditions:</label>
+        <label indent="1">* The text hasn't been transformed</label>
+        <label indent="1">* The text consists of only one line of text</label>
+        <label indent="1">* The text should not be too large for the given path</label>
+        <spacer />
+        <label>The stretch option defines whether the spaces between glyphs should be expanded so that the text stretches over the entire path.</label>
+      </page>
+    </param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
I see a lot of people having a hard time to bend their Ink/Stitch lettering text along a path.

Using the path effect "bend path" works, but it stretches the letters, so that it is difficult to achieve good results. Means users need to rotate and position each glyph by hand. Let's give them a new extension to make it a little bit easier for them. The extension can also stretch the text spacings, so that it will expand over the entire path (if desired).