### PR TITLE
Zip: expose file name option better

### DIFF
--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -30,7 +30,6 @@ class Zip(InkstitchExtension):
         self.arg_parser.add_argument('--notebook', type=Boolean, default=True)
         self.arg_parser.add_argument('--file-formats', type=Boolean, default=True)
         self.arg_parser.add_argument('--panelization', type=Boolean, default=True)
-        self.arg_parser.add_argument('--output-options', type=Boolean, default=True)
 
         # it's kind of obnoxious that I have to do this...
         self.formats = []

--- a/templates/zip.xml
+++ b/templates/zip.xml
@@ -9,6 +9,9 @@
         <filetypetooltip>Create a ZIP with multiple embroidery file formats using Ink/Stitch</filetypetooltip>
         <dataloss>true</dataloss>
     </output>
+    <param name="custom-file-name" type="string" gui-text="Custom file name"
+       gui-description="Defines the file names inside the zip archive. Leave empty for default file name."></param>
+    <spacer />
     <param name="notebook" type="notebook">
       <page name="file-formats" gui-text="File Formats">
         <label>Output formats:</label>
@@ -28,10 +31,6 @@
         <param name="x-spacing" type="float" min="-1000" max="1000" gui-text="Horizontal spacing (mm)">100</param>
         <param name="y-repeats" type="int" min="1" max="20" gui-text="Vertical repeats">1</param>
         <param name="y-spacing" type="float" min="-1000" max="1000" gui-text="Vertical spacing (mm)">100</param>
-      </page>
-      <page name="output-options" gui-text="Output Options">
-          <param name="custom-file-name" type="string" gui-text="Custom file name"
-                 gui-description="Defines the file names inside the zip archive. Leave empty for default file name."></param>
       </page>
     </param>
     <script>


### PR DESCRIPTION
Inkscape will load the extension with the last settings. Once entered people will forget the hidden setting and wonder why they are always exporting to the same file name. So let's not hide this option and avoid cursing on zip file export :D