### PR TITLE
disable electron-builder signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       - shell: bash
         run: |
           # disable electron-builder signing
-          export CSC_IDENTITY_AUTO_DISCOVERY=false
+          #export CSC_IDENTITY_AUTO_DISCOVERY=false
           make dist
         env:
           BUILD: osx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,8 @@ jobs:
           echo "${{ env.pythonLocation }}/bin" >> $GITHUB_PATH
       - shell: bash
         run: |
+          # disable electron-builder signing
+          export CSC_IDENTITY_AUTO_DISCOVERY=false
           make dist
         env:
           BUILD: osx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           # scipy gives us a ELF error when stripped
           sudo apt-get install gcc g++ gfortran python3-dev libopenblas-dev liblapack-dev
           python -m pip uninstall --yes scipy
-          python -m pip install scipy==1.9.0 --no-binary scipy
+          python -m pip install scipy --no-binary scipy
 
           echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
       - shell: bash

--- a/electron/package.json
+++ b/electron/package.json
@@ -45,6 +45,7 @@
       ],
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
+      "strictVerify": false,
       "entitlements": "build/electron-entitlements.plist",
       "entitlementsInherit": "build/electron-entitlements.plist"
     }


### PR DESCRIPTION
Disables electron-builder code signing in build, code signing is done before pkg and zip creation.  