### PR TITLE
produce only one satin from convert to satin

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -825,6 +825,38 @@ class SatinColumn(EmbroideryElement):
 
         return SatinColumn(node)
 
+    def merge(self, satin):
+        """Merge this satin with another satin
+
+        This method expects that the provided satin continues on directly after
+        this one, as would be the case, for example, if the two satins were the
+        result of the split() method.
+
+        Returns a new SatinColumn instance that combines the rails and rungs of
+        this satin and the provided satin.  A rung is added at the end of this
+        satin.
+        """
+        rails = [self.flatten_subpath(rail) for rail in self.rails]
+        other_rails = [satin.flatten_subpath(rail) for rail in satin.rails]
+
+        if len(rails) != 2 or len(other_rails) != 2:
+            # weird non-satin things, give up and don't merge
+            return self
+
+        rails[0].extend(other_rails[0])
+        rails[1].extend(other_rails[1])
+
+        rungs = [self.flatten_subpath(rung) for rung in self.rungs]
+        other_rungs = [satin.flatten_subpath(rung) for rung in satin.rungs]
+
+        # add a rung at the end of my satin
+        rungs.append([rails[0][-1], rails[1][-1]])
+
+        # add on the other satin's rungs
+        rungs.extend(other_rungs)
+
+        return self._csp_to_satin(point_lists_to_csp(rails + rungs))
+
     @property
     @cache
     def center_line(self):

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -698,7 +698,7 @@ class SatinColumn(EmbroideryElement):
         new SatinColumn's node will not be in the SVG document.
         """
 
-        return self._csp_to_satin(self.csp, True)
+        return self._csp_to_satin(self.csp)
 
     def split(self, split_point):
         """Split a satin into two satins at the specified point
@@ -713,6 +713,9 @@ class SatinColumn(EmbroideryElement):
         Returns two new SatinColumn instances: the part before and the part
         after the split point.  All parameters are copied over to the new
         SatinColumn instances.
+
+        The returned SatinColumns will not be in the SVG document and will have
+        their transforms applied.
         """
 
         cut_points = self._find_cut_points(split_point)
@@ -814,12 +817,13 @@ class SatinColumn(EmbroideryElement):
     def _path_list_to_satins(self, path_list):
         return self._csp_to_satin(line_strings_to_csp(path_list))
 
-    def _csp_to_satin(self, csp, remove_transform=False):
+    def _csp_to_satin(self, csp):
         node = deepcopy(self.node)
         d = paths.CubicSuperPath(csp).to_path()
         node.set("d", d)
 
-        if remove_transform and node.get("transform"):
+        # we've already applied the transform, so get rid of it
+        if node.get("transform"):
             del node.attrib["transform"]
 
         return SatinColumn(node)
@@ -834,6 +838,9 @@ class SatinColumn(EmbroideryElement):
         Returns a new SatinColumn instance that combines the rails and rungs of
         this satin and the provided satin.  A rung is added at the end of this
         satin.
+
+        The returned SatinColumn will not be in the SVG document and will have
+        its transforms applied.
         """
         rails = [self.flatten_subpath(rail) for rail in self.rails]
         other_rails = [satin.flatten_subpath(rail) for rail in satin.rails]

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -51,7 +51,7 @@ class ConvertToSatin(InkstitchExtension):
             path_style = self.path_style(element)
 
             for path in element.paths:
-                path = self.remove_duplicate_points(path)
+                path = self.remove_duplicate_points(self.fix_loop(path))
 
                 if len(path) < 2:
                     # ignore paths with just one point -- they're not visible to the user anyway
@@ -101,6 +101,17 @@ class ConvertToSatin(InkstitchExtension):
         halves[1] = [midpoint] + halves[1]
 
         return halves
+
+    def fix_loop(self, path):
+        if path[0] == path[-1] and len(path) > 1:
+            first = Point.from_tuple(path[0])
+            second = Point.from_tuple(path[1])
+            midpoint = (first + second) / 2
+            midpoint = midpoint.as_tuple()
+
+            return [midpoint] + path[1:] + [path[0], midpoint]
+        else:
+            return path
 
     def remove_duplicate_points(self, path):
         path = [[round(coord, 4) for coord in point] for point in path]

--- a/lib/extensions/convert_to_satin.py
+++ b/lib/extensions/convert_to_satin.py
@@ -319,10 +319,8 @@ class ConvertToSatin(InkstitchExtension):
             # Rotate 90 degrees left to make a normal vector.
             normal = tangent.rotate_left()
 
-            # Travel 75% of the stroke width left and right to make the rung's
-            # endpoints.  This means the rung's length is 150% of the stroke
-            # width.
-            offset = normal * stroke_width * 0.75
+            # Extend the rungs by an offset value to make sure they will cross the rails
+            offset = normal * (stroke_width / 2) * 1.2
             rung_start = rung_center + offset
             rung_end = rung_center - offset
 

--- a/lib/svg/path.py
+++ b/lib/svg/path.py
@@ -53,11 +53,18 @@ def get_node_transform(node):
 
 
 def get_correction_transform(node, child=False):
-    """Get a transform to apply to new siblings or children of this SVG node"""
+    """Get a transform to apply to new siblings or children of this SVG node
 
-    # if we want to place our new nodes in the same group/layer as this node,
-    # then we'll need to factor in the effects of any transforms set on
-    # the parents of this node.
+    Arguments:
+        child (boolean) -- whether the new nodes we're going to add will be
+                           children of node (child=True) or siblings of node
+                           (child=False)
+
+    This allows us to add a new child node that has its path specified in
+    absolute coordinates.  The correction transform will undo the effects of
+    the parent's and ancestors' transforms so that absolute coordinates
+    work properly.
+    """
 
     if child:
         transform = get_node_transform(node)


### PR DESCRIPTION
At long last!  With this change, Convert Line To Satin now produces only a single satin, rather than potentially a bunch of pieces as before.

Corners are also handled better.  Previously, if Ink/Stitch had to split the line to deal with a self-intersection, and it split at a corner, the satin wouldn't go around the corner nicely.  Now, it does!  A great example of this is trying to convert a rectangle from the rectangle tool to a satin.

Loops are handled better too.  The path is broken halfway from the first to the second point, which should hopefully avoid the weirdness.  So far it seems to handle circles and rectangles well, at least.

I wonder if this might allow us to convert simple satins to satin columns under the hood automatically?
