### PR TITLE
expose the trim_after param in the interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ locales/
 /profile_stats
 /profile_stats.prof
 /.vscode
+__pycache__

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -342,6 +342,12 @@ class EmbroideryElement(object):
         return self.strip_control_points(path[0])
 
     @property
+    @param('trim_after',
+           _ ('Trim After'),
+           tooltip=_('Add a TRIM command after stitching this object.'),
+           type='boolean',
+           default=False,
+           sort_index=52)
     def trim_after(self):
         return self.get_boolean_param('trim_after', False)
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -352,6 +352,12 @@ class EmbroideryElement(object):
         return self.get_boolean_param('trim_after', False)
 
     @property
+    @param('stop_after',
+           _ ('Stop After'),
+           tooltip=_('Add a STOP command after stitching this object.'),
+           type='boolean',
+           default=False,
+           sort_index=53)
     def stop_after(self):
         return self.get_boolean_param('stop_after', False)
 


### PR DESCRIPTION
This provides an alternative to the connector-based commands (which inkscape can't copy-paste) allowing for re-usable embroidery elements with trims. `trim_after` has been around for a long time as a hidden param, but never exposed.