### PR TITLE
fixed mac dev mode translations

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -95,7 +95,7 @@
     "devtron": "^1.4.0",
     "easygettext": "^2.7.0",
     "electron": "4.1.3",
-    "electron-builder": "22.8.0",
+    "electron-builder": "^23.0.3",
     "electron-debug": "^1.5.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-prebuilt-compile": "4.0.0",

--- a/lib/gui/electron.py
+++ b/lib/gui/electron.py
@@ -37,7 +37,7 @@ def open_url(url):
     if sys.platform == "darwin" and getattr(sys, 'frozen', None) is None:
         mac_dev_env = os.environ.copy()
         # these are paths installed by brew or macports
-        yarn_path = "/usr/local/bin:/opt/local/bin:"
+        yarn_path = "/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:"
         if yarn_path in mac_dev_env["PATH"]:
             pass
         else:

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -30,7 +30,7 @@ def _set_locale_dir():
     else:
         locale_dir = dirname(dirname(realpath(__file__)))
 
-    if sys.platform == "darwin":
+    if sys.platform == "darwin" and getattr(sys, 'frozen', False):
         locale_dir = os.path.join(locale_dir, "..", 'Resources', 'locales')
     else:
         locale_dir = os.path.join(locale_dir, 'locales')


### PR DESCRIPTION
updated electron-builder
fixed wxpython translations for macos manual install
added path to for yarn homebrew arm path for macos manual install 