### PR TITLE
fix split text

### DIFF
--- a/lib/extensions/palette_split_text.py
+++ b/lib/extensions/palette_split_text.py
@@ -11,32 +11,38 @@ from .base import InkstitchExtension
 
 class PaletteSplitText(InkstitchExtension):
     # Splits sublines of text into it's own text elements in order to color them with the color picker
-    def __init__(self, *args, **kwargs):
-        InkstitchExtension.__init__(self, *args, **kwargs)
-        self.arg_parser.add_argument("-l", "--line-height", type=int, default=6, dest="line_height")
-
     def effect(self):
         if not self.svg.selection:
             inkex.errormsg(_("Please select one or more text elements to split lines."))
             return
-
-        line_height = self.options.line_height
 
         for text in self.svg.selection.get(inkex.elements.TextElement):
             parent = text.getparent()
             content = text.get_text()
             lines = content.split('\n')
             lines.reverse()
-            style = text.get('style')
-            x = text.get('x')
-            y = text.get('y')
-            y = float(y) + (len(lines) - 1) * line_height
+            lines = [line for line in lines if not len(line) == 0]
+
+            style = text.style
+            # If shape-inside style is used, it will lead to bad placement
+            style.pop('shape-inside', None)
+
+            transform = text.transform
+            text.pop('transform')
+
+            bbox = text.get_inkscape_bbox()
+            x = bbox.left
+            y = bbox.bottom
+            height = bbox.height / (len(lines))
+
             for line in lines:
                 element = inkex.TextElement()
                 element.text = line
-                element.set('style', style)
-                element.set('x', x)
+                element.set('style', str(style))
+                element.set('x', str(x))
                 element.set('y', str(y))
-                y = float(y) - line_height
+                element.set('transform', str(transform))
+
+                y -= height
                 parent.insert(0, element)
             parent.remove(text)

--- a/templates/palette_split_text.xml
+++ b/templates/palette_split_text.xml
@@ -13,7 +13,6 @@
           </submenu>
         </effects-menu>
     </effect>
-    <param name="line-height" type="int" min="1" max="100" gui-text="Line Height">6</param>
     <script>
         {{ command_tag | safe }}
     </script>


### PR DESCRIPTION
This uses get_inkscape_bbox() to get the text position instead of relying on x and y values which may be slower but less error prone. This happens in a for loop, but most of the time this extensions will be used with only one text element selected. So speed really doesn't matter.