### PR TITLE
Render satins with only one subpath as running stitch

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -31,6 +31,15 @@ class MultipleGuideLineWarning(ValidationWarning):
     ]
 
 
+class TooFewSubpathsWarning(ValidationWarning):
+    name = _("Too few subpaths")
+    description = _("This element renders as running stitch while it has a satin column parameter.")
+    steps_to_solve = [
+        _("* Convert to stroke: select the element and open the parameter dialog. Enable running stitch along path."),
+        _("* Use as satin column: add an other rail and optionally rungs.")
+    ]
+
+
 class Stroke(EmbroideryElement):
     element_name = _("Stroke")
 
@@ -567,6 +576,9 @@ class Stroke(EmbroideryElement):
         return coords[int(len(coords)/2)]
 
     def validation_warnings(self):
+        # satin column warning
+        if self.get_boolean_param("satin_column", False):
+            yield TooFewSubpathsWarning(self._representative_point())
         # guided fill warnings
         if self.stroke_method == 1:
             guide_lines = get_marker_elements(self.node, "guide-line", False, True, True)

--- a/lib/elements/utils.py
+++ b/lib/elements/utils.py
@@ -41,7 +41,7 @@ def node_to_elements(node, clone_to_element=False):  # noqa: C901
         if element.get_style("fill", "black") and not element.get_style('fill-opacity', 1) == "0":
             elements.append(FillStitch(node))
         if element.get_style("stroke"):
-            if element.get_boolean_param("satin_column"):
+            if element.get_boolean_param("satin_column") and len(element.path) > 1:
                 elements.append(SatinColumn(node))
             elif not is_command(element.node):
                 elements.append(Stroke(node))


### PR DESCRIPTION
Currently Ink/Stitch will output an error message on elements with only one subpath and even a traceback message when the troubleshoot extension is run on it :O

So why don't we just render it as a stroke and output a warning in troubleshoot.