### PR TITLE
Macos 11 -> 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
           name: inkstitch-windows64
           path: artifacts
   mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
There has been a brew update ... looks as if we need to move on to macos 12