### PR TITLE
fix "lock" checkbox in stitch plan preview

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -62,7 +62,7 @@ class StitchPlanPreview(InkstitchExtension):
         if self.options.insensitive is True:
             layer.set(SODIPODI_INSENSITIVE, True)
         else:
-            layer.set(SODIPODI_INSENSITIVE, False)
+            layer.pop(SODIPODI_INSENSITIVE)
 
         # translate stitch plan to the right side of the canvas
         if self.options.move_to_side:


### PR DESCRIPTION
We were always locking the stitch plan layer no matter what the user set in the Stitch Plan Preview extension dialog.

It turns out that setting `inkscape:insensitive` to `false` doesn't actually disable insensitive-mode.  Inkscape only cares that the attribute exists and doesn't pay attention to the content.  We have to make sure the attribute is not there to unlock the layer.