### PR TITLE
Params error message

### DIFF
--- a/templates/install.xml
+++ b/templates/install.xml
@@ -3,7 +3,7 @@
     <name>Install thread color palettes for Inkscape</name>
     <id>org.inkstitch.install</id>
     <param name="extension" type="string" gui-hidden="true">install</param>
-    <effect implements-custom-gui="true">
+    <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch" translatable="no">

--- a/templates/params.xml
+++ b/templates/params.xml
@@ -3,7 +3,7 @@
     <name>Params</name>
     <id>org.inkstitch.params</id>
     <param name="extension" type="string" gui-hidden="true">params</param>
-    <effect implements-custom-gui="true">
+    <effect>
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch" translatable="no" />


### PR DESCRIPTION
Defining "custom-gui" in the template file prevents the error message in inkscape 1.3
But it seems as if we can just simply remove it.

An other option would be to add the error message inside the custom gui.