### PR TITLE
fix needle points for windows

### DIFF
--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -450,7 +450,7 @@ class DrawingPanel(wx.Panel):
         if self.control_panel.nppBtn.GetValue():
             npp_pen = wx.Pen(pen.GetColour(), width=int(0.5 * PIXELS_PER_MM * self.PIXEL_DENSITY))
             canvas.SetPen(npp_pen)
-            canvas.StrokeLineSegments(stitches, stitches)
+            canvas.StrokeLineSegments(stitches, [(stitch[0] + 0.001, stitch[1]) for stitch in stitches])
 
     def clear(self):
         dc = wx.ClientDC(self)


### PR DESCRIPTION
Zero length line segments do not show in Windows, while they do in Linux and macOS. So we need to actually make little tiny lines instead of feeding it with the exact same start and end points.

So after years of not knowing that the needle points in Windows won't show ... here is a fix.