### PR TITLE
Fix networkx no path errors (fill)

### DIFF
--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -195,7 +195,7 @@ def insert_node(graph, shape, point):
 
     edges = []
     for start, end, key, data in graph.edges(keys=True, data=True):
-        if key == "outline":
+        if key == "outline" and data['outline'] == outline:
             edges.append(((start, end), data))
 
     edge, data = min(edges, key=lambda edge_data: shgeo.LineString(edge_data[0]).distance(projected_point))


### PR DESCRIPTION
This should fix a lot of the networkx no path errors.

The problems seems to be that it didn't care into which outline the starting and ending node edges will be inserted. Nearest edges are not necessarily on the correct outline.

Fixes #2056 
Fixes #2516 
Fixes #2452