### PR TITLE
stagger split satin rows

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1346,7 +1346,7 @@ class SatinColumn(EmbroideryElement):
 
     def _get_split_points_staggered(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False, min_split_length=None,
                                     seed=None, row_num=0, from_end=False, _staggers=None):
-        if not length:
+        if not length or a.distance(b) <= length:
             return []
 
         if _staggers is None:

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1304,6 +1304,7 @@ class SatinColumn(EmbroideryElement):
 
         if from_end:
             a, b = b, a
+            a_short, b_short = b_short, a_short
 
         line = shgeo.LineString((a, b))
         a_short_projection = line.project(shgeo.Point(a_short))

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1334,7 +1334,7 @@ class SatinColumn(EmbroideryElement):
     def _get_split_points_staggered(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False, min_split_length=None,
                                     seed=None, row_num=0, from_end=False, _staggers=None):
         if not length:
-            return ([], None)
+            return []
 
         if _staggers is None:
             # This is only here to allow _get_split_points_simple to override

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1276,6 +1276,10 @@ class SatinColumn(EmbroideryElement):
         # turn the list of points back into pairs
         pairs = [points[i:i + 2] for i in range(0, len(points), 2)]
 
+        # remove last item if it isn't paired up
+        if len(pairs[-1]) == 1:
+            del pairs[-1]
+
         short_pairs = self.inset_short_stitches_sawtooth(pairs)
         max_stitch_length = self.max_stitch_length_px
         length_sigma = self.random_split_jitter

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -53,16 +53,20 @@ def split_segment_random_phase(a, b, length: float, length_sigma: float, random_
     return [line.interpolate(x, normalized=False) for x in splits]
 
 
-def split_segment_stagger_phase(a, b, segment_length: float, num_staggers: int, this_segment_num: int) -> typing.List[shgeo.Point]:
+def split_segment_stagger_phase(a, b, segment_length: float, num_staggers: int, this_segment_num: int, min=0, max=None) \
+        -> typing.List[shgeo.Point]:
     line = shgeo.LineString([a, b])
     distance = line.length
     stagger_phase = (this_segment_num / num_staggers) % 1
     stagger_offset = stagger_phase * segment_length
+    if max is None:
+        max = distance
 
     splits = []
     progress = stagger_offset
     while progress < distance:
-        splits.append(progress)
+        if progress > min and progress < max:
+            splits.append(progress)
         progress += segment_length
     return [line.interpolate(x, normalized=False) for x in splits]
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -53,6 +53,20 @@ def split_segment_random_phase(a, b, length: float, length_sigma: float, random_
     return [line.interpolate(x, normalized=False) for x in splits]
 
 
+def split_segment_stagger_phase(a, b, segment_length: float, num_staggers: int, this_segment_num: int) -> typing.List[shgeo.Point]:
+    line = shgeo.LineString([a, b])
+    distance = line.length
+    stagger_phase = (this_segment_num / num_staggers) % 1
+    stagger_offset = stagger_phase * segment_length
+
+    splits = []
+    progress = stagger_offset
+    while progress < distance:
+        splits.append(progress)
+        progress += segment_length
+    return [line.interpolate(x, normalized=False) for x in splits]
+
+
 class AngleInterval():
     # Modular interval containing either the entire circle or less than half of it
     # partially based on https://fgiesen.wordpress.com/2015/09/24/intervals-in-modular-arithmetic/

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -148,6 +148,8 @@ inkstitch_attribs = [
     'random_width_decrease_percent',
     'random_width_increase_percent',
     'random_zigzag_spacing_percent',
+    'split_method',
+    'split_staggers',
     'random_split_phase',
     'random_split_jitter_percent',
     'min_random_split_length_mm',


### PR DESCRIPTION
This adds a staggering option for split satin.  

![image](https://github.com/inkstitch/inkstitch/assets/4446653/4f86c69f-2343-49a7-90f1-69c5ba061890)
![image](https://github.com/inkstitch/inkstitch/assets/4446653/7dc92c17-3bc8-4fd4-b353-d71d8e7bba25)

It also adds a new "S" stitch Satin method (second picture) which makes the staggering line up more nicely.  You can also use S stitch to turn a satin into a new kind of curved fill stitch!

Staggering is accessed through the new "split method" option.  The current split method is the default (called "default" in the menu).  There's also a new "simple" method that just splits at the maximum stitch length you give it, without trying to split an even number of times.