### PR TITLE
Param simulator: stitch plan metadata

### DIFF
--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -31,9 +31,11 @@ class LetteringFrame(wx.Frame):
     DEFAULT_FONT = "small_font"
 
     def __init__(self, *args, **kwargs):
-        # begin wxGlade: MyFrame.__init__
         self.group = kwargs.pop('group')
         self.cancel_hook = kwargs.pop('on_cancel', None)
+        self.metadata = kwargs.pop('metadata', [])
+
+        # begin wxGlade: MyFrame.__init__
         wx.Frame.__init__(self, None, wx.ID_ANY,
                           _("Ink/Stitch Lettering")
                           )
@@ -492,8 +494,9 @@ class Lettering(CommandsExtension):
             return group
 
     def effect(self):
+        metadata = self.get_inkstitch_metadata()
         app = wx.App()
-        frame = LetteringFrame(group=self.get_or_create_group(), on_cancel=self.cancel)
+        frame = LetteringFrame(group=self.get_or_create_group(), on_cancel=self.cancel, metadata=metadata)
 
         # position left, center
         current_screen = wx.Display.GetFromPoint(wx.GetMousePosition())

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -478,9 +478,11 @@ class SettingsFrame(wx.Frame):
             lc = wx.Locale()
             lc.Init(wx.LANGUAGE_DEFAULT)
 
-        # begin wxGlade: MyFrame.__init__
         self.tabs_factory = kwargs.pop('tabs_factory', [])
         self.cancel_hook = kwargs.pop('on_cancel', None)
+        self.metadata = kwargs.pop('metadata', [])
+
+        # begin wxGlade: MyFrame.__init__
         wx.Frame.__init__(self, None, wx.ID_ANY,
                           _("Embroidery Params")
                           )
@@ -786,8 +788,11 @@ class Params(InkstitchExtension):
     def effect(self):
         try:
             app = wx.App()
+            metadata = self.get_inkstitch_metadata()
             frame = SettingsFrame(
-                tabs_factory=self.create_tabs, on_cancel=self.cancel)
+                tabs_factory=self.create_tabs,
+                on_cancel=self.cancel,
+                metadata=metadata)
 
             # position left, center
             current_screen = wx.Display.GetFromPoint(wx.GetMousePosition())

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -805,7 +805,10 @@ class SimulatorPreview(Thread):
             return
 
         if patches and not self.refresh_needed.is_set():
-            stitch_plan = stitch_groups_to_stitch_plan(patches)
+            metadata = self.parent.metadata
+            collapse_len = metadata['collapse_len_mm']
+            min_stitch_len = metadata['min_stitch_len_mm']
+            stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
 
             # GUI stuff needs to happen in the main thread, so we ask the main
             # thread to call refresh_simulator().


### PR DESCRIPTION
The params (and lettering) simulator did not apply minimum stitch length and minimum jump stitch setting.
It bothered me somehow ...