### PR TITLE
Lettering: preserve scale

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1094,11 +1094,11 @@ class SatinColumn(EmbroideryElement):
                 points, _ = self.get_split_points(last_point, left, last_point, left, max_stitch_length)
                 patch.add_stitches(points)
 
-            patch.add_stitch(a_short, ("edge"))
-            patch.add_stitches(split_points, ("split_stitch"))
-            patch.add_stitch(b_short, ("edge"))
-            patch.add_stitches(split_points[::-1], ("split_stitch"))
-            patch.add_stitch(a_short, ("edge"))
+            patch.add_stitch(a_short, ("edge", "left"))
+            patch.add_stitches(split_points, ("split_stitch",))
+            patch.add_stitch(b_short, ("edge",))
+            patch.add_stitches(split_points[::-1], ("split_stitch",))
+            patch.add_stitch(a_short, ("edge",))
 
             last_point = a_short
 

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -135,9 +135,9 @@ class LetteringFrame(wx.Frame):
         self.back_and_forth_checkbox.SetValue(bool(self.settings.back_and_forth))
         self.trim_option_choice.SetSelection(self.settings.trim_option)
         self.use_trim_symbols.SetValue(bool(self.settings.use_trim_symbols))
-        self.set_initial_font(self.settings.font)
         self.text_editor.SetValue(self.settings.text)
         self.scale_spinner.SetValue(self.settings.scale)
+        self.set_initial_font(self.settings.font)
 
     def save_settings(self):
         """Save the settings into the SVG group element."""

--- a/lib/stitch_plan/lock_stitch.py
+++ b/lib/stitch_plan/lock_stitch.py
@@ -98,7 +98,7 @@ class RelativeLock(LockStitchDefinition):
             direction = to_previous.unit()
 
             for delta in path:
-                lock_stitches.append(Stitch(stitches[0] + delta * length * direction, tags=('lock_stitch')))
+                lock_stitches.append(Stitch(stitches[0] + delta * length * direction, tags=('lock_stitch',)))
         else:
             # Too short to travel part of the way to the previous stitch; just go
             # back and forth to it a couple times.


### PR DESCRIPTION
When someone opened the lettering tool with an Ink/Stitch font selected the scale was always set to 100%