### PR TITLE
Point to troubleshoot in fatal error message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml
           pip uninstall --yes shapely
-          pip install -v -U Shapely==1.8.1 --no-binary Shapely
+          pip install -v -U Shapely==1.8.5 --no-binary Shapely
           pip install pyinstaller
 
           echo "${{ env.pythonLocation }}/bin" >> $GITHUB_PATH

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -393,7 +393,7 @@ class EmbroideryElement(object):
         error_msg = "%s %s: %s" % (_("Failed on "), name, message)
         if point_to_troubleshoot:
             error_msg += "\n\n%s" % _("Please run Extensions > Ink/Stitch > Troubleshoot > Troubleshoot objects. "
-                "This will indicate the errorneus position.")
+                                      "This will indicate the errorneus position.")
         inkex.errormsg(error_msg)
         sys.exit(1)
 

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -380,7 +380,7 @@ class EmbroideryElement(object):
 
         return patches
 
-    def fatal(self, message):
+    def fatal(self, message, point_to_troubleshoot=False):
         label = self.node.get(INKSCAPE_LABEL)
         id = self.node.get("id")
         if label:
@@ -389,8 +389,11 @@ class EmbroideryElement(object):
             name = id
 
         # L10N used when showing an error message to the user such as
-        # "Some Path (path1234): error: satin column: One or more of the rungs doesn't intersect both rails."
-        error_msg = "%s: %s %s" % (name, _("error:"), message)
+        # "Failed on PathLabel (path1234): Satin column: One or more of the rungs doesn't intersect both rails."
+        error_msg = "%s %s: %s" % (_("Failed on "), name, message)
+        if point_to_troubleshoot:
+            error_msg += "\n\n%s" % _("Please run Extensions > Ink/Stitch > Troubleshoot > Troubleshoot objects. "
+                "This will indicate the errorneus position.")
         inkex.errormsg(error_msg)
         sys.exit(1)
 
@@ -425,4 +428,4 @@ class EmbroideryElement(object):
 
         for error in self.validation_errors():
             # note that self.fatal() exits, so this only shows the first error
-            self.fatal(error.description)
+            self.fatal(error.description, True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ wxPython>=4.1.1
 
 backports.functools_lru_cache
 networkx
-shapely
+shapely==1.8.5
 lxml
 appdirs
 numpy


### PR DESCRIPTION
A lot of people don't know how to intrepret the error message if Ink/Stitch fails on an object.
Maybe a pointer to the troubleshoot extension can help them to handle their issues better?!?