### PR TITLE
Cleanup document: add option to remove empty groups/layers

### DIFF
--- a/lib/extensions/cleanup.py
+++ b/lib/extensions/cleanup.py
@@ -7,6 +7,7 @@ from inkex import NSS, Boolean, errormsg
 
 from ..elements import FillStitch, Stroke
 from ..i18n import _
+from ..svg.tags import SVG_GROUP_TAG
 from .base import InkstitchExtension
 
 
@@ -17,12 +18,14 @@ class Cleanup(InkstitchExtension):
         self.arg_parser.add_argument("-s", "--rm_stroke", dest="rm_stroke", type=Boolean, default=True)
         self.arg_parser.add_argument("-a", "--fill_threshold", dest="fill_threshold", type=int, default=20)
         self.arg_parser.add_argument("-l", "--stroke_threshold", dest="stroke_threshold", type=int, default=5)
+        self.arg_parser.add_argument("-g", "--rm_groups", dest="rm_groups", type=Boolean, default=True)
 
     def effect(self):
         self.rm_fill = self.options.rm_fill
         self.rm_stroke = self.options.rm_stroke
         self.fill_threshold = self.options.fill_threshold
         self.stroke_threshold = self.options.stroke_threshold
+        self.rm_groups = self.options.rm_groups
 
         self.svg.selection.clear()
 
@@ -38,12 +41,21 @@ class Cleanup(InkstitchExtension):
             return
 
         for element in self.elements:
-            if (isinstance(element, FillStitch) and self.rm_fill and element.shape.area < self.fill_threshold):
+            if self.rm_fill and (isinstance(element, FillStitch) and element.shape.area < self.fill_threshold):
                 element.node.getparent().remove(element.node)
                 count += 1
-            if (isinstance(element, Stroke) and self.rm_stroke and
+            if self.rm_stroke and (isinstance(element, Stroke) and
                element.shape.length < self.stroke_threshold and element.node.getparent() is not None):
                 element.node.getparent().remove(element.node)
                 count += 1
 
         errormsg(_("%s elements removed" % count))
+
+        count = 0
+        if self.rm_groups:
+            for group in self.svg.iterdescendants(SVG_GROUP_TAG):
+                if len(group.getchildren()) == 0:
+                    group.getparent().remove(group)
+                    count += 1
+
+            errormsg(_("%s groups/layers removed" % count))

--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -9,6 +9,7 @@
     <param name="rm_stroke" type="boolean" gui-text="Remove Small strokes"
            gui-description="Removes small strokes shorter than defined by threshold.">true</param>
     <param name="stroke_threshold" type="int" gui-text="Stroke threshold (px)" min="2" max="800">5</param>
+    <param name="rm_groups" type="boolean" gui-text="Remove empty layers and groups">true</param>
     <param name="extension" type="string" gui-hidden="true">cleanup</param>
     <effect>
         <object-type>all</object-type>

--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -10,6 +10,11 @@
            gui-description="Removes small strokes shorter than defined by threshold.">true</param>
     <param name="stroke_threshold" type="int" gui-text="Stroke threshold (px)" min="2" max="800">5</param>
     <param name="rm_groups" type="boolean" gui-text="Remove empty layers and groups">true</param>
+    <spacer />
+    <separator />
+    <spacer />
+    <param name="dry_run" type="boolean" gui-text="Test run"
+        gui-description="Only display labels and ids of affected elements and groups without removing them.">true</param>
     <param name="extension" type="string" gui-hidden="true">cleanup</param>
     <effect>
         <object-type>all</object-type>


### PR DESCRIPTION
* Adds options to remove empty layers and groups
* Adds option for a test run (do not delete, but display labels and ids of elements/groups to be removed)
  (see feature request #2550)