### PR TITLE
Auto route satin: apply path effects

### DIFF
--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -16,7 +16,7 @@ from ..commands import add_commands
 from ..elements import SatinColumn, Stroke
 from ..i18n import _
 from ..svg import PIXELS_PER_MM, generate_unique_id, line_strings_to_csp
-from ..svg.tags import INKSCAPE_LABEL, INKSTITCH_ATTRIBS
+from ..svg.tags import INKSCAPE_LABEL, INKSTITCH_ATTRIBS, PATH_EFFECT, ORIGINAL_D
 from ..utils import Point as InkstitchPoint
 from ..utils import cache, cut
 from .utils.autoroute import (add_elements_to_group, add_jumps,
@@ -330,6 +330,14 @@ def auto_satin(elements, preserve_order=False, starting_point=None, ending_point
     # save these for create_new_group() call below
     parent = elements[0].node.getparent()
     index = parent.index(elements[0].node)
+
+    # apply live path effects
+    # It would be nice if we could preserve them, but this could have unwanted side effects
+    # if the path needs to be broken up for better routing
+    for element in elements:
+        if element.node.get(PATH_EFFECT, None):
+            element.node.pop(PATH_EFFECT)
+            element.node.pop(ORIGINAL_D)
 
     graph = build_graph(elements, preserve_order)
     add_jumps(graph, elements, preserve_order)

--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -6,25 +6,25 @@
 import math
 from itertools import chain
 
+import inkex
 import networkx as nx
 from shapely import geometry as shgeo
 from shapely.geometry import Point as ShapelyPoint
-
-import inkex
 
 from ..commands import add_commands
 from ..elements import SatinColumn, Stroke
 from ..i18n import _
 from ..svg import PIXELS_PER_MM, generate_unique_id, line_strings_to_csp
-from ..svg.tags import INKSCAPE_LABEL, INKSTITCH_ATTRIBS, PATH_EFFECT, ORIGINAL_D
+from ..svg.tags import (INKSCAPE_LABEL, INKSTITCH_ATTRIBS, ORIGINAL_D,
+                        PATH_EFFECT)
 from ..utils import Point as InkstitchPoint
 from ..utils import cache, cut
+from ..utils.threading import check_stop_flag
 from .utils.autoroute import (add_elements_to_group, add_jumps,
                               create_new_group, find_path,
                               get_starting_and_ending_nodes,
                               preserve_original_groups,
                               remove_original_elements)
-from ..utils.threading import check_stop_flag
 
 
 class SatinSegment(object):


### PR DESCRIPTION
Fixes #376

Path effects are really nice to create special effects and also an option to build satin columns. But for auto-routing they are not very suitable. So let's apply them before the routing.

The strange scaling being reported by users could easily be fixed, but that alone wouldn't solve the issues that we would face if we tried to keep them alive. For example if the pattern isn't stretched but only repeated, breaking the path would possibly leave a gap, etc.