### PR TITLE
Fix invalid clip path

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -10,7 +10,7 @@ import re
 import numpy as np
 from inkex import Transform
 from shapely import geometry as shgeo
-from shapely.errors import TopologicalError
+from shapely.errors import GEOSException
 from shapely.validation import explain_validity, make_valid
 
 from .. import tiles
@@ -562,16 +562,20 @@ class FillStitch(EmbroideryElement):
                 polygons.append(polygon)
             if isinstance(polygon, shgeo.MultiPolygon):
                 polygons.extend(polygon.geoms)
-        return shgeo.MultiPolygon(polygons)
 
     def _get_clipped_path(self):
         if self.node.clip is None:
             return self.original_shape
 
         clip_path = get_clip_path(self.node)
+
+        # make sure clip path and shape are valid
+        clip_path = make_valid(clip_path)
+        shape = make_valid(self.original_shape)
+
         try:
-            intersection = clip_path.intersection(self.original_shape)
-        except TopologicalError:
+            intersection = clip_path.intersection(shape)
+        except GEOSException:
             return self.original_shape
 
         if isinstance(intersection, shgeo.Polygon):

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -7,6 +7,7 @@ from math import ceil
 
 import shapely.geometry as shgeo
 from inkex import Transform
+from shapely.errors import GEOSException
 
 from ..i18n import _
 from ..marker import get_marker_elements
@@ -14,13 +15,12 @@ from ..stitch_plan import StitchGroup
 from ..stitches.ripple_stitch import ripple_stitch
 from ..stitches.running_stitch import bean_stitch, running_stitch
 from ..svg import get_node_transform, parse_length_with_units
+from ..svg.clip import get_clip_path
 from ..threads import ThreadColor
 from ..utils import Point, cache
 from ..utils.param import ParamOption
 from .element import EmbroideryElement, param
-from ..svg.clip import get_clip_path
 from .validation import ValidationWarning
-from shapely.errors import TopologicalError
 
 
 class MultipleGuideLineWarning(ValidationWarning):
@@ -411,7 +411,7 @@ class Stroke(EmbroideryElement):
         line_strings = [shgeo.LineString(path) for path in paths]
         try:
             intersection = clip_path.intersection(shgeo.MultiLineString(line_strings))
-        except TopologicalError:
+        except GEOSException:
             return paths
 
         coords = []


### PR DESCRIPTION
+ use fallback if shape has grating issues (too small)

Fixes issues in #2575 

Shapely error handling has changed slightly. GEOS errors can be caught with GEOSException.