### PR TITLE
Ripple stitch: add density and stagger option

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -244,7 +244,7 @@ class Stroke(EmbroideryElement):
         return self.get_boolean_param("reverse", False)
 
     @property
-    @param('grid_size',
+    @param('grid_size_mm',
            _('Grid size'),
            tooltip=_('Render as grid. Use with care and watch your stitch density.'),
            type='float',
@@ -254,7 +254,7 @@ class Stroke(EmbroideryElement):
            sort_index=15)
     @cache
     def grid_size(self):
-        return abs(self.get_float_param("grid_size", 0))
+        return abs(self.get_float_param("grid_size_mm", 0))
 
     @property
     @param('scale_axis',

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -161,6 +161,7 @@ class Stroke(EmbroideryElement):
     @param('min_line_dist_mm',
            _('Minimum line distance'),
            tooltip=_('Overrides the number of lines setting.'),
+           unit='mm',
            type='float',
            select_items=[('stroke_method', 'ripple_stitch')],
            sort_index=8)

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -20,17 +20,6 @@ from ..utils.param import ParamOption
 from .element import EmbroideryElement, param
 from .validation import ValidationWarning
 
-warned_about_legacy_running_stitch = False
-
-
-class IgnoreSkipValues(ValidationWarning):
-    name = _("Ignore skip")
-    description = _("Skip values are ignored, because there was no line left to embroider.")
-    steps_to_solve = [
-        _('* Open the params dialog with this object selected'),
-        _('* Reduce Skip values or increase number of lines'),
-    ]
-
 
 class MultipleGuideLineWarning(ValidationWarning):
     name = _("Multiple Guide Lines")
@@ -136,7 +125,7 @@ class Stroke(EmbroideryElement):
            unit='mm',
            type='float',
            select_items=[('stroke_method', 'manual_stitch')],
-           sort_index=4)
+           sort_index=5)
     def max_stitch_length(self):
         max_length = self.get_float_param("max_stitch_length_mm", None)
         if not max_length or max_length <= 0:
@@ -151,7 +140,7 @@ class Stroke(EmbroideryElement):
            type='float',
            default=0.4,
            select_items=[('stroke_method', 'zigzag_stitch')],
-           sort_index=5)
+           sort_index=6)
     @cache
     def zigzag_spacing(self):
         return max(self.get_float_param("zigzag_spacing_mm", 0.4), 0.01)
@@ -163,15 +152,36 @@ class Stroke(EmbroideryElement):
            type='int',
            default=10,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=5)
+           sort_index=7)
     @cache
     def line_count(self):
         return max(self.get_int_param("line_count", 10), 1)
 
-    def get_line_count(self):
-        if self.is_closed or self.join_style == 1:
-            return self.line_count + 1
-        return self.line_count
+    @property
+    @param('min_line_dist_mm',
+           _('Minimum line distance'),
+           tooltip=_('Overrides the number of lines setting.'),
+           type='float',
+           select_items=[('stroke_method', 'ripple_stitch')],
+           sort_index=8)
+    @cache
+    def min_line_dist(self):
+        min_dist = self.get_float_param("min_line_dist_mm")
+        if min_dist is None:
+            return
+        return max(min_dist, 0.01)
+
+    @property
+    @param('staggers',
+           _('Stagger rows this many times before repeating. For linear ripples only.'),
+           tooltip=_('Length of the cycle by which successive stitch rows are staggered. '
+                     'Fractional values are allowed and can have less visible diagonals than integer values.'),
+           type='int',
+           select_items=[('stroke_method', 'ripple_stitch')],
+           default=1,
+           sort_index=9)
+    def staggers(self):
+        return self.get_float_param("staggers", 1)
 
     @property
     @param('skip_start',
@@ -180,7 +190,7 @@ class Stroke(EmbroideryElement):
            type='int',
            default=0,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=6)
+           sort_index=10)
     @cache
     def skip_start(self):
         return abs(self.get_int_param("skip_start", 0))
@@ -192,22 +202,10 @@ class Stroke(EmbroideryElement):
            type='int',
            default=0,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=7)
+           sort_index=11)
     @cache
     def skip_end(self):
         return abs(self.get_int_param("skip_end", 0))
-
-    def _adjust_skip(self, skip):
-        if self.skip_start + self.skip_end >= self.line_count:
-            return 0
-        else:
-            return skip
-
-    def get_skip_start(self):
-        return self._adjust_skip(self.skip_start)
-
-    def get_skip_end(self):
-        return self._adjust_skip(self.skip_end)
 
     @property
     @param('exponent',
@@ -216,7 +214,7 @@ class Stroke(EmbroideryElement):
            type='float',
            default=1,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=8)
+           sort_index=12)
     @cache
     def exponent(self):
         return max(self.get_float_param("exponent", 1), 0.1)
@@ -228,7 +226,7 @@ class Stroke(EmbroideryElement):
            type='boolean',
            default=False,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=9)
+           sort_index=13)
     @cache
     def flip_exponent(self):
         return self.get_boolean_param("flip_exponent", False)
@@ -240,7 +238,7 @@ class Stroke(EmbroideryElement):
            type='boolean',
            default=False,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=10)
+           sort_index=14)
     @cache
     def reverse(self):
         return self.get_boolean_param("reverse", False)
@@ -253,7 +251,7 @@ class Stroke(EmbroideryElement):
            default=0,
            unit='mm',
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=11)
+           sort_index=15)
     @cache
     def grid_size(self):
         return abs(self.get_float_param("grid_size", 0))
@@ -267,7 +265,7 @@ class Stroke(EmbroideryElement):
            # 0: xy, 1: x, 2: y, 3: none
            options=["X Y", "X", "Y", _("None")],
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=12)
+           sort_index=16)
     def scale_axis(self):
         return self.get_int_param('scale_axis', 0)
 
@@ -279,7 +277,7 @@ class Stroke(EmbroideryElement):
            unit='%',
            default=100,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=13)
+           sort_index=17)
     def scale_start(self):
         return self.get_float_param('scale_start', 100.0)
 
@@ -291,7 +289,7 @@ class Stroke(EmbroideryElement):
            unit='%',
            default=0.0,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=14)
+           sort_index=18)
     def scale_end(self):
         return self.get_float_param('scale_end', 0.0)
 
@@ -302,7 +300,7 @@ class Stroke(EmbroideryElement):
            type='boolean',
            default=True,
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=15)
+           sort_index=19)
     @cache
     def rotate_ripples(self):
         return self.get_boolean_param("rotate_ripples", True)
@@ -315,7 +313,7 @@ class Stroke(EmbroideryElement):
            default=0,
            options=(_("flat"), _("point")),
            select_items=[('stroke_method', 'ripple_stitch')],
-           sort_index=16)
+           sort_index=20)
     @cache
     def join_style(self):
         return self.get_int_param('join_style', 0)
@@ -504,9 +502,6 @@ class Stroke(EmbroideryElement):
         return coords[int(len(coords)/2)]
 
     def validation_warnings(self):
-        if self.stroke_method == 1 and self.skip_start + self.skip_end >= self.line_count:
-            yield IgnoreSkipValues(self.shape.centroid)
-
         # guided fill warnings
         if self.stroke_method == 1:
             guide_lines = get_marker_elements(self.node, "guide-line", False, True, True)

--- a/lib/stitches/ripple_stitch.py
+++ b/lib/stitches/ripple_stitch.py
@@ -56,12 +56,12 @@ def _get_staggered_stitches(stroke, lines):
         stitched_line = []
         connector = []
         if i != 0 and stroke.join_style == 0:
-            if i % 2 != 0:
-                last_point = lines[i-1][-1]
-                first_point = line[-1]
-            else:
+            if i % 2 == 0:
                 last_point = lines[i-1][0]
                 first_point = line[0]
+            else:
+                last_point = lines[i-1][-1]
+                first_point = line[-1]
             connector = running_stitch([InkstitchPoint(*last_point), InkstitchPoint(*first_point)],
                                        stroke.running_stitch_length,
                                        stroke.running_stitch_tolerance)

--- a/lib/stitches/ripple_stitch.py
+++ b/lib/stitches/ripple_stitch.py
@@ -95,7 +95,7 @@ def get_line_count(stroke, pairs_or_line):
     # no min_line_dist set? use line_count from user settings
     if not stroke.min_line_dist:
         num_lines = stroke.line_count
-    # the arious ripple stitch methods need to caluclate the line distances based on various parameters
+    # the various ripple stitch methods need to caluclate the line distances based on various parameters
     elif isinstance(pairs_or_line, LineString):
         num_lines = ceil(pairs_or_line.length / stroke.min_line_dist)
     elif type(pairs_or_line) == tuple:

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -109,6 +109,7 @@ inkstitch_attribs = [
     'cutwork_needle',
     # ripples
     'line_count',
+    'min_line_dist_mm',
     'exponent',
     'flip_exponent',
     'skip_start',
@@ -117,7 +118,7 @@ inkstitch_attribs = [
     'scale_start',
     'scale_end',
     'rotate_ripples',
-    'grid_size',
+    'grid_size_mm',
     # satin column
     'satin_column',
     'satin_method',
@@ -157,6 +158,8 @@ inkstitch_attribs = [
     'stop_after',
     'random_seed',
     'manual_stitch',
+    # legacy
+    'grid_size'
 ]
 for attrib in inkstitch_attribs:
     INKSTITCH_ATTRIBS[attrib] = inkex.addNS(attrib, 'inkstitch')

--- a/lib/tiles.py
+++ b/lib/tiles.py
@@ -1,5 +1,5 @@
 import os
-from math import ceil, floor
+from math import ceil
 
 import inkex
 import json

--- a/lib/update.py
+++ b/lib/update.py
@@ -1,8 +1,9 @@
 from inkex import errormsg
 
-from .i18n import _
 from .elements import EmbroideryElement
+from .i18n import _
 from .metadata import InkStitchMetadata
+from .svg import PIXELS_PER_MM
 from .svg.tags import INKSTITCH_ATTRIBS
 
 INKSTITCH_SVG_VERSION = 1
@@ -116,11 +117,12 @@ def _update_to_one(element):  # noqa: C901
                 not element.node.style('stroke-dasharray')):
             element.set_param('stroke_method', 'zigzag_stitch')
         # grid_size was supposed to be mm, but it was in pixels
-        grid_size = self.get_float_param('grid_size', None)
+        grid_size = element.get_float_param('grid_size', None)
         if grid_size:
             size = grid_size / PIXELS_PER_MM
-            self.set_param('grid_size_mm', size)
-            self.remove_param('grid_size')
+            element.set_param('grid_size_mm', size)
+            element.remove_param('grid_size')
+
 
 def _replace_legacy_embroider_param(element, param):
     # remove "embroider_" prefix

--- a/lib/update.py
+++ b/lib/update.py
@@ -120,6 +120,7 @@ def _update_to_one(element):  # noqa: C901
         if grid_size:
             size = grid_size / PIXELS_PER_MM
             self.set_param('grid_size_mm', size)
+            self.remove_param('grid_size')
 
 def _replace_legacy_embroider_param(element, param):
     # remove "embroider_" prefix

--- a/lib/update.py
+++ b/lib/update.py
@@ -115,7 +115,11 @@ def _update_to_one(element):  # noqa: C901
                 element.get_param('satin_column', False) is False and
                 not element.node.style('stroke-dasharray')):
             element.set_param('stroke_method', 'zigzag_stitch')
-
+        # grid_size was supposed to be mm, but it was in pixels
+        grid_size = self.get_float_param('grid_size', None)
+        if grid_size:
+            size = grid_size / PIXELS_PER_MM
+            self.set_param('grid_size_mm', size)
 
 def _replace_legacy_embroider_param(element, param):
     # remove "embroider_" prefix

--- a/lib/update.py
+++ b/lib/update.py
@@ -120,6 +120,7 @@ def _update_to_one(element):  # noqa: C901
         grid_size = element.get_float_param('grid_size', None)
         if grid_size:
             size = grid_size / PIXELS_PER_MM
+            size = "{:.2f}".format(size)
             element.set_param('grid_size_mm', size)
             element.remove_param('grid_size')
 


### PR DESCRIPTION
This pull request feels a bit chaotic. There is possibly better ways to do this...

Anyway. I was bothered that it is hard to scale ripple stitch elements, because their density is defined by a line count. This adds a minimum density setting which overwrites the line count setting which stays the default.

Also I found a stagger setting useful. This enables us to create stitches as in #2155 easily with the ripple stitch (satin guided ripple would do).

While working on this I noticed, that the grid size wasn't in mm as users were told in the params dialog. So I changed that as well.