### PR TITLE
Fix lettering id-error and trims

### DIFF
--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -365,7 +365,7 @@ class Font(object):
         line_break_indices = [i for i, t in enumerate(text) if t == "\n"]
         for group in destination_group.iterdescendants(SVG_GROUP_TAG):
             # make sure we are only looking at glyph groups
-            if group.get("id") != "glyph":
+            if not group.get("id", "").startswith("glyph"):
                 continue
 
             i += 1

--- a/lib/svg/svg.py
+++ b/lib/svg/svg.py
@@ -14,20 +14,13 @@ def get_document(node):
     return node.getroottree().getroot()
 
 
-def generate_unique_id(document_or_element, prefix="path"):
+def generate_unique_id(document_or_element, prefix="path", blacklist=None):
     if isinstance(document_or_element, etree._ElementTree):
         document = document_or_element.getroot()
     else:
         document = get_document(document_or_element)
 
-    doc_ids = {node.get('id') for node in document.iterdescendants() if 'id' in node.attrib}
-
-    i = 1
-    while True:
-        new_id = "%s%d" % (prefix, i)
-        if new_id not in doc_ids:
-            break
-        i += 1
+    new_id = document.get_unique_id(prefix, blacklist=blacklist)
 
     return new_id
 

--- a/lib/svg/svg.py
+++ b/lib/svg/svg.py
@@ -14,13 +14,13 @@ def get_document(node):
     return node.getroottree().getroot()
 
 
-def generate_unique_id(document_or_element, prefix="path", blacklist=None):
+def generate_unique_id(document_or_element, prefix="path", blocklist=None):
     if isinstance(document_or_element, etree._ElementTree):
         document = document_or_element.getroot()
     else:
         document = get_document(document_or_element)
 
-    new_id = document.get_unique_id(prefix, blacklist=blacklist)
+    new_id = document.get_unique_id(prefix, blacklist=blocklist)
 
     return new_id
 


### PR DESCRIPTION
Auto-routed fonts with current main will return an error when it tries to set an id which is already in the document.
Also setting trims won't work because at the time of the trim insertion the glyph group id seems to already have been altered by inkex to make the id unique.