### PR TITLE
Stitch plan: save stitch plan display mode

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -19,7 +19,7 @@ class StitchPlanPreview(InkstitchExtension):
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self, *args, **kwargs)
         self.arg_parser.add_argument("-s", "--move-to-side", type=Boolean, default=True, dest="move_to_side")
-        self.arg_parser.add_argument("-v", "--layer-visibility", type=int, default=0, dest="layer_visibility")
+        self.arg_parser.add_argument("-v", "--layer-visibility", type=str, default="unchanged", dest="layer_visibility")
         self.arg_parser.add_argument("-n", "--needle-points", type=Boolean, default=False, dest="needle_points")
         self.arg_parser.add_argument("-i", "--insensitive", type=Boolean, default=False, dest="insensitive")
         self.arg_parser.add_argument("-c", "--visual-commands", type=Boolean, default="symbols", dest="visual_commands")
@@ -45,13 +45,13 @@ class StitchPlanPreview(InkstitchExtension):
         # apply options
         layer = svg.find(".//*[@id='__inkstitch_stitch_plan__']")
 
-        # update layer visibility 0 = unchanged, 1 = hidden, 2 = lower opacity
+        # update layer visibility (unchanged, hidden, lower opacity)
         groups = self.document.getroot().findall(SVG_GROUP_TAG)
         self.set_invisible_layers_attribute(groups, layer)
-        if self.options.layer_visibility == 1:
+        if self.options.layer_visibility == "hidden":
             self.hide_all_layers()
             layer.style['display'] = "inline"
-        elif self.options.layer_visibility == 2:
+        elif self.options.layer_visibility == "lower_opacity":
             for g in groups:
                 style = g.specified_style()
                 # check groupmode and exclude stitch_plan layer
@@ -85,6 +85,7 @@ class StitchPlanPreview(InkstitchExtension):
             if g.get(INKSCAPE_GROUPMODE) == "layer" and 'display' in g.style and g.style['display'] == 'none':
                 invisible_layers.append(g.get_id())
         layer.set(INKSTITCH_ATTRIBS['invisible_layers'], ",".join(invisible_layers))
+        layer.set(INKSTITCH_ATTRIBS['layer_visibility'], self.options.layer_visibility)
 
     def ensure_marker(self):
         xpath = ".//svg:marker[@id='inkstitch-needle-point']"

--- a/lib/extensions/stitch_plan_preview_undo.py
+++ b/lib/extensions/stitch_plan_preview_undo.py
@@ -17,8 +17,12 @@ def reset_stitch_plan(svg):
     layer = svg.find(".//*[@id='__inkstitch_stitch_plan__']")
     # get previously invisible layers (they still should be hidden afterwards)
     if layer is not None:
+        display_method = layer.get(INKSTITCH_ATTRIBS['layer_visibility'], 'unchanged')
         invisible_layers = layer.get(INKSTITCH_ATTRIBS['invisible_layers'], '').split(",")
         layer.getparent().remove(layer)
+
+        if display_method == "unchanged":
+            return
 
         # if there are layers with reduced opacity, remove opacity attribute or unhide hidden layers
         for g in svg.findall(SVG_GROUP_TAG):

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -153,6 +153,7 @@ inkstitch_attribs = [
     'min_random_split_length_mm',
     # stitch_plan
     'invisible_layers',
+    'layer_visibility',
     # All elements
     'trim_after',
     'stop_after',

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -13,9 +13,9 @@
     </effect>
     <param name="move-to-side" type="boolean" gui-text="Move stitch plan beside the canvas">true</param>
     <param name="layer-visibility" type="optiongroup" appearance="combo" gui-text="Design layer visibility">
-        <option value="0">Unchanged</option>
-        <option value="1">Hidden</option>
-        <option value="2">Lower opacity</option>
+        <option value="unchanged">Unchanged</option>
+        <option value="hidden">Hidden</option>
+        <option value="lower_opacity">Lower opacity</option>
     </param>
     <param name="needle-points" type="boolean" gui-text="Needle points">false</param>
     <param name="insensitive" type="boolean" gui-text="Lock"


### PR DESCRIPTION
Don't touch layer visibility for stitch plans which were created in 'unchanged' mode when undo.