### PR TITLE
auto reverse rung

### DIFF
--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -124,7 +124,7 @@ inkstitch_attribs = [
     'short_stitch_distance_mm',
     'short_stitch_inset',
     'running_stitch_length_mm',
-    'reverse_one_rail',
+    'reverse_rails',
     'swap_satin_rails',
     'center_walk_underlay',
     'center_walk_underlay_stitch_length_mm',

--- a/lib/tiles.py
+++ b/lib/tiles.py
@@ -1,5 +1,5 @@
 import os
-from math import ceil, floor
+from math import ceil
 
 import inkex
 import json

--- a/lib/update.py
+++ b/lib/update.py
@@ -117,9 +117,9 @@ def _update_to_one(element):  # noqa: C901
             element.set_param('stroke_method', 'zigzag_stitch')
 
     if element.get_boolean_param('satin_column', False):
-        # reverse_one_rail defaults to Automatic, but we should never reverse an
+        # reverse_rails defaults to Automatic, but we should never reverse an
         # old satin automatically, only new ones
-        element.set_param('reverse_one_rail', 'none')
+        element.set_param('reverse_rails', 'none')
 
 
 def _replace_legacy_embroider_param(element, param):

--- a/lib/update.py
+++ b/lib/update.py
@@ -121,6 +121,7 @@ def _update_to_one(element):  # noqa: C901
         # old satin automatically, only new ones
         element.set_param('reverse_one_rail', 'none')
 
+
 def _replace_legacy_embroider_param(element, param):
     # remove "embroider_" prefix
     new_param = param[10:]

--- a/lib/update.py
+++ b/lib/update.py
@@ -116,6 +116,10 @@ def _update_to_one(element):  # noqa: C901
                 not element.node.style('stroke-dasharray')):
             element.set_param('stroke_method', 'zigzag_stitch')
 
+    if element.get_boolean_param('satin_column', False):
+        # reverse_one_rail defaults to Automatic, but we should never reverse an
+        # old satin automatically, only new ones
+        element.set_param('reverse_one_rail', 'none')
 
 def _replace_legacy_embroider_param(element, param):
     # remove "embroider_" prefix


### PR DESCRIPTION
Attempt to automatically detect a reversed rung.  This should help with the number one source of confusion for new (and experienced) Ink/Stitch users: an accidentally reversed rail.

before:

![image](https://user-images.githubusercontent.com/4446653/232252700-e93f71fa-69fc-44bf-981e-a1c0bedd1be9.png)

after:

![image](https://user-images.githubusercontent.com/4446653/232252710-0eba3764-d335-46f8-b1d4-336f2b57bc9d.png)

Importantly, this only works on _new_ satins.  Existing SVGs will have all their satins automatically marked to not reverse one rail automatically, so that things like purposeful star shapes aren't broken.  Newly-added satins will have a reversed rail automatically fixed.  The idea is that we won't break users' existing designs, but new for new designs, if they want to purposefully make a star shape, they'll have to set the new "Reverse one rail" option to "none" to get that effect.

I think the method I used to automatically detect a reversed rail should be pretty reliable, but please test lots of satins!