### PR TITLE
Add zoom to page and zoom to selection to simulator

### DIFF
--- a/electron/src/renderer/assets/js/simulator.js
+++ b/electron/src/renderer/assets/js/simulator.js
@@ -522,11 +522,11 @@ export default {
       .back()
       this.page_specs["bbox"] = page.bbox()
     },
-    zoomSelection () {
+    zoomDesign () {
       let [minx, miny, maxx, maxy] = this.stitchPlan.bounding_box
-      let selectionWidth = maxx - minx
-      let selectionHeight = maxy - miny
-      this.svg.viewbox(0, 0, selectionWidth, selectionHeight);
+      let designWidth = maxx - minx
+      let designHeight = maxy - miny
+      this.svg.viewbox(0, 0, designWidth, designHeight);
       this.resizeCursor()
     },
     zoomPage () {
@@ -619,7 +619,7 @@ export default {
       Mousetrap.bind("space", this.toggleAnimation)
       Mousetrap.bind("+", this.animationForwardOneStitch)
       Mousetrap.bind("-", this.animationBackwardOneStitch)
-      Mousetrap.bind("]", this.zoomSelection)
+      Mousetrap.bind("]", this.zoomDesign)
       Mousetrap.bind("[", this.zoomPage)
 
       this.svg.on('zoom', this.resizeCursor)

--- a/electron/src/renderer/assets/js/simulator.js
+++ b/electron/src/renderer/assets/js/simulator.js
@@ -511,7 +511,7 @@ export default {
     },
     generatePage () {
       this.$refs.simulator.style.backgroundColor = this.page_specs.deskcolor
-      this.svg.rect(this.page_specs.width, this.page_specs.height)
+      let page = this.svg.rect(this.page_specs.width, this.page_specs.height)
       .move(-this.stitchPlan.bounding_box[0],-this.stitchPlan.bounding_box[1])
       .fill(this.page_specs.pagecolor)
       .stroke({width: 1, color: 'black'})
@@ -520,6 +520,18 @@ export default {
         add.blend(add.$source, blur)
       })
       .back()
+      this.page_specs["bbox"] = page.bbox()
+    },
+    zoomSelection () {
+      let [minx, miny, maxx, maxy] = this.stitchPlan.bounding_box
+      let selectionWidth = maxx - minx
+      let selectionHeight = maxy - miny
+      this.svg.viewbox(0, 0, selectionWidth, selectionHeight);
+      this.resizeCursor()
+    },
+    zoomPage () {
+      this.svg.viewbox(this.page_specs.bbox.x, this.page_specs.bbox.y - 50, this.page_specs.bbox.width + 100, this.page_specs.bbox.height + 100)
+      this.resizeCursor()
     }
   },
   created: function () {
@@ -607,6 +619,8 @@ export default {
       Mousetrap.bind("space", this.toggleAnimation)
       Mousetrap.bind("+", this.animationForwardOneStitch)
       Mousetrap.bind("-", this.animationBackwardOneStitch)
+      Mousetrap.bind("]", this.zoomSelection)
+      Mousetrap.bind("[", this.zoomPage)
 
       this.svg.on('zoom', this.resizeCursor)
       this.resizeCursor()

--- a/electron/src/renderer/components/Simulator.vue
+++ b/electron/src/renderer/components/Simulator.vue
@@ -140,6 +140,28 @@
                   </p>
                 </div>
               </div>
+              <div>
+                  <p>
+                    <font-awesome-icon icon="search-minus" class="fa-button"/>
+                  </p>
+                  <p>
+                    <translate>Zoom page</translate>
+                  </p>
+                  <p>
+                    <translate>[ Left square bracket</translate>
+                  </p>
+                </div>
+                <div>
+                  <p>
+                    <font-awesome-icon icon="search-plus" class="fa-button"/>
+                  </p>
+                  <p>
+                    <translate>Zoom selection</translate>
+                  </p>
+                  <p>
+                    <translate>] Right square bracket</translate>
+                  </p>
+                </div>
             </div>
           </collapse-transition>
         </div>

--- a/electron/src/renderer/components/Simulator.vue
+++ b/electron/src/renderer/components/Simulator.vue
@@ -156,7 +156,7 @@
                     <font-awesome-icon icon="search-plus" class="fa-button"/>
                   </p>
                   <p>
-                    <translate>Zoom selection</translate>
+                    <translate>Zoom design</translate>
                   </p>
                   <p>
                     <translate>] Right square bracket</translate>
@@ -220,7 +220,7 @@
             <button v-on:click="zoomPage" :title="$gettext('Zoom page ([)')">
               <font-awesome-icon icon="search-minus" size="2x" class="fa-button"/>
             </button>
-            <button v-on:click="zoomSelection" :title="$gettext('Zoom selection (])')">
+            <button v-on:click="zoomDesign" :title="$gettext('Zoom design (])')">
               <font-awesome-icon icon="search-plus" size="2x" class="fa-button"/>
             </button>
           </fieldset>

--- a/electron/src/renderer/components/Simulator.vue
+++ b/electron/src/renderer/components/Simulator.vue
@@ -213,6 +213,17 @@
               <font-awesome-icon icon="horse" size="2x" class="fa-button fa-fast"/>
             </button>
           </fieldset>
+          <fieldset class="view">
+            <legend>
+              <translate>View</translate>
+            </legend>
+            <button v-on:click="zoomPage" :title="$gettext('Zoom page ([)')">
+              <font-awesome-icon icon="search-minus" size="2x" class="fa-button"/>
+            </button>
+            <button v-on:click="zoomSelection" :title="$gettext('Zoom selection (])')">
+              <font-awesome-icon icon="search-plus" size="2x" class="fa-button"/>
+            </button>
+          </fieldset>
           <fieldset class="command">
             <legend>
               <translate>Command</translate>

--- a/electron/src/renderer/main.js
+++ b/electron/src/renderer/main.js
@@ -37,7 +37,9 @@ import {
   faSpinner,
   faStepBackward,
   faStepForward,
-  faStop
+  faStop,
+  faSearchPlus,
+  faSearchMinus
 } from '@fortawesome/free-solid-svg-icons'
 import {FontAwesomeIcon, FontAwesomeLayers} from '@fortawesome/vue-fontawesome'
 import Transitions from 'vue2-transitions'
@@ -74,7 +76,9 @@ library.add(
   faSpinner,
   faStepBackward,
   faStepForward,
-  faStop
+  faStop,
+  faSearchPlus,
+  faSearchMinus
 )
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)


### PR DESCRIPTION
This adds two buttons to the simulator: zoom to page and zoom to selection. Related to https://github.com/inkstitch/inkstitch/issues/1140
The buttons make it easy to quickly reset your view.
 
![Screenshot from 2023-04-01 10-50-57](https://user-images.githubusercontent.com/17163297/229296657-035c5c4e-6731-4168-b5d1-5d67b73dec7d.png)
