### PR TITLE
Fix toggle command visibility

### DIFF
--- a/lib/extensions/object_commands_toggle_visibility.py
+++ b/lib/extensions/object_commands_toggle_visibility.py
@@ -19,6 +19,6 @@ class ObjectCommandsToggleVisibility(InkstitchExtension):
         for command_group in command_groups:
             if first_iteration:
                 first_iteration = False
-                if not command_group.is_visible():
+                if command_group.style('display', 'inline') == 'none':
                     display = "inline"
             command_group.style['display'] = display


### PR DESCRIPTION
... did not work when the first command was in an invisible group/layer.
We should check the command group directly instead.