### PR TITLE
new way betterer satin algo

### DIFF
--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -4,7 +4,9 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import math
+import typing
 
+import numpy
 from shapely.geometry import LineString, LinearRing, MultiLineString, Polygon, MultiPolygon, MultiPoint, GeometryCollection
 from shapely.geometry import Point as ShapelyPoint
 
@@ -148,9 +150,9 @@ def cut_path(points, length):
 
 
 class Point:
-    def __init__(self, x: float, y: float):
-        self.x = x
-        self.y = y
+    def __init__(self, x: typing.Union[float, numpy.float64], y: typing.Union[float, numpy.float64]):
+        self.x = float(x)
+        self.y = float(y)
 
     @classmethod
     def from_shapely_point(cls, point):

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -203,13 +203,14 @@ class Point:
         return "%s(%s,%s)" % (type(self), self.x, self.y)
 
     def length(self):
-        return math.sqrt(math.pow(self.x, 2.0) + math.pow(self.y, 2.0))
+        return (self.x ** 2 + self.y ** 2) ** 0.5
 
     def distance(self, other):
         return (other - self).length()
 
     def unit(self):
-        return self.mul(1.0 / self.length())
+        length = self.length()
+        return self.__class__(self.x / length, self.y / length)
 
     def angle(self):
         return math.atan2(self.y, self.x)


### PR DESCRIPTION
3 years ago, I merged #607, "new way better satin algo".  Spoiler alert: it wasn't way better.

Since then, sometimes satins are way too sparse around sharp corners. #1799 was the last straw.  Here's an example:

![image](https://user-images.githubusercontent.com/4446653/228121647-3175a463-aaff-45d3-8e59-fc4df7ec5e46.png)

The stitches are spaced too far apart on the outside of the corner.  That's gonna look like absolute garbage.  Now that we have the short stitches option, we can properly follow the stitch spacing on the outside of a corner without worrying about making the inside of the corner too dense.

This PR is yet another rewrite of the satin algorithm that uses the right stitch spacing on the outsides of corners.  Here's how that looks:

![image](https://user-images.githubusercontent.com/4446653/228122005-5c2503bb-8f26-4a91-ac7d-afd7173e6048.png)

I also had to deal with the "V" case, rails coming together or spreading apart screws up the density.  This time, I have the simplest algorithm yet, and it seems to work pretty well!  And the best part: this algorithm is _tons_ faster.  I also got rid of the ancient `SatinColumn.walk()` method -- turns out that calling `interpolate()` a bunch on a LineString is actually quite fast.

For testing, I used the same test SVG from last time, courtesy of @jameskolme:

![testi satin diff](https://user-images.githubusercontent.com/4446653/228122547-8aec9496-5dff-4234-ac73-5ff092a88849.svg)

Also this new one:

![satin_density 2](https://user-images.githubusercontent.com/4446653/228122630-d42e1796-5ba2-453f-a90f-bbc0e4c0b27f.svg)

Please test the hell out of this on a bunch of different satins!