### PR TITLE
Remove specific commands only

### DIFF
--- a/lib/extensions/remove_embroidery_settings.py
+++ b/lib/extensions/remove_embroidery_settings.py
@@ -5,7 +5,7 @@
 
 from inkex import NSS, Boolean, ShapeElement
 
-from ..commands import find_commands
+from ..commands import OBJECT_COMMANDS, find_commands
 from ..svg.svg import find_elements
 from .base import InkstitchExtension
 
@@ -14,7 +14,7 @@ class RemoveEmbroiderySettings(InkstitchExtension):
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self, *args, **kwargs)
         self.arg_parser.add_argument("-p", "--del_params", dest="del_params", type=Boolean, default=True)
-        self.arg_parser.add_argument("-c", "--del_commands", dest="del_commands", type=Boolean, default=False)
+        self.arg_parser.add_argument("-c", "--del_commands", dest="del_commands", type=str, default="none")
         self.arg_parser.add_argument("-d", "--del_print", dest="del_print", type=Boolean, default=False)
 
     def effect(self):
@@ -22,7 +22,7 @@ class RemoveEmbroiderySettings(InkstitchExtension):
 
         if self.options.del_params:
             self.remove_params()
-        if self.options.del_commands:
+        if self.options.del_commands != 'none':
             self.remove_commands()
         if self.options.del_print:
             self.remove_print_settings()
@@ -43,28 +43,53 @@ class RemoveEmbroiderySettings(InkstitchExtension):
             elements = self.get_selected_elements()
             self.remove_inkstitch_attributes(elements)
 
-    def remove_commands(self):
-        if not self.svg.selection:
-            # remove intact command groups
-            xpath = ".//svg:g[starts-with(@id,'command_group')]"
-            groups = find_elements(self.svg, xpath)
-            for group in groups:
+    def remove_all_commands(self):
+        xpath = ".//svg:g[starts-with(@id,'command_group')]"
+        groups = find_elements(self.svg, xpath)
+        for group in groups:
+            group.getparent().remove(group)
+
+        # remove standalone commands and ungrouped object commands
+        standalone_commands = ".//svg:use[starts-with(@xlink:href, '#inkstitch_')]|.//svg:path[starts-with(@id, 'command_connector')]"
+        self.remove_elements(standalone_commands)
+
+        # let's remove the symbols (defs), we won't need them in the document
+        symbols = ".//*[starts-with(@id, 'inkstitch_')]"
+        self.remove_elements(symbols)
+
+    def remove_specific_commands(self, command):
+        # remove object commands
+        if command in OBJECT_COMMANDS:
+            xlink = f"#inkstitch_{command}"
+            xpath = f".//svg:use[starts-with(@xlink:href, '{xlink}')]"
+            connectors = find_elements(self.svg, xpath)
+            for connector in connectors:
+                group = connector.getparent()
                 group.getparent().remove(group)
-        else:
-            elements = self.get_selected_elements()
-            for element in elements:
-                for command in find_commands(element):
+
+        # remove standalone commands and ungrouped object commands
+        standalone_commands = ".//svg:use[starts-with(@xlink:href, '#inkstitch_{command}')]"
+        self.remove_elements(standalone_commands)
+
+        # let's remove the symbols (defs), we won't need them in the document
+        symbols = f".//*[starts-with(@id, 'inkstitch_{command}')]"
+        self.remove_elements(symbols)
+
+    def remove_selected_commands(self):
+        elements = self.get_selected_elements()
+        for element in elements:
+            for command in find_commands(element):
+                if self.options.del_commands in ('all', command.command):
                     group = command.connector.getparent()
                     group.getparent().remove(group)
 
-        if not self.svg.selection:
-            # remove standalone commands and ungrouped object commands
-            standalone_commands = ".//svg:use[starts-with(@xlink:href, '#inkstitch_')]|.//svg:path[starts-with(@id, 'command_connector')]"
-            self.remove_elements(standalone_commands)
-
-            # let's remove the symbols (defs), we won't need them in the document
-            symbols = ".//*[starts-with(@id, 'inkstitch_')]"
-            self.remove_elements(symbols)
+    def remove_commands(self):
+        if self.svg.selection:
+            self.remove_selected_commands()
+        elif self.options.del_commands == "all":
+            self.remove_all_commands()
+        else:
+            self.remove_specific_commands(self.options.del_commands)
 
     def get_selected_elements(self):
         return self.svg.selection.get(ShapeElement)

--- a/templates/remove_embroidery_settings.xml
+++ b/templates/remove_embroidery_settings.xml
@@ -5,8 +5,21 @@
     <param name="description" type="description">Use this extension to remove the information Ink/Stitch has stored in your document.  This can be especially useful if you copy and paste objects from an embroidery design into another document.</param>
     <param name="del_params" type="boolean" gui-text="Remove Params"
            gui-description="Removes params from selected objects or all objects if nothing is selected.">true</param>
-    <param name="del_commands" type="boolean" gui-text="Remove Commands"
-           gui-description="Removes visual commands from selected objects or all objects if nothing is selected.">false</param>
+    <param name="del_commands" type="optiongroup" gui-text="Remove Commands"
+           gui-description="Removes visual commands from selected objects or all objects if nothing is selected."
+           appearance="combo">
+        <option value="none">None</option>
+        <option value="all">All</option>
+        {%- for command, description in object_commands -%}
+        <option value="{{ command }}">{{ description }}</option>
+        {% endfor %}
+        {% for command, description in layer_commands %}
+        <option value="{{ command }}">{{ description }}</option>
+        {% endfor %}
+        {% for command, description in global_commands %}
+        <option value="{{ command }}">{{ description }}</option>
+        {% endfor %}
+    </param>
     <param name="del_print" type="boolean" gui-text="Remove Print Settings from SVG metadata">false</param>
     <param name="extension" type="string" gui-hidden="true">remove_embroidery_settings</param>
     <effect>


### PR DESCRIPTION
Needed this.
May be useful for others as well...

Enables `Troubleshoot > Remove embroidery settings ... ` to remove only specific command types.