### PR TITLE
Add svg updater extension

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -33,7 +33,6 @@ from .lettering_force_lock_stitches import LetteringForceLockStitches
 from .lettering_generate_json import LetteringGenerateJson
 from .lettering_remove_kerning import LetteringRemoveKerning
 from .letters_to_font import LettersToFont
-from .zigzag_line_to_satin import ZigzagLineToSatin
 from .object_commands import ObjectCommands
 from .object_commands_toggle_visibility import ObjectCommandsToggleVisibility
 from .output import Output
@@ -51,6 +50,8 @@ from .simulator import Simulator
 from .stitch_plan_preview import StitchPlanPreview
 from .stitch_plan_preview_undo import StitchPlanPreviewUndo
 from .stroke_to_lpe_satin import StrokeToLpeSatin
+from .update_svg import UpdateSvg
+from .zigzag_line_to_satin import ZigzagLineToSatin
 from .zip import Zip
 
 from.lettering_along_path import LetteringAlongPath
@@ -91,6 +92,7 @@ __all__ = extensions = [StitchPlanPreview,
                         Troubleshoot,
                         RemoveEmbroiderySettings,
                         Cleanup,
+                        UpdateSvg,
                         BreakApart,
                         GradientBlocks,
                         ApplyThreadlist,

--- a/lib/extensions/update_svg.py
+++ b/lib/extensions/update_svg.py
@@ -1,0 +1,15 @@
+# Authors: see git history
+#
+# Copyright (c) 2010 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from ..update import update_inkstitch_document
+from .base import InkstitchExtension
+
+
+class UpdateSvg(InkstitchExtension):
+
+    def effect(self):
+        metadata = self.get_inkstitch_metadata()
+        del metadata['inkstitch_svg_version']
+        update_inkstitch_document(self.document)

--- a/lib/extensions/update_svg.py
+++ b/lib/extensions/update_svg.py
@@ -3,13 +3,37 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from inkex import errormsg
+
+from ..i18n import _
 from ..update import update_inkstitch_document
 from .base import InkstitchExtension
 
 
 class UpdateSvg(InkstitchExtension):
 
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        # TODO: When there are more legacy versions than only one, this can be transformed in a user input
+        # inkstitch_svg_version history: 1 -> v2.3.0
+        self.update_from = 0
+
     def effect(self):
+        if not self.svg.selection:
+            errormsg(_('Please select at least one element to update. '
+                       'This extension is designed to help you update copy and pasted elements from old designs.'))
+
+        # set the file version to the update_from value, so that the updater knows where to start from
+        # the updater will then reset it to the current version after the update has finished
         metadata = self.get_inkstitch_metadata()
-        del metadata['inkstitch_svg_version']
-        update_inkstitch_document(self.document)
+        metadata['inkstitch_svg_version'] = self.update_from
+
+        update_inkstitch_document(self.document, self.get_selection())
+
+    def get_selection(self):
+        selection = []
+        for element in self.svg.selection:
+            selection.append(element)
+            for descendant in element.iterdescendants():
+                selection.append(descendant)
+        return selection

--- a/lib/update.py
+++ b/lib/update.py
@@ -4,7 +4,7 @@ from .elements import EmbroideryElement
 from .i18n import _
 from .metadata import InkStitchMetadata
 from .svg import PIXELS_PER_MM
-from .svg.tags import INKSTITCH_ATTRIBS
+from .svg.tags import EMBROIDERABLE_TAGS, INKSTITCH_ATTRIBS
 
 INKSTITCH_SVG_VERSION = 1
 
@@ -44,7 +44,8 @@ def update_inkstitch_document(svg):
         for element in document.iterdescendants():
             # We are just checking for params and update them.
             # No need to check for specific stitch types at this point
-            update_legacy_params(EmbroideryElement(element), file_version, INKSTITCH_SVG_VERSION)
+            if element.tag in EMBROIDERABLE_TAGS:
+                update_legacy_params(EmbroideryElement(element), file_version, INKSTITCH_SVG_VERSION)
         _update_inkstitch_svg_version(svg)
 
 
@@ -100,7 +101,7 @@ def _update_to_one(element):  # noqa: C901
         element.set_param('fill_underlay', False)
 
     # convert legacy stroke_method
-    if element.get_style("stroke"):
+    if element.get_style("stroke") and not element.node.get('inkscape:connection-start', None):
         # manual stitch
         legacy_manual_stitch = element.get_boolean_param('manual_stitch', False)
         if legacy_manual_stitch is True:

--- a/templates/update_svg.xml
+++ b/templates/update_svg.xml
@@ -3,7 +3,7 @@
     <name>Update inkstitch svg</name>
     <id>org.inkstitch.update_svg</id>
     <param name="extension" type="string" gui-hidden="true">update_svg</param>
-    <effect>
+    <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu>
             <submenu name="Ink/Stitch" translatable="no">
@@ -11,6 +11,13 @@
             </submenu>
         </effects-menu>
     </effect>
+    <label appearance="header">Usually there is no need to run this extension: Ink/Stitch automatically updates old designs once.</label>
+    <spacer />
+    <label>However, when you copy and paste parts from old files into a new design, you may see for example, that a former contour fill renders as a standard fill, etc.</label>
+    <spacer />
+    <label>Tipp: You can prevent inserting legacy designs into new files by running any Ink/Stitch extension before you copy the design parts (for example open and re-apply parameters on a single element in the document).</label>
+    <spacer />
+    <label appearance="header">This extension only updates selected elements.</label>
     <script>
         {{ command_tag | safe }}
     </script>

--- a/templates/update_svg.xml
+++ b/templates/update_svg.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Update inkstitch svg</name>
+    <id>org.inkstitch.update_svg</id>
+    <param name="extension" type="string" gui-hidden="true">update_svg</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch" translatable="no">
+                <submenu name="Troubleshoot" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Running this extension shouldn't be necessary since Ink/Stitch updates the svg itself.

However in rare cases something can go wrong. Let's take an example. A user worked out a design but is missing a design part he has previously done in an other file. The current design already has all the updated parameters and the inkstitch_svg_version tag. Now he opens the old design, but doesn't run any Ink/Stitch method before copy and paste an old legacy design into the new design - the params of the inserted design parts won't get updated again. Ripples fallback to running stitches and the guided fill suddenly renders as autofill - until they run this extension.