### PR TITLE
fix "skip last stitch in each row"

### DIFF
--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -7,6 +7,7 @@
 
 import math
 from itertools import chain, groupby
+import warnings
 
 import networkx
 from shapely import geometry as shgeo
@@ -359,7 +360,10 @@ def process_travel_edges(graph, fill_stitch_graph, shape, travel_edges):
     # allows for building a set of shapes and then efficiently testing
     # the set for intersection.  This allows us to do blazing-fast
     # queries of which line segments overlap each underpath edge.
-    strtree = STRtree(segments)
+    with warnings.catch_warnings():
+        # We know about this upcoming change and we don't want to bother users.
+        warnings.filterwarnings('ignore', 'STRtree will be changed in 2.0.0 and will not be compatible with versions < 2.')
+        strtree = STRtree(segments)
 
     # This makes the distance calculations below a bit faster.  We're
     # not looking for high precision anyway.


### PR DESCRIPTION
This one has bothered me for awhile.  The "skip last stitch in each row" only worked for some rows, basically whenever it felt like it (which wasn't often).  This branch fixes it once and for all.

I also suppressed an annoying warning from shapely 1.8.5 -- no way to avoid it but to filter it.  We'll need to rewrite the STRtree bits for shapely 2.0.0+.