### PR TITLE
Do not filter small segments for linear gradient graph

### DIFF
--- a/lib/stitches/linear_gradient_fill.py
+++ b/lib/stitches/linear_gradient_fill.py
@@ -259,7 +259,7 @@ def _get_stitch_groups(fill, shape, colors, color_lines, starting_point, ending_
     for i, color in enumerate(colors):
         lines = color_lines[color]
 
-        multiline = ensure_multi_line_string(MultiLineString(lines).intersection(shape), 1.5)
+        multiline = ensure_multi_line_string(MultiLineString(lines).intersection(shape))
         if multiline.is_empty:
             continue
 


### PR DESCRIPTION
Weird shapes may need those for their routing. The small stitch filter will take care of this later.