### PR TITLE
Add outline extension

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -37,6 +37,7 @@ from .lettering_update_json_glyphlist import LetteringUpdateJsonGlyphlist
 from .letters_to_font import LettersToFont
 from .object_commands import ObjectCommands
 from .object_commands_toggle_visibility import ObjectCommandsToggleVisibility
+from .outline import Outline
 from .output import Output
 from .palette_split_text import PaletteSplitText
 from .palette_to_text import PaletteToText
@@ -92,6 +93,7 @@ __all__ = extensions = [ApplyThreadlist,
                         LettersToFont,
                         ObjectCommands,
                         ObjectCommandsToggleVisibility,
+                        Outline,
                         Output,
                         PaletteSplitText,
                         PaletteToText,

--- a/lib/extensions/outline.py
+++ b/lib/extensions/outline.py
@@ -1,0 +1,50 @@
+# Authors: see git history
+#
+# Copyright (c) 2010 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import inkex
+from shapely import concave_hull
+from shapely.geometry import LineString, MultiPolygon
+
+from ..i18n import _
+from ..svg.tags import SVG_PATH_TAG
+from .base import InkstitchExtension
+
+
+class Outline(InkstitchExtension):
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("-r", "--ratio", type=float, default=0.0, dest="ratio")
+        self.arg_parser.add_argument("-a", "--allow-holes", type=inkex.Boolean, default=False, dest="allow_holes")
+
+    def effect(self):
+        if not self.svg.selection:
+            inkex.errormsg(_("Please select one or more shapes to convert to their outline."))
+            return
+
+        for element in self.svg.selection:
+            self.element_to_outline(element)
+
+    def element_to_outline(self, element):
+        if element.tag_name == 'g':
+            for element in element.iterdescendants(SVG_PATH_TAG):
+                self.element_to_outline(element)
+            return
+
+        path = element.get_path()
+        path = path.end_points
+        hull = concave_hull(LineString(path), ratio=self.options.ratio, allow_holes=self.options.allow_holes)
+        if isinstance(hull, LineString):
+            return
+
+        if not isinstance(hull, MultiPolygon):
+            hull = MultiPolygon([hull])
+        d = ''
+        for geom in hull.geoms:
+            d += 'M '
+            for x, y in geom.exterior.coords:
+                d += f'{x}, {y} '
+            d += "Z"
+
+        element.set('d', d)

--- a/templates/outline.xml
+++ b/templates/outline.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Outline</name>
+    <id>org.inkstitch.outline</id>
+    <param name="extension" type="string" gui-hidden="true">outline</param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="Ink/Stitch" translatable="no">
+                <submenu name="Tools: Stroke" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <param name="ratio" type="float" appearance="full" gui-text="Ratio" precision="2" min="0" max="1">0</param>
+    <param name="allow-holes" type="boolean" gui-text="Allow Holes">false</param>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
Works only in with #2471 

Draws an outline around objects.
It could be useful to convert an imported embroidery element back to an svg element.