### PR TITLE
Change method to update legacy fill_method

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -72,6 +72,15 @@ class EmbroideryElement(object):
         elif legacy_tie == "False":
             self.set_param('ties', 3)
 
+        # convert legacy fill_method
+        legacy_fill_method = self.get_int_param('fill_method', None)
+        if legacy_fill_method == 1:
+            self.set_param('fill_method', 'contour_fill')
+        elif legacy_fill_method == 2:
+            self.set_param('fill_method', 'guided_fill')
+        elif legacy_fill_method == 3:
+            self.set_param('fill_method', 'legacy_fill')
+
         # default setting for fill_underlay has changed
         if legacy_attribs and not self.get_param('fill_underlay', ""):
             self.set_param('fill_underlay', False)

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -110,12 +110,12 @@ class FillStitch(EmbroideryElement):
     def auto_fill(self):
         return self.get_boolean_param('auto_fill', True)
 
-    _fill_methods = [ParamOption('auto_fill', _("Auto Fill"), 0),
-                     ParamOption('contour_fill', _("Contour Fill"), 1),
-                     ParamOption('guided_fill', _("Guided Fill"), 2),
+    _fill_methods = [ParamOption('auto_fill', _("Auto Fill")),
+                     ParamOption('contour_fill', _("Contour Fill")),
+                     ParamOption('guided_fill', _("Guided Fill")),
                      ParamOption('meander_fill', _("Meander Fill")),
                      ParamOption('circular_fill', _("Circular Fill")),
-                     ParamOption('legacy_fill', _("Legacy Fill"), 3)]
+                     ParamOption('legacy_fill', _("Legacy Fill"))]
 
     @property
     @param('fill_method',
@@ -125,13 +125,6 @@ class FillStitch(EmbroideryElement):
            options=_fill_methods,
            sort_index=2)
     def fill_method(self):
-        # convert legacy values
-        legacy_method = self.get_int_param('fill_method', None)
-        if legacy_method in range(0, 4):
-            method = [method.id for method in self._fill_methods if method.legacy == legacy_method][0]
-            self.set_param('fill_method', method)
-            return method
-
         return self.get_param('fill_method', 'auto_fill')
 
     @property

--- a/lib/utils/param.py
+++ b/lib/utils/param.py
@@ -1,9 +1,8 @@
 class ParamOption:
-    def __init__(self, param_id=None, name=None, legacy=None, preview_image=None):
+    def __init__(self, param_id=None, name=None, preview_image=None):
         self.id: str = param_id
         self.name: str = name
-        self.legacy: int = legacy
-        self.preview_image: str = None
+        self.preview_image: str = preview_image
 
     def __repr__(self):
-        return "ParamOption(%s, %s, %s, %s)" % (self.id, self.name, self.legacy, self.preview_image)
+        return "ParamOption(%s, %s, %s)" % (self.id, self.name, self.preview_image)


### PR DESCRIPTION
The old method caused issues and couldn't select the correct fill method in params. We could make it right there too, but I don't want to check for legacy at various places. Let's keep it all in one place.