### PR TITLE
Add insensitive option to stitch plan

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from lxml import etree
-
 from inkex import Boolean, Style
+from lxml import etree
 
 from ..stitch_plan import stitch_groups_to_stitch_plan
 from ..svg import render_stitch_plan
-from ..svg.tags import (INKSCAPE_GROUPMODE, INKSTITCH_ATTRIBS, SVG_DEFS_TAG,
-                        SVG_GROUP_TAG, SVG_PATH_TAG)
+from ..svg.tags import (INKSCAPE_GROUPMODE, INKSTITCH_ATTRIBS,
+                        SODIPODI_INSENSITIVE, SVG_DEFS_TAG, SVG_GROUP_TAG,
+                        SVG_PATH_TAG)
 from .base import InkstitchExtension
 from .stitch_plan_preview_undo import reset_stitch_plan
 
@@ -21,6 +21,7 @@ class StitchPlanPreview(InkstitchExtension):
         self.arg_parser.add_argument("-s", "--move-to-side", type=Boolean, default=True, dest="move_to_side")
         self.arg_parser.add_argument("-v", "--layer-visibility", type=int, default=0, dest="layer_visibility")
         self.arg_parser.add_argument("-n", "--needle-points", type=Boolean, default=False, dest="needle_points")
+        self.arg_parser.add_argument("-i", "--insensitive", type=Boolean, default=False, dest="insensitive")
 
     def effect(self):
         # delete old stitch plan
@@ -57,6 +58,11 @@ class StitchPlanPreview(InkstitchExtension):
                 if (g.get(INKSCAPE_GROUPMODE) == "layer" and not g == layer and
                         float(style.get('opacity', 1)) > 0.4 and not style.get('display', 'inline') == 'none'):
                     g.style['opacity'] = 0.4
+
+        if self.options.insensitive is True:
+            layer.set(SODIPODI_INSENSITIVE, True)
+        else:
+            layer.set(SODIPODI_INSENSITIVE, False)
 
         # translate stitch plan to the right side of the canvas
         if self.options.move_to_side:

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -40,6 +40,7 @@ XLINK_HREF = inkex.addNS('href', 'xlink')
 SODIPODI_NAMEDVIEW = inkex.addNS('namedview', 'sodipodi')
 SODIPODI_GUIDE = inkex.addNS('guide', 'sodipodi')
 SODIPODI_ROLE = inkex.addNS('role', 'sodipodi')
+SODIPODI_INSENSITIVE = inkex.addNS('insensitive', 'sodipodi')
 
 INKSTITCH_LETTERING = inkex.addNS('lettering', 'inkstitch')
 

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -18,6 +18,7 @@
         <option value="2">Lower opacity</option>
     </param>
     <param name="needle-points" type="boolean" gui-text="Needle points">false</param>
+    <param name="insensitive" type="boolean" gui-text="Insensitive">false</param>
     <spacer />
     <script>
         {{ command_tag | safe }}

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -18,7 +18,8 @@
         <option value="2">Lower opacity</option>
     </param>
     <param name="needle-points" type="boolean" gui-text="Needle points">false</param>
-    <param name="insensitive" type="boolean" gui-text="Insensitive">false</param>
+    <param name="insensitive" type="boolean" gui-text="Lock"
+           gui-description="Make stitch plan insensitive to mouse interactions">false</param>
     <spacer />
     <script>
         {{ command_tag | safe }}


### PR DESCRIPTION
Since we have the option to undo the stitch plan preview, we may want to work on the design with an active stitch plan. It is annoying to have to lock it everytime in order to select design elements without accidentally moving parts of the stitch plan around. So let's add an option to lock the stitch plan automatically.