### PR TITLE
Enable electron builder signing again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,8 +182,6 @@ jobs:
           echo "${{ env.pythonLocation }}/bin" >> $GITHUB_PATH
       - shell: bash
         run: |
-          # disable electron-builder signing and make dist
-          export CSC_IDENTITY_AUTO_DISCOVERY=false
           make dist
         env:
           BUILD: osx


### PR DESCRIPTION
Although we overwrite it later on it seems to be needed...