### PR TITLE
Add filename to .dst header

### DIFF
--- a/lib/output.py
+++ b/lib/output.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+import os
 import sys
 
 import inkex
@@ -60,6 +61,10 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
     # origin = origin * scale
 
     pattern = pyembroidery.EmbPattern()
+
+    # For later use when writing .dst header title field.
+    pattern.extras['filename'] = os.path.splitext(os.path.basename(file_path))[0]
+
     stitch = Stitch(0, 0)
 
     for color_block in stitch_plan:

--- a/lib/output.py
+++ b/lib/output.py
@@ -63,7 +63,7 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
     pattern = pyembroidery.EmbPattern()
 
     # For later use when writing .dst header title field.
-    pattern.extras['filename'] = os.path.splitext(os.path.basename(file_path))[0]
+    pattern.extras['name'] = os.path.splitext(os.path.basename(file_path))[0]
 
     stitch = Stitch(0, 0)
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -63,8 +63,7 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
     pattern = pyembroidery.EmbPattern()
 
     # For later use when writing .dst header title field.
-    svg_docname = svg.root.attrib['{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}docname']
-    pattern.extras['name'] = os.path.splitext(os.path.basename(svg_docname))[0]
+    pattern.extras['name'] = os.path.splitext(svg.name)[0]
 
     stitch = Stitch(0, 0)
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -63,7 +63,8 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
     pattern = pyembroidery.EmbPattern()
 
     # For later use when writing .dst header title field.
-    pattern.extras['name'] = os.path.splitext(os.path.basename(file_path))[0]
+    svg_docname = svg.root.attrib['{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}docname']
+    pattern.extras['name'] = os.path.splitext(os.path.basename(svg_docname))[0]
 
     stitch = Stitch(0, 0)
 


### PR DESCRIPTION
Write pattern filename into .dst header. Currently, title in all .dst files defaults to "Untitled," which isn't useful on embroidery machines that only display the .dst title.