### PR TITLE
Fix fills without underpath

### DIFF
--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -634,9 +634,9 @@ def travel(shape, travel_graph, edge, running_stitch_length, running_stitch_tole
     path = networkx.shortest_path(travel_graph, start, end, weight='weight')
     if underpath and path != (start, end):
         path = smooth_path(path, 2)
+        path = clamp_path_to_polygon(path, shape)
     else:
         path = [InkstitchPoint.from_tuple(point) for point in path]
-    path = clamp_path_to_polygon(path, shape)
 
     points = running_stitch(path, running_stitch_length, running_stitch_tolerance)
     stitches = [Stitch(point) for point in points]


### PR DESCRIPTION
Fills which have underpath disabled tend to create jumps between sections since we do clamping.
@lexelby is there a better way to avoid those jumps other than disable clamping for fills without underpathing?