### PR TITLE
correct tooltip

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -118,7 +118,7 @@ class SatinColumn(EmbroideryElement):
     @property
     @param('random_zigzag_spacing_percent',
            _('Random zig-zag spacing percentage'),
-           tooltip=_('Amount of random jitter added to stitch length.'),
+           tooltip=_('Amount of random jitter added to zigzag spacing.'),
            default=0, type='float', unit="± %", sort_index=92)
     def random_zigzag_spacing(self):
         # peak-to-peak distance between zigzags


### PR DESCRIPTION
tooltip for random zig-zag spacing was  hinting it was applied to stitch length.