### PR TITLE
Row spacing for circular fill

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -256,6 +256,7 @@ class FillStitch(EmbroideryElement):
            select_items=[('fill_method', 'auto_fill'),
                          ('fill_method', 'contour_fill'),
                          ('fill_method', 'guided_fill'),
+                         ('fill_method', 'circular_fill'),
                          ('fill_method', 'legacy_fill')],
            default=0.25)
     def row_spacing(self):

--- a/lib/stitch_plan/lock_stitch.py
+++ b/lib/stitch_plan/lock_stitch.py
@@ -1,10 +1,8 @@
 import re
-from copy import copy
 from math import degrees
 
 from inkex import DirectedLineSegment, Path
 from shapely.geometry import LineString
-from shapely.ops import substring
 
 from ..i18n import _
 from ..svg import PIXELS_PER_MM

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -44,7 +44,7 @@ class StitchGroup:
         # instance.foo = None
 
         instance.lock_stitches = None
-        
+
         return instance
 
     def __add__(self, other):


### PR DESCRIPTION
It got lost when I changed fill methods ids.

Also fixes minor style issues.