### PR TITLE
Simulator: page border

### DIFF
--- a/electron/src/renderer/assets/js/simulator.js
+++ b/electron/src/renderer/assets/js/simulator.js
@@ -514,15 +514,23 @@ export default {
     },
     generatePage () {
       this.$refs.simulator.style.backgroundColor = this.page_specs.deskcolor
+
       let page = this.svg.rect(this.page_specs.width, this.page_specs.height)
       .move(-this.stitchPlan.bounding_box[0],-this.stitchPlan.bounding_box[1])
       .fill(this.page_specs.pagecolor)
-      .stroke({width: 1, color: 'black'})
-      .filterWith(add => {
-        let blur = add.offset(2,2).in(add.$sourceAlpha).gaussianBlur(2)
-        add.blend(add.$source, blur)
-      })
+      .stroke({width: 0.1, color: this.page_specs.bordercolor})
       .back()
+
+      if (this.page_specs.showpageshadow === "true") {
+        let shadow = this.svg.rect(this.page_specs.width, this.page_specs.height)
+        .move(-this.stitchPlan.bounding_box[0],-this.stitchPlan.bounding_box[1])
+        .fill(this.page_specs.bordercolor)
+        .filterWith(add => {
+            let blur = add.offset(.5,.5).in(add.$source).gaussianBlur(.5)
+          })
+          .back()
+      }
+
       this.page_specs["bbox"] = page.bbox()
     },
     zoomDesign () {

--- a/lib/api/page_specs.py
+++ b/lib/api/page_specs.py
@@ -15,16 +15,22 @@ def get_page_specs():
     height = svg.get('height', 0)
     pagecolor = "white"
     deskcolor = "white"
+    bordercolor = "black"
+    showpageshadow = True
 
     namedview = svg.namedview
     if namedview is not None:
         pagecolor = namedview.get('pagecolor', pagecolor)
         deskcolor = namedview.get('inkscape:deskcolor', deskcolor)
+        bordercolor = namedview.get('bordercolor', bordercolor)
+        showpageshadow = namedview.get('inkscape:showpageshadow', showpageshadow)
 
     page_specs = {
         "width": width,
         "height": height,
         "pagecolor": pagecolor,
-        "deskcolor": deskcolor
+        "deskcolor": deskcolor,
+        "bordercolor": bordercolor,
+        "showpageshadow": showpageshadow
     }
     return jsonify(page_specs)


### PR DESCRIPTION
On request

The page border as is distracts from seeing the design. This brings the stroke width down and uses the same color settings for the border as in Inkscape.