### PR TITLE
fix preferences "set default" buttons

### DIFF
--- a/electron/src/renderer/components/Preferences.vue
+++ b/electron/src/renderer/components/Preferences.vue
@@ -37,7 +37,9 @@
                     mm
                   </td>
                   <td class="button">
-                    <v-btn small @click="set_default('collapse_len_mm')"><translate>set as default</translate></v-btn>
+                    <v-btn small @click="setDefault('collapse_len_mm')">
+                      <translate>set as default</translate>
+                    </v-btn>
                   </td>
                 </tr>
                 <tr>
@@ -56,7 +58,9 @@
                     mm
                   </td>
                   <td class="button">
-                    <v-btn small @click="set_default('min_stitch_len_mm')"><translate>set as default</translate></v-btn>
+                    <v-btn small @click="setDefault('min_stitch_len_mm')">
+                      <translate>set as default</translate>
+                    </v-btn>
                   </td>
                 </tr>
               </table>

--- a/lib/api/server.py
+++ b/lib/api/server.py
@@ -14,7 +14,7 @@ import requests
 from flask import Flask, g
 from werkzeug.serving import make_server
 
-from ..utils.json import InkStitchJSONEncoder
+from ..utils.json import InkStitchJSONProvider
 from .install import install
 from .simulator import simulator
 from .stitch_plan import stitch_plan
@@ -41,7 +41,7 @@ class APIServer(Thread):
         cli.show_server_banner = lambda *x: None
 
         self.app = Flask(__name__)
-        self.app.json_encoder = InkStitchJSONEncoder
+        self.app.json = InkStitchJSONProvider(self.app)
 
         self.app.register_blueprint(simulator, url_prefix="/simulator")
         self.app.register_blueprint(stitch_plan, url_prefix="/stitch_plan")

--- a/lib/utils/json.py
+++ b/lib/utils/json.py
@@ -3,10 +3,15 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from flask.json import JSONEncoder
+from flask.json.provider import DefaultJSONProvider
+from ..exceptions import InkstitchException
 
 
-class InkStitchJSONEncoder(JSONEncoder):
+class InkstitchJSONException(InkstitchException):
+    pass
+
+
+class InkStitchJSONProvider(DefaultJSONProvider):
     """JSON encoder class that runs __json__ on an object if available.
 
     The __json__ method should return a JSON-compatible representation of the
@@ -17,4 +22,5 @@ class InkStitchJSONEncoder(JSONEncoder):
         try:
             return obj.__json__()
         except AttributeError:
-            return JSONEncoder.default(self, obj)
+            raise InkstitchJSONException(
+                f"Object of type {obj.__class__.__name__} cannot be serialized to JSON because it does not implement __json__()")

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ colormath @ git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f6
 
 stringcase
 tinycss2
-flask
+flask>=2.2.0
 fonttools
 trimesh>=3.15.2
 scipy


### PR DESCRIPTION
The "set default" buttons threw a javascript error and didn't work.  I had switched the method name to use javascript camelCase but forgot to change the method call.

While I was in there I went through the obnoxious exercise of figuring out how to fix the flask JSON deprecation warning.