### PR TITLE
Ensure synthesized rung intersects

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -717,7 +717,6 @@ class SatinColumn(EmbroideryElement):
         """
 
         rungs = [shgeo.LineString(self.flatten_subpath(rung)) for rung in self.rungs]
-
         for path_list in split_rails:
             path_list.extend(rung for rung in rungs if path_list[0].intersects(rung) and path_list[1].intersects(rung))
 

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -454,9 +454,10 @@ class SatinColumn(EmbroideryElement):
                 # Don't bother putting rungs at the start and end.
                 points = points[1:-1]
             else:
-                # But do include one at the start if we wouldn't add one otherwise.
+                # But do include one near the start if we wouldn't add one otherwise.
                 # This avoids confusing other parts of the code.
-                points = points[:-1]
+                linestring_rail = shgeo.LineString(points)
+                points = [linestring_rail.interpolate(0.2)]
 
             rung_endpoints.append(points)
 

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -462,7 +462,10 @@ class SatinColumn(EmbroideryElement):
 
         rungs = []
         for start, end in zip(*rung_endpoints):
-            rungs.append([[start, start, start], [end, end, end]])
+            rung = shgeo.LineString((start, end))
+            # make it a bit bigger so that it definitely intersects
+            rung = shaffinity.scale(rung, 1.1, 1.1).coords
+            rungs.append([[rung[0]] * 3, [rung[1]] * 3])
 
         return rungs
 
@@ -613,8 +616,8 @@ class SatinColumn(EmbroideryElement):
             rails.reverse()
             path_list = rails
 
-            rung_start = path_list[0].interpolate(0.1)
-            rung_end = path_list[1].interpolate(0.1)
+            rung_start = path_list[0].interpolate(0.2)
+            rung_end = path_list[1].interpolate(0.2)
             rung = shgeo.LineString((rung_start, rung_end))
             # make it a bit bigger so that it definitely intersects
             rung = shaffinity.scale(rung, 1.1, 1.1)
@@ -714,6 +717,7 @@ class SatinColumn(EmbroideryElement):
         """
 
         rungs = [shgeo.LineString(self.flatten_subpath(rung)) for rung in self.rungs]
+
         for path_list in split_rails:
             path_list.extend(rung for rung in rungs if path_list[0].intersects(rung) and path_list[1].intersects(rung))
 
@@ -733,10 +737,14 @@ class SatinColumn(EmbroideryElement):
 
         for path_list in path_lists:
             if len(path_list) in (2, 4):
-                # Add the rung at the start of the satin.
-                rung_start = path_list[0].coords[0]
-                rung_end = path_list[1].coords[0]
+                # Add the rung just after the start of the satin.
+                rung_start = path_list[0].interpolate(0.3)
+                rung_end = path_list[1].interpolate(0.3)
                 rung = shgeo.LineString((rung_start, rung_end))
+
+                # make it a bit bigger so that it definitely intersects
+                rung = shaffinity.scale(rung, 1.1, 1.1)
+
                 path_list.append(rung)
 
     def _path_list_to_satins(self, path_list):

--- a/lib/extensions/cut_satin.py
+++ b/lib/extensions/cut_satin.py
@@ -16,7 +16,7 @@ class CutSatin(InkstitchExtension):
         if not self.get_elements():
             return
 
-        if not self.svg.selection:
+        if not self.svg.selection or not any([isinstance(element, SatinColumn) for element in self.elements]):
             inkex.errormsg(_("Please select one or more satin columns to cut."))
             return
 


### PR DESCRIPTION
When the satins are scaled down at a later time, we may experience rounding errors which lead to non-intersecting rungs (when we simply use the rail endpoints to synthesize rungs).

Ink/Stitch can now deal with non-intersecting rungs ... but when it comes to rail/rung detection it can be a problem (we decide on which is which based on the intersection count).