### PR TITLE
Stitch plan preview: do not render hidden layers

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -47,8 +47,8 @@ class StitchPlanPreview(InkstitchExtension):
 
         # update layer visibility 0 = unchanged, 1 = hidden, 2 = lower opacity
         groups = self.document.getroot().findall(SVG_GROUP_TAG)
+        self.set_invisible_layers_attribute(groups, layer)
         if self.options.layer_visibility == 1:
-            self.set_invisible_layers_attribute(groups, layer)
             self.hide_all_layers()
             layer.style['display'] = "inline"
         elif self.options.layer_visibility == 2:


### PR DESCRIPTION
Stitch plan preview sometimes turned hidden layers into embroidery... let's avoid that.