### PR TITLE
Apply clip to stroke

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -23,6 +23,7 @@ from ..stitches import (auto_fill, circular_fill, contour_fill, guided_fill,
                         legacy_fill)
 from ..stitches.meander_fill import meander_fill
 from ..svg import PIXELS_PER_MM, get_node_transform
+from ..svg.clip import get_clip_path
 from ..svg.tags import INKSCAPE_LABEL
 from ..utils import cache, version
 from ..utils.param import ParamOption
@@ -571,12 +572,9 @@ class FillStitch(EmbroideryElement):
         if self.node.clip is None:
             return self.original_shape
 
-        from .element import EmbroideryElement
-        clip_element = EmbroideryElement(self.node.clip)
-        clip_element.paths.sort(key=lambda point_list: shgeo.Polygon(point_list).area, reverse=True)
-        polygon = shgeo.MultiPolygon([(clip_element.paths[0], clip_element.paths[1:])])
+        clip_path = get_clip_path(self.node)
         try:
-            intersection = polygon.intersection(self.original_shape)
+            intersection = clip_path.intersection(self.original_shape)
         except TopologicalError:
             return self.original_shape
 

--- a/lib/svg/clip.py
+++ b/lib/svg/clip.py
@@ -1,0 +1,18 @@
+# Authors: see git history
+#
+# Copyright (c) 2023 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from shapely.geometry import MultiPolygon, Polygon
+
+from ..elements import EmbroideryElement
+
+
+def get_clip_path(node):
+    # get clip and apply node transform
+    clip = node.clip
+    transform = node.composed_transform()
+    clip.transform = transform
+    clip_element = EmbroideryElement(clip)
+    clip_element.paths.sort(key=lambda point_list: Polygon(point_list).area, reverse=True)
+    return MultiPolygon([(clip_element.paths[0], clip_element.paths[1:])])


### PR DESCRIPTION
When there is a clipped path, render only visible parts of the orginal path (as we do for fill areas already).