### PR TITLE
Add bean stitch repeat pattern

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -162,6 +162,16 @@ class EmbroideryElement(object):
     def get_split_mm_param_as_px(self, param, default):
         return self.get_split_float_param(param, default) * PIXELS_PER_MM
 
+    # returns an array of multiple space separated int values
+    @cache
+    def get_multiple_int_param(self, param, default="0"):
+        params = self.get_param(param, default).split(" ")
+        try:
+            params = [int(param) for param in params]
+        except (TypeError, ValueError):
+            return [default]
+        return params
+
     def set_param(self, name, value):
         param = INKSTITCH_ATTRIBS[name]
         self.node.set(param, str(value))

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -415,6 +415,8 @@ class FillStitch(EmbroideryElement):
         default_value = [self.angle + math.pi / 2.0]
         if underlay_angles is not None:
             underlay_angles = underlay_angles.strip().split(' ')
+            # remove comma separator for backward compatibility
+            underlay_angles = [angle[:-1] if angle.endswith(',') else angle for angle in underlay_angles]
             try:
                 underlay_angles = [math.radians(
                     float(angle)) for angle in underlay_angles]

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -405,7 +405,7 @@ class FillStitch(EmbroideryElement):
     @property
     @param('fill_underlay_angle',
            _('Fill angle'),
-           tooltip=_('Default: fill angle + 90 deg. Insert comma-seperated list for multiple layers.'),
+           tooltip=_('Default: fill angle + 90 deg. Insert a list for multiple layers separated by a space.'),
            unit='deg',
            group=_('Fill Underlay'),
            type='float')
@@ -414,7 +414,7 @@ class FillStitch(EmbroideryElement):
         underlay_angles = self.get_param('fill_underlay_angle', None)
         default_value = [self.angle + math.pi / 2.0]
         if underlay_angles is not None:
-            underlay_angles = underlay_angles.strip().split(',')
+            underlay_angles = underlay_angles.strip().split(' ')
             try:
                 underlay_angles = [math.radians(
                     float(angle)) for angle in underlay_angles]

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -101,12 +101,13 @@ class Stroke(EmbroideryElement):
         _('Bean stitch number of repeats'),
         tooltip=_('Backtrack each stitch this many times.  '
                   'A value of 1 would triple each stitch (forward, back, forward).  '
-                  'A value of 2 would quintuple each stitch, etc.'),
-        type='int',
+                  'A value of 2 would quintuple each stitch, etc.\n\n'
+                  'A pattern with various repeats can be created with a list of values separated by a space.'),
+        type='str',
         default=0,
         sort_index=3)
     def bean_stitch_repeats(self):
-        return self.get_int_param("bean_stitch_repeats", 0)
+        return self.get_multiple_int_param("bean_stitch_repeats", "0")
 
     @property
     @param('running_stitch_length_mm',
@@ -452,7 +453,7 @@ class Stroke(EmbroideryElement):
         if self.stroke_method == 1:
             patch = self.ripple_stitch()
             if patch:
-                if self.bean_stitch_repeats > 0:
+                if any(self.bean_stitch_repeats):
                     patch.stitches = self.do_bean_repeats(patch.stitches)
                 patches.append(patch)
         else:
@@ -464,7 +465,8 @@ class Stroke(EmbroideryElement):
                 # running stitch
                 elif self.is_running_stitch():
                     patch = self.running_stitch(path, self.running_stitch_length, self.running_stitch_tolerance)
-                    if self.bean_stitch_repeats > 0:
+                    # bean stitch
+                    if any(self.bean_stitch_repeats):
                         patch.stitches = self.do_bean_repeats(patch.stitches)
                 # simple satin
                 else:

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -79,24 +79,35 @@ def running_stitch(points, stitch_length, tolerance):
 def bean_stitch(stitches, repeats):
     """Generate bean stitch from a set of stitches.
 
-    "Bean" stitch is made by backtracking each stitch to make it heaver.  A
+    "Bean" stitch is made by backtracking each stitch to make it heavier.  A
     simple bean stitch would be two stitches forward, one stitch back, two
     stitches forward, etc.  This would result in each stitch being tripled.
 
     We'll say that the above counts as 1 repeat.  Backtracking each stitch
     repeatedly will result in a heavier bean stitch.  There will always be
     an odd number of threads piled up for each stitch.
+
+    Repeats is a list of a repeated pattern e.g. [0, 1, 3] doesn't repeat the first stitch,
+    goes back and forth on the second stitch, goes goes 3 times back and forth on the third stitch,
+    and starts the pattern again by not repeating the fourth stitch, etc.
     """
 
     if len(stitches) < 2:
         return stitches
+
+    repeat_list_length = len(repeats)
+    repeat_list_pos = 0
 
     new_stitches = [stitches[0]]
 
     for stitch in stitches:
         new_stitches.append(stitch)
 
-        for i in range(repeats):
+        for i in range(repeats[repeat_list_pos]):
             new_stitches.extend(copy(new_stitches[-2:]))
+
+        repeat_list_pos += 1
+        if repeat_list_pos == repeat_list_length:
+            repeat_list_pos = 0
 
     return new_stitches


### PR DESCRIPTION
This is based on a feature request I have received (not on GitHub).
It's is an addition to the bean stitch. If you enter space separated multiple integer values, it will repeat the stitches with the given pattern. For example "0 1" will do one normal stitch and then a triple stitch, etc. Something like this: -=-=-=-=