### PR TITLE
Fill to stroke: add close gap option

### DIFF
--- a/templates/fill_to_stroke.xml
+++ b/templates/fill_to_stroke.xml
@@ -19,6 +19,7 @@
                  gui-description="Deletes small lines. A good value in most cases is the approximate line width of the original shape">10</param>
           <param name="dashed_line" type="boolean" gui-text="Dashed line">true</param>
           <param name="line_width_mm" type="float" gui-text="Line width (mm)" min="0" max="15" precision="2">0.26</param>
+          <param name="close_gaps" type="boolean" gui-text="Cut lines: close gaps">false</param>
       </page>
       <page name="info" gui-text="Help">
           <label appearance="header">Fill to Stroke</label>


### PR DESCRIPTION
When we are using the fill to stroke extension for actual running stitch and to create satins in a second step, users may want to close the gaps that are a side effect of the cutting lines. So this will add an option for that.