### PR TITLE
feat(CI): add dependabot to create update PRs for GH action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Enables dependabot to check the workflow scripts for updates.

## Problem

GH action scripts need regular updates to avoid security problems.
GH also disables them after some time: https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/

Currently there is no simple way to check for outdated GH actions like `npm outdated`.

## Advantage

Dependabot can do the check for outdated GH actions and create a PR with changelog.
Keep in mind that the bot just does a version bump and no migration.

## Example

https://github.com/OSSLibraries/Arduino_MFRC522v2/pull/19

## Reference

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file