### PR TITLE
Add bean stitch option to meander fill

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -330,6 +330,17 @@ class FillStitch(EmbroideryElement):
         return max(self.get_float_param("running_stitch_tolerance_mm", 0.2), 0.01)
 
     @property
+    @param('repeats',
+           _('Repeats'),
+           tooltip=_('Defines how many times to run down and back along the path.'),
+           type='int',
+           default="1",
+           select_items=[('fill_method', 'meander_fill')],
+           sort_index=7)
+    def repeats(self):
+        return max(1, self.get_int_param("repeats", 1))
+
+    @property
     @param('bean_stitch_repeats',
            _('Bean stitch number of repeats'),
            tooltip=_('Backtrack each stitch this many times.  '
@@ -339,7 +350,7 @@ class FillStitch(EmbroideryElement):
            type='str',
            select_items=[('fill_method', 'meander_fill')],
            default=0,
-           sort_index=7)
+           sort_index=8)
     def bean_stitch_repeats(self):
         return self.get_multiple_int_param("bean_stitch_repeats", "0")
 

--- a/lib/stitches/meander_fill.py
+++ b/lib/stitches/meander_fill.py
@@ -15,7 +15,7 @@ from ..utils.list import poprandom
 from ..utils.prng import iter_uniform_floats
 from ..utils.smoothing import smooth_path
 from ..utils.threading import check_stop_flag
-from .running_stitch import running_stitch
+from .running_stitch import bean_stitch, running_stitch
 
 
 def meander_fill(fill, shape, original_shape, shape_index, starting_point, ending_point):
@@ -182,6 +182,8 @@ def post_process(points, shape, original_shape, fill):
     smoothed_points = [InkStitchPoint.from_tuple(point) for point in smoothed_points]
 
     stitches = running_stitch(smoothed_points, fill.running_stitch_length, fill.running_stitch_tolerance)
+    if fill.bean_stitch_repeats:
+        stitches = bean_stitch(stitches, fill.bean_stitch_repeats)
 
     if fill.clip:
         stitches = clamp_path_to_polygon(stitches, original_shape)

--- a/lib/stitches/meander_fill.py
+++ b/lib/stitches/meander_fill.py
@@ -182,11 +182,20 @@ def post_process(points, shape, original_shape, fill):
     smoothed_points = [InkStitchPoint.from_tuple(point) for point in smoothed_points]
 
     stitches = running_stitch(smoothed_points, fill.running_stitch_length, fill.running_stitch_tolerance)
-    if fill.bean_stitch_repeats:
-        stitches = bean_stitch(stitches, fill.bean_stitch_repeats)
 
     if fill.clip:
         stitches = clamp_path_to_polygon(stitches, original_shape)
+
+    if fill.bean_stitch_repeats:
+        stitches = bean_stitch(stitches, fill.bean_stitch_repeats)
+
+    if fill.repeats:
+        for i in range(1, fill.repeats):
+            if i % 2 == 1:
+                # reverse every other pass
+                stitches.extend(stitches[::-1])
+            else:
+                stitches.extend(stitches)
 
     return stitches
 


### PR DESCRIPTION
On request

This looks like a lot of changes, but this is just copy paste of code. I wondered why the path methods were in between the param properties.