### PR TITLE
Win wxpython version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.1.1-cp38-cp38-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.1-cp38-cp38-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
@@ -112,7 +112,6 @@ jobs:
           python -m pip install wheel
           # scipy 1.9.1 is the last version to support 32-bit windows
           python -m pip install scipy==1.9.1
-          python -m pip install wxpython==4.2.1
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 
@@ -171,7 +170,6 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
-          pip install wxpython==4.1.1
           pip install -r requirements.txt
           # with --no-binary argument may fix notary issues as well shapely speedups error issue
           pip install -U lxml --no-binary lxml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
           python -m pip install wheel
           # scipy 1.9.1 is the last version to support 32-bit windows
           python -m pip install scipy==1.9.1
-          python -m pip install wxpython==4.1.1
+          python -m pip install wxpython==4.2.1
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -100,12 +100,6 @@ class LetteringFrame(wx.Frame):
         self.load_settings()
         self.apply_settings()
 
-    def InitLocale(self):
-        # This is necessary because of https://github.com/inkstitch/inkstitch/issues/1186
-        if sys.platform.startswith('win'):
-            import locale
-            locale.setlocale(locale.LC_ALL, "C")
-
     def load_settings(self):
         """Load the settings saved into the SVG group element"""
 

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -472,13 +472,6 @@ class ParamsTab(ScrolledPanel):
 
 class SettingsFrame(wx.Frame):
     def __init__(self, *args, **kwargs):
-        # This is necessary because of https://github.com/inkstitch/inkstitch/issues/1186
-        if sys.platform.startswith('win'):
-            import locale
-            locale.setlocale(locale.LC_ALL, "C")
-            lc = wx.Locale()
-            lc.Init(wx.LANGUAGE_DEFAULT)
-
         self.tabs_factory = kwargs.pop('tabs_factory', [])
         self.cancel_hook = kwargs.pop('on_cancel', None)
         self.metadata = kwargs.pop('metadata', [])

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -60,7 +60,7 @@ def fallback(shape, guideline, row_spacing, max_stitch_length, running_stitch_le
 
 
 def path_to_stitches(path, travel_graph, fill_stitch_graph, stitch_length, running_stitch_length, running_stitch_tolerance, skip_last):
-    path = collapse_sequential_outline_edges(path)
+    path = collapse_sequential_outline_edges(path, fill_stitch_graph)
 
     stitches = []
 
@@ -89,7 +89,7 @@ def path_to_stitches(path, travel_graph, fill_stitch_graph, stitch_length, runni
 
             travel_graph.remove_edges_from(fill_stitch_graph[edge[0]][edge[1]]['segment'].get('underpath_edges', []))
         else:
-            stitches.extend(travel(travel_graph, edge[0], edge[1], running_stitch_length, running_stitch_tolerance, skip_last))
+            stitches.extend(travel(travel_graph, edge, running_stitch_length, running_stitch_tolerance, skip_last))
 
     return stitches
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@
 # get up to date inkex version (March 18 2023)
 inkex @ git+https://gitlab.com/inkscape/extensions.git@29205f3cc6c39283e190a36d72d01ef428f668e5
 
-# lower bound to allow for the use of system packages on Debian and distros that have updated to 4.2
-# CI adds an == 4.1.1 constraint for prebuilt packages
-wxPython>=4.1.1
+wxPython>=4.2.1
 
 backports.functools_lru_cache
 networkx

--- a/templates/select_elements.xml
+++ b/templates/select_elements.xml
@@ -63,7 +63,7 @@
                 <label>Clone</label>
                     <param indent="1" name="select-clone" type="boolean" gui-text="Clone">false</param>
           </vbox>
-        </hobx>
+        </hbox>
         </page>
 
         <page name="info" gui-text="Help">


### PR DESCRIPTION
Fixes #2345 with an wxpython update to 4.2.1

Pulls in the fix for guided fill as well to have a functional version for test purposes.