### PR TITLE
Fix new param simulator for macOS

### DIFF
--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -37,9 +37,8 @@ class LetteringFrame(wx.Frame):
         self.metadata = kwargs.pop('metadata', [])
 
         # begin wxGlade: MyFrame.__init__
-        wx.Frame.__init__(self, None, wx.ID_ANY,
-                          _("Ink/Stitch Lettering")
-                          )
+        wx.Frame.__init__(self, None, wx.ID_ANY, _("Ink/Stitch Lettering"))
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
 
         icon = wx.Icon(os.path.join(get_resource_dir("icons"), "inkstitch256x256.png"))
         self.SetIcon(icon)

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -477,9 +477,9 @@ class SettingsFrame(wx.Frame):
         self.metadata = kwargs.pop('metadata', [])
 
         # begin wxGlade: MyFrame.__init__
-        wx.Frame.__init__(self, None, wx.ID_ANY,
-                          _("Embroidery Params")
-                          )
+        wx.Frame.__init__(self, None, wx.ID_ANY, _("Embroidery Params"))
+
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
 
         icon = wx.Icon(os.path.join(
             get_resource_dir("icons"), "inkstitch256x256.png"))

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -16,6 +16,8 @@ class ElementInfoFrame(wx.Frame):
         self.index = 0
         wx.Frame.__init__(self, None, wx.ID_ANY, _("Element Info"), *args, **kwargs)
 
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
+
         self.main_panel = wx.Panel(self, wx.ID_ANY)
 
         notebook_sizer = wx.BoxSizer(wx.VERTICAL)

--- a/lib/gui/preferences.py
+++ b/lib/gui/preferences.py
@@ -16,6 +16,8 @@ class PreferencesFrame(wx.Frame):
         wx.Frame.__init__(self, None, wx.ID_ANY, _("Preferences"), *args, **kwargs)
         self.SetTitle(_("Preferences"))
 
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
+
         metadata = self.extension.get_inkstitch_metadata()
 
         self.panel_1 = wx.Panel(self, wx.ID_ANY)

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -993,6 +993,8 @@ class EmbroiderySimulator(wx.Frame):
         target_duration = kwargs.pop('target_duration', None)
         wx.Frame.__init__(self, *args, **kwargs)
 
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
+
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.simulator_panel = SimulatorPanel(self,
                                               stitch_plan=stitch_plan,

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -106,6 +106,7 @@ class ControlPanel(wx.Panel):
         self.stitchBox.Bind(wx.EVT_TEXT_ENTER, self.on_stitch_box_focusout)
         self.stitchBox.Bind(wx.EVT_KILL_FOCUS, self.on_stitch_box_focusout)
         self.Bind(wx.EVT_LEFT_DOWN, self.on_stitch_box_focusout)
+        self.totalstitchText = wx.StaticText(self, -1, label=f"/ { self.stitch_plan.num_stitches }")
         self.btnJump = wx.BitmapToggleButton(self, -1, style=self.button_style)
         self.btnJump.SetToolTip(_('Show jump stitches'))
         self.btnJump.SetBitmap(self.load_icon('jump'))
@@ -126,7 +127,8 @@ class ControlPanel(wx.Panel):
         # Layout
         self.hbSizer1 = wx.BoxSizer(wx.HORIZONTAL)
         self.hbSizer1.Add(self.slider, 1, wx.EXPAND | wx.RIGHT, 10)
-        self.hbSizer1.Add(self.stitchBox, 0, wx.ALIGN_TOP | wx.RIGHT, 10)
+        self.hbSizer1.Add(self.stitchBox, 0, wx.ALIGN_CENTER | wx.RIGHT, 10)
+        self.hbSizer1.Add(self.totalstitchText, 0, wx.ALIGN_CENTER | wx.RIGHT, 10)
 
         self.controls_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Controls")), wx.HORIZONTAL)
         self.controls_inner_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -824,9 +826,10 @@ class SimulatorSlider(wx.Panel):
     def __init__(self, parent, id=wx.ID_ANY, *args, **kwargs):
         super().__init__(parent, id)
 
-        kwargs['style'] = wx.SL_HORIZONTAL | wx.SL_LABELS | wx.SL_TOP | wx.ALIGN_TOP
+        kwargs['style'] = wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL | wx.SL_TOP | wx.ALIGN_TOP
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.sizer.Add((10, 1), 1, wx.EXPAND)
         self.slider = wx.Slider(self, *args, **kwargs)
         self.sizer.Add(self.slider, 0, wx.EXPAND)
 
@@ -845,11 +848,14 @@ class SimulatorSlider(wx.Panel):
         self.color_sections = []
         self.margin = 13
         self.color_bar_start = 0
-        self.color_bar_thickness = 0.25
-        self.marker_start = 0.25
+        self.color_bar_thickness = 0.1
+        self.marker_start = 0
         self.marker_end = 0.75
         self.marker_icon_start = 0.75
         self.marker_icon_size = size.height // 3
+
+        if sys.platform == "darwin":
+            self.margin = 8
 
         self.Bind(wx.EVT_PAINT, self.on_paint)
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.on_erase_background)
@@ -890,8 +896,9 @@ class SimulatorSlider(wx.Panel):
 
     def on_paint(self, event):
         dc = wx.BufferedPaintDC(self)
-        background_brush = wx.Brush(self.GetTopLevelParent().GetBackgroundColour(), wx.SOLID)
-        dc.SetBackground(background_brush)
+        if not sys.platform.startswith("win"):
+            background_brush = wx.Brush(self.GetTopLevelParent().GetBackgroundColour(), wx.SOLID)
+            dc.SetBackground(background_brush)
         dc.Clear()
         gc = wx.GraphicsContext.Create(dc)
 

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -101,9 +101,9 @@ class ControlPanel(wx.Panel):
         self.btnNpp.Bind(wx.EVT_TOGGLEBUTTON, self.toggle_npp)
         self.btnNpp.SetBitmap(self.load_icon('npp'))
         self.btnNpp.SetToolTip(_('Display needle penetration point (O)'))
-        self.slider = SimulatorSlider(self, -1, value=1, minValue=1, maxValue=2)
+        self.slider = SimulatorSlider(self, -1, value=1, minValue=1, maxValue=self.stitch_plan.num_stitches)
         self.slider.Bind(wx.EVT_SLIDER, self.on_slider)
-        self.stitchBox = IntCtrl(self, -1, value=1, min=1, max=2, limited=True, allow_none=True, style=wx.TE_PROCESS_ENTER)
+        self.stitchBox = IntCtrl(self, -1, value=1, min=1, max=self.stitch_plan.num_stitches, size=((100, -1)), limited=True, allow_none=True, style=wx.TE_PROCESS_ENTER)
         self.stitchBox.Bind(wx.EVT_LEFT_DOWN, self.on_stitch_box_focus)
         self.stitchBox.Bind(wx.EVT_SET_FOCUS, self.on_stitch_box_focus)
         self.stitchBox.Bind(wx.EVT_TEXT_ENTER, self.on_stitch_box_focusout)
@@ -129,7 +129,7 @@ class ControlPanel(wx.Panel):
         # Layout
         self.hbSizer1 = wx.BoxSizer(wx.HORIZONTAL)
         self.hbSizer1.Add(self.slider, 1, wx.EXPAND | wx.RIGHT, 10)
-        self.hbSizer1.Add(self.stitchBox, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+        self.hbSizer1.Add(self.stitchBox, 0, wx.ALIGN_TOP | wx.RIGHT, 10)
 
         self.command_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Command")), wx.VERTICAL)
         self.command_text = wx.StaticText(self, wx.ID_ANY, label="", style=wx.ALIGN_CENTRE_HORIZONTAL | wx.ST_NO_AUTORESIZE)
@@ -836,7 +836,7 @@ class SimulatorSlider(wx.Panel):
     def __init__(self, parent, id=wx.ID_ANY, *args, **kwargs):
         super().__init__(parent, id)
 
-        kwargs['style'] = wx.SL_HORIZONTAL | wx.SL_LABELS
+        kwargs['style'] = wx.SL_HORIZONTAL | wx.SL_LABELS | wx.SL_TOP | wx.ALIGN_TOP
 
         self.sizer = wx.BoxSizer(wx.VERTICAL)
         self.slider = wx.Slider(self, *args, **kwargs)
@@ -856,9 +856,9 @@ class SimulatorSlider(wx.Panel):
         self.marker_pen = wx.Pen(wx.Colour(0, 0, 0))
         self.color_sections = []
         self.margin = 13
-        self.color_bar_start = 0.25
+        self.color_bar_start = 0
         self.color_bar_thickness = 0.25
-        self.marker_start = 0.375
+        self.marker_start = 0.25
         self.marker_end = 0.75
         self.marker_icon_start = 0.75
         self.marker_icon_size = size.height // 3

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -339,7 +339,11 @@ class ControlPanel(wx.Panel):
     def on_stitch_box_focusout(self, event):
         self.SetAcceleratorTable(self.accel_table)
         stitch = self.stitchBox.GetValue()
-        self.parent.SetFocus()
+        # We now want to remove the focus from the stitchBox.
+        # In Windows it won't work if we set focus to self.parent, while setting the focus to the
+        # top level would work. This in turn would activate the trim button in Linux. So let's
+        # set the focus on the slider instead where it doesn't cause any harm in any of the operating systems
+        self.slider.SetFocus()
 
         if stitch is None:
             stitch = 1
@@ -349,6 +353,7 @@ class ControlPanel(wx.Panel):
 
         if self.drawing_panel:
             self.drawing_panel.set_current_stitch(stitch)
+        event.Skip()
 
     def animation_slow_down(self, event):
         """"""

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -829,7 +829,7 @@ class ColorSection:
 class SimulatorSlider(wx.Panel):
     PROXY_EVENTS = (wx.EVT_SLIDER,)
 
-    def __init__(self, parent, id=wx.ID_ANY, *args, **kwargs):
+    def __init__(self, parent, id=wx.ID_ANY, minValue=0, maxValue=1, **kwargs):
         super().__init__(parent, id)
 
         kwargs['style'] = wx.SL_HORIZONTAL | wx.SL_VALUE_LABEL | wx.SL_TOP | wx.ALIGN_TOP
@@ -856,8 +856,8 @@ class SimulatorSlider(wx.Panel):
         self.marker_icon_start = 0.75
         self.marker_icon_size = self._height // 4
 
-        self._min = 0
-        self._max = 1
+        self._min = minValue
+        self._max = maxValue
         self._value = 0
         self._tab_rect = None
 
@@ -973,7 +973,9 @@ class SimulatorSlider(wx.Panel):
         min_value = self._min
         max_value = self._max
         spread = max_value - min_value
-        value = (point.x - self.margin) * spread / (width - 2 * self.margin)
+        value = round((point.x - self.margin) * spread / (width - 2 * self.margin))
+        value = max(value, self._min)
+        value = min(value, self._max)
         self.SetValue(round(value))
 
         event = wx.CommandEvent(wx.wxEVT_COMMAND_SLIDER_UPDATED, self.GetId())

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -103,7 +103,8 @@ class ControlPanel(wx.Panel):
         self.btnNpp.SetToolTip(_('Display needle penetration point (O)'))
         self.slider = SimulatorSlider(self, -1, value=1, minValue=1, maxValue=self.stitch_plan.num_stitches)
         self.slider.Bind(wx.EVT_SLIDER, self.on_slider)
-        self.stitchBox = IntCtrl(self, -1, value=1, min=1, max=self.stitch_plan.num_stitches, size=((100, -1)), limited=True, allow_none=True, style=wx.TE_PROCESS_ENTER)
+        self.stitchBox = IntCtrl(self, -1, value=1, min=1, max=self.stitch_plan.num_stitches,
+                                 size=((100, -1)), limited=True, allow_none=True, style=wx.TE_PROCESS_ENTER)
         self.stitchBox.Bind(wx.EVT_LEFT_DOWN, self.on_stitch_box_focus)
         self.stitchBox.Bind(wx.EVT_SET_FOCUS, self.on_stitch_box_focus)
         self.stitchBox.Bind(wx.EVT_TEXT_ENTER, self.on_stitch_box_focusout)
@@ -1000,7 +1001,15 @@ class EmbroiderySimulator(wx.Frame):
                                               stitches_per_second=stitches_per_second)
         sizer.Add(self.simulator_panel, 1, wx.EXPAND)
 
-        self.SetSizeHints(sizer.CalcMin())
+        # SetSizeHints seems to be ignored in macOS, so we have to adjust size manually
+        # self.SetSizeHints(sizer.CalcMin())
+        frame_width, frame_height = self.GetSize()
+        sizer_width, sizer_height = sizer.CalcMin()
+        size_diff = frame_width - sizer_width
+        if size_diff < 0:
+            frame_x, frame_y = self.GetPosition()
+            self.SetPosition((frame_x + size_diff, frame_y))
+            self.SetSize((sizer_width, frame_height))
 
         self.Bind(wx.EVT_CLOSE, self.on_close)
 

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -84,7 +84,7 @@ class ControlPanel(wx.Panel):
         self.btnReverse = wx.BitmapToggleButton(self, -1, style=self.button_style)
         self.btnReverse.Bind(wx.EVT_TOGGLEBUTTON, self.on_reverse_button)
         self.btnReverse.SetBitmap(self.load_icon('reverse'))
-        self.btnReverse.SetToolTip(_('Animate in reverse (arrow right)'))
+        self.btnReverse.SetToolTip(_('Animate in reverse (arrow left)'))
         self.btnPlay = wx.BitmapToggleButton(self, -1, style=self.button_style)
         self.btnPlay.Bind(wx.EVT_TOGGLEBUTTON, self.on_play_button)
         self.btnPlay.SetBitmap(self.load_icon('play'))

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -128,13 +128,6 @@ class ControlPanel(wx.Panel):
         self.hbSizer1.Add(self.slider, 1, wx.EXPAND | wx.RIGHT, 10)
         self.hbSizer1.Add(self.stitchBox, 0, wx.ALIGN_TOP | wx.RIGHT, 10)
 
-        self.command_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Command")), wx.VERTICAL)
-        self.command_text = wx.StaticText(self, wx.ID_ANY, label="", style=wx.ALIGN_CENTRE_HORIZONTAL | wx.ST_NO_AUTORESIZE)
-        self.command_text.SetFont(wx.Font(wx.FontInfo(20).Bold()))
-        self.command_text.SetMinSize(self.get_max_command_text_size())
-        self.command_sizer.Add(self.command_text, 0, wx.EXPAND | wx.ALL, 10)
-        self.hbSizer1.Add(self.command_sizer, 0, wx.EXPAND)
-
         self.controls_sizer = wx.StaticBoxSizer(wx.StaticBox(self, wx.ID_ANY, _("Controls")), wx.HORIZONTAL)
         self.controls_inner_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.controls_inner_sizer.Add(self.btnBackwardCommand, 0, wx.EXPAND | wx.ALL, 2)
@@ -321,10 +314,6 @@ class ControlPanel(wx.Panel):
     def update_speed_text(self):
         self.speed_text.SetLabel(self.format_speed_text(self.speed * self.direction))
 
-    def get_max_command_text_size(self):
-        extents = [self.command_text.GetTextExtent(command) for command in COMMAND_NAMES]
-        return max(extents, key=lambda extent: extent.x)
-
     def on_slider(self, event):
         stitch = event.GetEventObject().GetValue()
         self.stitchBox.SetValue(stitch)
@@ -339,7 +328,6 @@ class ControlPanel(wx.Panel):
             self.current_stitch = stitch
             self.slider.SetValue(stitch)
             self.stitchBox.SetValue(stitch)
-            self.command_text.SetLabel(COMMAND_NAMES[command])
 
     def on_stitch_box_focus(self, event):
         self.animation_pause()
@@ -723,7 +711,10 @@ class DrawingPanel(wx.Panel):
     def set_current_stitch(self, stitch):
         self.current_stitch = stitch
         self.clamp_current_stitch()
-        self.control_panel.on_current_stitch(self.current_stitch, self.commands[self.current_stitch])
+        command = self.commands[self.current_stitch]
+        self.control_panel.on_current_stitch(self.current_stitch, command)
+        statusbar = self.GetTopLevelParent().statusbar
+        statusbar.SetStatusText(_("Command: %s") % COMMAND_NAMES[command])
         self.stop_if_at_end()
         self.Refresh()
 
@@ -996,6 +987,8 @@ class EmbroiderySimulator(wx.Frame):
                                               target_duration=target_duration,
                                               stitches_per_second=stitches_per_second)
         sizer.Add(self.simulator_panel, 1, wx.EXPAND)
+
+        self.statusbar = self.CreateStatusBar()
 
         # SetSizeHints seems to be ignored in macOS, so we have to adjust size manually
         # self.SetSizeHints(sizer.CalcMin())

--- a/lib/gui/simulator.py
+++ b/lib/gui/simulator.py
@@ -89,10 +89,6 @@ class ControlPanel(wx.Panel):
         self.btnPlay.Bind(wx.EVT_TOGGLEBUTTON, self.on_play_button)
         self.btnPlay.SetBitmap(self.load_icon('play'))
         self.btnPlay.SetToolTip(_('Play (P)'))
-        self.btnPause = wx.BitmapToggleButton(self, -1, style=self.button_style)
-        self.btnPause.Bind(wx.EVT_TOGGLEBUTTON, self.on_pause_button)
-        self.btnPause.SetBitmap(self.load_icon('pause'))
-        self.btnPause.SetToolTip(_('Pause (P)'))
         self.btnRestart = wx.Button(self, -1, style=self.button_style)
         self.btnRestart.Bind(wx.EVT_BUTTON, self.animation_restart)
         self.btnRestart.SetBitmap(self.load_icon('restart'))
@@ -148,7 +144,6 @@ class ControlPanel(wx.Panel):
         self.controls_inner_sizer.Add(self.btnReverse, 0, wx.EXPAND | wx.ALL, 2)
         self.controls_inner_sizer.Add(self.btnForward, 0, wx.EXPAND | wx.ALL, 2)
         self.controls_inner_sizer.Add(self.btnPlay, 0, wx.EXPAND | wx.ALL, 2)
-        self.controls_inner_sizer.Add(self.btnPause, 0, wx.EXPAND | wx.ALL, 2)
         self.controls_inner_sizer.Add(self.btnRestart, 0, wx.EXPAND | wx.ALL, 2)
         self.controls_sizer.Add((1, 1), 1)
         self.controls_sizer.Add(self.controls_inner_sizer, 0, wx.ALIGN_CENTER_VERTICAL | wx.ALL, 10)
@@ -375,25 +370,26 @@ class ControlPanel(wx.Panel):
 
     def animation_pause(self, event=None):
         self.drawing_panel.stop()
+        self.btnPlay.SetBitmap(self.load_icon('play'))
 
     def animation_start(self, event=None):
         self.drawing_panel.go()
+        self.btnPlay.SetBitmap(self.load_icon('pause'))
 
     def on_start(self):
-        self.btnPause.SetValue(False)
         self.btnPlay.SetValue(True)
+        self.btnPlay.SetBitmap(self.load_icon('pause'))
 
     def on_stop(self):
-        self.btnPause.SetValue(True)
         self.btnPlay.SetValue(False)
-
-    def on_pause_button(self, event):
-        """"""
-        self.animation_pause()
+        self.btnPlay.SetBitmap(self.load_icon('play'))
 
     def on_play_button(self, event):
-        """"""
-        self.animation_start()
+        play = self.btnPlay.GetValue()
+        if play:
+            self.animation_start()
+        else:
+            self.animation_pause()
 
     def play_or_pause(self, event):
         if self.drawing_panel.animating:

--- a/lib/gui/test_swatches.py
+++ b/lib/gui/test_swatches.py
@@ -20,6 +20,8 @@ class GenerateSwatchesFrame(wx.Frame):
         wx.Frame.__init__(self, *args, **kwargs)
         wx.Frame.__init__(self, None, wx.ID_ANY, _("Generate Swatches"), *args, **kwargs)
 
+        self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT)
+
         self.panel = wx.Panel(self, wx.ID_ANY)
 
         main_sizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
Fixes some style issues for macOS. The simulator still doesn't look right on windows.
We may need to move the color bar above the slider. But I haven't played with the Windows version yet, so I'm not sure if this is really necessary. I hope not. I would post a screenshot, but have no Windows system at hand right now.