### PR TITLE
Replace running stitch algorithm to give consistent stitch lengths

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -873,9 +873,11 @@ class SatinColumn(EmbroideryElement):
         pairs = self.plot_points_on_rails(
             self.contour_underlay_stitch_length,
             -self.contour_underlay_inset_px, -self.contour_underlay_inset_percent/100)
-        stitches = [p[0] for p in pairs] + [p[1] for p in reversed(pairs)]
+
         if self._center_walk_is_odd():
-            stitches = list(reversed(stitches))
+            stitches = [p[0] for p in reversed(pairs)] + [p[1] for p in pairs]
+        else:
+            stitches = [p[1] for p in pairs] + [p[0] for p in reversed(pairs)]
 
         return StitchGroup(
             color=self.color,

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -432,21 +432,20 @@ class Stroke(EmbroideryElement):
         return patch
 
     def running_stitch(self, path, stitch_length, tolerance):
-        repeated_path = []
+        stitches = running_stitch(path, stitch_length, tolerance)
 
+        repeated_stitches = []
         # go back and forth along the path as specified by self.repeats
         for i in range(self.repeats):
             if i % 2 == 1:
                 # reverse every other pass
-                this_path = path[::-1]
+                this_path = stitches[::-1]
             else:
-                this_path = path[:]
+                this_path = stitches[:]
 
-            repeated_path.extend(this_path)
+            repeated_stitches.extend(this_path)
 
-        stitches = running_stitch(repeated_path, stitch_length, tolerance)
-
-        return StitchGroup(self.color, stitches)
+        return StitchGroup(self.color, repeated_stitches)
 
     def ripple_stitch(self):
         return StitchGroup(

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -209,6 +209,8 @@ def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tole
 
 def path_to_curves(points: typing.List[Point]):
     # split a path at obvious corner points so that they get stitched exactly
+    if len(points) < 3:
+        return [points]
     curves = []
     last = 0
     last_seg = points[1] - points[0]

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -151,13 +151,10 @@ def cut_segment_with_circle(origin: Point, r: float, a: Point, b: Point) -> Poin
     return a + d*t
 
 
-def take_stitch(start: Point | None, points: typing.Sequence[Point], idx: int, stitch_length: float, tolerance: float):
+def take_stitch(start: Point, points: typing.Sequence[Point], idx: int, stitch_length: float, tolerance: float):
     # Based on a single step of the Zhao-Saalfeld curve simplification algorithm.
     # https://cartogis.org/docs/proceedings/archive/auto-carto-13/pdf/linear-time-sleeve-fitting-polyline-simplification-algorithms.pdf
     # Adds early termination condition based on stitch length.
-    if not start and idx < len(points):
-        start = points[idx]
-        idx += 1
     if idx >= len(points):
         return None, None
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -82,6 +82,7 @@ class AngleInterval():
             return None
         elif diff < math.pi:
             return AngleInterval(angleA - 1e-6, angleB + 1e-6)
+            # slightly larger than normal to avoid rounding error when this method is used in cutSegment
         else:
             return AngleInterval(angleB - 1e-6, angleA + 1e-6)
 
@@ -183,7 +184,8 @@ def take_stitch(start: Point, points: typing.Sequence[Point], idx: int, stitch_l
 
 
 def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tolerance: float):
-    # includes end point but not start point.
+    # Will split a straight line into even-length stitches while still handling curves correctly.
+    # Includes end point but not start point.
     if len(points) < 2:
         return []
     distLeft = [0] * len(points)
@@ -207,31 +209,39 @@ def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tole
     return stitches
 
 
-def path_to_curves(points: typing.List[Point]):
+def path_to_curves(points: typing.List[Point], min_len: float):
     # split a path at obvious corner points so that they get stitched exactly
+    # min_len controls the minimum length after splitting for which it won't split again,
+    # which is used to avoid creating large numbers of corner points when encouintering micro-messes.
     if len(points) < 3:
         return [points]
     curves = []
     last = 0
     last_seg = points[1] - points[0]
+    seg_len = last_seg.length()
     for i in range(1, len(points) - 1):
         a = last_seg
         b = points[i + 1] - points[i]
         aabb = (a * a) * (b * b)
         abab = (a * b) * abs(a * b)
-        if aabb > 0 and 2 * abab < aabb:
+        if aabb > 0 and abab < 0.5 * aabb:
             # inner angle of at most 135 deg
-            curves.append(points[last: i + 1])
-            last = i
+            if seg_len >= min_len:
+                curves.append(points[last: i + 1])
+                last = i
+            seg_len = 0
         if b * b > 0:
             last_seg = b
+        seg_len += b.length()
     curves.append(points[last:])
     return curves
 
 
 def running_stitch(points, stitch_length, tolerance):
+    # Turn a continuous path into a running stitch.
     stitches = [points[0]]
-    for curve in path_to_curves(points):
+    for curve in path_to_curves(points, 2 * tolerance):
+        # segments longer than twice the tollerance will usually be forced by it, so set that as the minimum for corner detection
         stitches.extend(stitch_curve_even(curve, stitch_length, tolerance))
     return stitches
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -227,9 +227,9 @@ def path_to_curves(points: typing.List[Point], min_len: float):
         aabb = (a * a) * (b * b)
         abab = (a * b) * abs(a * b)
 
-        # Test if the turn angle from vectors a to b is more than 45 degrees
-        # Uses the property of inner products that abab = ± aabb * cos(angle(a,b))**2
-        if aabb > 0 and abab < 0.5 * aabb:
+        # Test if the turn angle from vectors a to b is more than 45 degrees.
+        # Optimized version of checking if cos(angle(a,b)) <= sqrt(0.5) and is defined
+        if aabb > 0 and abab <= 0.5 * aabb:
             if seg_len >= min_len:
                 curves.append(points[last: i + 1])
                 last = i

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -118,6 +118,8 @@ class AngleInterval():
         if self.all:
             return None
         segArc = AngleInterval.fromSegment(a - origin, b - origin)
+        if segArc is None:
+            return a  # b is exactly behind origin from a
         if segArc.containsAngle(self.a):
             return cut_segment_with_angle(origin, self.a, a, b)
         elif segArc.containsAngle(self.b):
@@ -209,15 +211,18 @@ def path_to_curves(points: typing.List[Point]):
     # split a path at obvious corner points so that they get stitched exactly
     curves = []
     last = 0
+    last_seg = points[1] - points[0]
     for i in range(1, len(points) - 1):
-        a = points[i] - points[i-1]
+        a = last_seg
         b = points[i + 1] - points[i]
         aabb = (a * a) * (b * b)
-        abab = (a * b) * (a * b)
-        if aabb > 0.000001 and 2 * abab < aabb:
+        abab = (a * b) * abs(a * b)
+        if aabb > 0 and 2 * abab < aabb:
             # inner angle of at most 135 deg
-            curves.append(points[last: i+1])
+            curves.append(points[last: i + 1])
             last = i
+        if b * b > 0:
+            last_seg = b
     curves.append(points[last:])
     return curves
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -127,6 +127,7 @@ class AngleInterval():
 
 
 def cut_segment_with_angle(origin: Point, angle: float, a: Point, b: Point) -> Point:
+    # Assumes the crossing is inside the segment
     p = a - origin
     d = b - a
     c = Point(math.cos(angle), math.sin(angle))
@@ -137,6 +138,7 @@ def cut_segment_with_angle(origin: Point, angle: float, a: Point, b: Point) -> P
 
 
 def cut_segment_with_circle(origin: Point, r: float, a: Point, b: Point) -> Point:
+    # assumes that a is inside the circle and b is outside
     p = a - origin
     d = b - a
     # inner products
@@ -191,7 +193,10 @@ def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tole
     stitches = []
     while i is not None and i < len(points):
         d = last.distance(points[i]) + distLeft[i]
-        stitch_len = d / math.ceil(d / stitch_length) if d > 0 else stitch_length
+        if d == 0:
+            return stitches
+        stitch_len = d / math.ceil(d / stitch_length) + 0.000001  # correction for rounding error
+
         stitch, newidx = take_stitch(last, points, i, stitch_len, tolerance)
         i = newidx
         if stitch is not None:
@@ -201,6 +206,7 @@ def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tole
 
 
 def path_to_curves(points: typing.List[Point]):
+    # split a path at obvious corner points so that they get stitched exactly
     curves = []
     last = 0
     for i in range(1, len(points) - 1):

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -183,7 +183,7 @@ def take_stitch(start: Point, points: typing.Sequence[Point], idx: int, stitch_l
     return points[-1], None
 
 
-def stitch_curve_even(points: typing.Sequence[Point], stitch_length: float, tolerance: float):
+def stitch_curve_evenly(points: typing.Sequence[Point], stitch_length: float, tolerance: float):
     # Will split a straight line into even-length stitches while still handling curves correctly.
     # Includes end point but not start point.
     if len(points) < 2:
@@ -216,23 +216,29 @@ def path_to_curves(points: typing.List[Point], min_len: float):
     if len(points) < 3:
         return [points]
     curves = []
+
     last = 0
     last_seg = points[1] - points[0]
     seg_len = last_seg.length()
     for i in range(1, len(points) - 1):
+        # vectors of the last and next segments
         a = last_seg
         b = points[i + 1] - points[i]
         aabb = (a * a) * (b * b)
         abab = (a * b) * abs(a * b)
+
+        # Test if the turn angle from vectors a to b is more than 45 degrees
+        # Uses the property of inner products that abab = ± aabb * cos(angle(a,b))**2
         if aabb > 0 and abab < 0.5 * aabb:
-            # inner angle of at most 135 deg
             if seg_len >= min_len:
                 curves.append(points[last: i + 1])
                 last = i
             seg_len = 0
+
         if b * b > 0:
             last_seg = b
         seg_len += b.length()
+
     curves.append(points[last:])
     return curves
 
@@ -242,7 +248,7 @@ def running_stitch(points, stitch_length, tolerance):
     stitches = [points[0]]
     for curve in path_to_curves(points, 2 * tolerance):
         # segments longer than twice the tollerance will usually be forced by it, so set that as the minimum for corner detection
-        stitches.extend(stitch_curve_even(curve, stitch_length, tolerance))
+        stitches.extend(stitch_curve_evenly(curve, stitch_length, tolerance))
     return stitches
 
 

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -211,6 +211,9 @@ class Point:
     def unit(self):
         return self.mul(1.0 / self.length())
 
+    def angle(self):
+        return math.atan2(self.y, self.x)
+
     def rotate_left(self):
         return self.__class__(-self.y, self.x)
 
@@ -228,6 +231,9 @@ class Point:
 
     def __len__(self):
         return 2
+
+    def __str__(self):
+        return "({0:.3f}, {1:.3f})".format(self.x, self.y)
 
 
 def line_string_to_point_list(line_string):


### PR DESCRIPTION
Use a modified Zhao-Saalfeld algorithm for running stitch instead of the previous Douglas-Peucker + additional subdivision. This makes stitch lengths much more consistent while still shortening stitches in order to stay within curve tolerance.

* Improves runtime of running stitch from quadratic to linear time.
* Also fix bug with interaction of contour and center-walk underlay in satin stitches.

Fixes #1676 