### PR TITLE
prevent mac build freeze

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       - shell: bash
         run: |
           # disable electron-builder signing
-          #export CSC_IDENTITY_AUTO_DISCOVERY=false
+          export CSC_IDENTITY_AUTO_DISCOVERY=false
           make dist
         env:
           BUILD: osx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
           echo "${{ env.pythonLocation }}/bin" >> $GITHUB_PATH
       - shell: bash
         run: |
-          # disable electron-builder signing
+          # disable electron-builder signing and make dist
           export CSC_IDENTITY_AUTO_DISCOVERY=false
           make dist
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           brew update
 
-          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext || true
+          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext coreutils || true
 
           export LDFLAGS="-L/usr/local/opt/libffi/lib"
           export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"

--- a/bin/build-electron
+++ b/bin/build-electron
@@ -28,4 +28,13 @@ fi
 cd electron
 which yarn > /dev/null 2>&1 || npm install -g yarn
 yarn --link-duplicates --pure-lockfile
-yarn run dist ${args}
+
+command="yarn run dist ${args}"
+
+if [ "$BUILD" = "osx" ]; then
+    # mac build freezes on signing fairly often
+    command="timeout 10m $command"
+fi
+
+# try up to 3 times
+$command || $command || $command || exit 1

--- a/bin/build-electron
+++ b/bin/build-electron
@@ -36,5 +36,5 @@ if [ "$BUILD" = "osx" ]; then
     command="timeout 10m $command"
 fi
 
-# try up to 3 times
-$command || $command || $command || exit 1
+# try up to 5 times
+$command || $command || $command || $command || $command || exit 1


### PR DESCRIPTION
I'm sick of the mac build getting canceled after 6 hours when signing never completes.