### PR TITLE
meander: pick ending point far from starting point

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -183,7 +183,7 @@ class FillStitch(EmbroideryElement):
     @param('meander_pattern', _('Meander Pattern'), type='combo', default=0,
            options=sorted(tiles.all_tiles()), select_items=[('fill_method', 'meander_fill')], sort_index=3)
     def meander_pattern(self):
-        return self.get_param('meander_pattern', None)
+        return self.get_param('meander_pattern', min(tiles.all_tiles()).id)
 
     @property
     @param('meander_scale_percent',

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -9,6 +9,7 @@ import re
 import sys
 import traceback
 
+import numpy as np
 from inkex import Transform
 from shapely import geometry as shgeo
 from shapely.errors import TopologicalError
@@ -192,7 +193,7 @@ class FillStitch(EmbroideryElement):
            select_items=[('fill_method', 'meander_fill')],
            sort_index=4)
     def meander_scale(self):
-        return self.get_split_float_param('meander_scale_percent', (100, 100)) / 100
+        return np.maximum(self.get_split_float_param('meander_scale_percent', (100, 100)), (1, 1)) / 100
 
     @property
     @param('angle',

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -149,11 +149,11 @@ class ParamsTab(ScrolledPanel):
     def update_combo_state(self, event=None):
         self.update_choice_state(event, True)
 
-    def get_combo_value_index(self, param, options):
+    def get_combo_value_index(self, param, options, default):
         for option in options:
             if option.id == param:
                 return options.index(option)
-        return 0
+        return default
 
     def pair_changed(self, value):
         new_value = not value
@@ -407,8 +407,7 @@ class ParamsTab(ScrolledPanel):
                     input.Append(option.name, image, option)
                 if not param.options:
                     input.Append(_('No options available'), ParamOption('not_available'))
-
-                value = self.get_combo_value_index(param.values[0], param.options)
+                value = self.get_combo_value_index(param.values[0], param.options, param.default or 0)
                 input.SetSelection(value)
                 input.Bind(wx.EVT_COMBOBOX, self.changed)
                 input.Bind(wx.EVT_COMBOBOX, self.update_combo_state)

--- a/lib/stitches/meander_fill.py
+++ b/lib/stitches/meander_fill.py
@@ -66,7 +66,9 @@ def find_starting_and_ending_nodes(graph, shape, starting_point, ending_point):
     starting_point = Point(starting_point)
 
     if ending_point is None:
-        ending_point = starting_point
+        # pick a spot on the opposite side of the shape
+        projection = (shape.exterior.project(starting_point, normalized=True) + 0.5) % 1.0
+        ending_point = shape.exterior.interpolate(projection, normalized=True)
     else:
         ending_point = Point(ending_point)
 


### PR DESCRIPTION
This fixes an issue @kaalleen found with meander where the default starting path left no possibility to extend the path.

![332810875_730092191813264_7025210776822283995_n](https://user-images.githubusercontent.com/4446653/221379478-e04dcc0a-c153-4728-8d02-6e7f729e0765.png)
