### PR TITLE
Jump to stroke options

### DIFF
--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -20,12 +20,17 @@ class JumpToStroke(InkstitchExtension):
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self, *args, **kwargs)
         self.arg_parser.add_argument("--tab")
-        self.arg_parser.add_argument("-l", "--stitch-length", type=float, default=2.5, dest="running_stitch_length_mm")
-        self.arg_parser.add_argument("-t", "--tolerance", type=float, default=2.0, dest="running_stitch_tolerance_mm")
-        self.arg_parser.add_argument("-c", "--connect", type=str, default="all", dest="connect")
-        self.arg_parser.add_argument("-m", "--merge", type=Boolean, default=False, dest="merge")
+
         self.arg_parser.add_argument("-i", "--minimum-jump-length", type=float, default=3.0, dest="min_jump")
         self.arg_parser.add_argument("-a", "--maximum-jump-length", type=float, default=0, dest="max_jump")
+        self.arg_parser.add_argument("--connect", type=str, default="all", dest="connect")
+        self.arg_parser.add_argument("--exclude-trim", type=Boolean, default=True, dest="exclude_trim")
+        self.arg_parser.add_argument("--exclude-stop", type=Boolean, default=True, dest="exclude_stop")
+        self.arg_parser.add_argument("--exclude-force-lock-stitch", type=Boolean, default=True, dest="exclude_forced_lock")
+
+        self.arg_parser.add_argument("-m", "--merge", type=Boolean, default=False, dest="merge")
+        self.arg_parser.add_argument("-l", "--stitch-length", type=float, default=2.5, dest="running_stitch_length_mm")
+        self.arg_parser.add_argument("-t", "--tolerance", type=float, default=2.0, dest="running_stitch_tolerance_mm")
 
     def effect(self):
         if not self.svg.selection or not self.get_elements() or len(self.elements) < 2:
@@ -51,7 +56,10 @@ class JumpToStroke(InkstitchExtension):
             if (last_stitch_group is None or
                     element.color != last_element.color or
                     (self.options.connect == "layer" and last_layer != layer) or
-                    (self.options.connect == "group" and last_group != group)):
+                    (self.options.connect == "group" and last_group != group) or
+                    (self.options.exclude_trim and (last_element.has_command("trim") or last_element.trim_after)) or
+                    (self.options.exclude_stop and (last_element.has_command("stop") or last_element.stop_after)) or
+                    (self.options.exclude_forced_lock and last_element.force_lock_stitches)):
                 last_layer = layer
                 last_group = group
                 last_stitch_group = stitch_group[-1]

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -19,6 +19,7 @@ class JumpToStroke(InkstitchExtension):
 
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("--tab")
         self.arg_parser.add_argument("-l", "--stitch-length", type=float, default=2.5, dest="running_stitch_length_mm")
         self.arg_parser.add_argument("-t", "--tolerance", type=float, default=2.0, dest="running_stitch_tolerance_mm")
         self.arg_parser.add_argument("-c", "--connect", type=str, default="all", dest="connect")

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -71,11 +71,8 @@ class JumpToStroke(InkstitchExtension):
         index = parent.index(node)
 
         # do not add a running stitch if the distance is smaller than the collapse setting
-        self.metadata = self.get_inkstitch_metadata()
-        collapse_len = self.metadata['collapse_len_mm'] or 3.0
-        collapse_len *= PIXELS_PER_MM
         line = DirectedLineSegment((start.x, start.y), (end.x, end.y))
-        if self.options.min_jump > line.length:
+        if self.options.min_jump * PIXELS_PER_MM > line.length:
             return
 
         path = Path([(start.x, start.y), (end.x, end.y)])

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -3,11 +3,13 @@
 # Copyright (c) 2023 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from inkex import DirectedLineSegment, PathElement, errormsg
+from inkex import (Boolean, DirectedLineSegment, Path, PathElement, Transform,
+                   errormsg)
 
+from ..elements import Stroke
 from ..i18n import _
 from ..svg import PIXELS_PER_MM, get_correction_transform
-from ..svg.tags import INKSTITCH_ATTRIBS
+from ..svg.tags import INKSTITCH_ATTRIBS, SVG_GROUP_TAG
 from .base import InkstitchExtension
 
 
@@ -19,25 +21,51 @@ class JumpToStroke(InkstitchExtension):
         InkstitchExtension.__init__(self, *args, **kwargs)
         self.arg_parser.add_argument("-l", "--stitch-length", type=float, default=2.5, dest="running_stitch_length_mm")
         self.arg_parser.add_argument("-t", "--tolerance", type=float, default=2.0, dest="running_stitch_tolerance_mm")
+        self.arg_parser.add_argument("-c", "--connect", type=str, default="all", dest="connect")
+        self.arg_parser.add_argument("-m", "--merge", type=Boolean, default=False, dest="merge")
+        self.arg_parser.add_argument("-j", "--minimum-jump-length", type=float, default=3.0, dest="min_jump")
 
     def effect(self):
         if not self.svg.selection or not self.get_elements() or len(self.elements) < 2:
             errormsg(_("Please select at least two elements to convert the jump stitch to a running stitch."))
             return
 
+        last_group = None
+        last_layer = None
+        last_element = None
         last_stitch_group = None
-        last_color = None
         for element in self.elements:
+            group = None
+            layer = None
+            for ancestor in element.node.iterancestors(SVG_GROUP_TAG):
+                if group is None:
+                    group = ancestor
+                if ancestor.groupmode == "layer":
+                    layer = ancestor
+                    break
+
             stitch_group = element.to_stitch_groups(last_stitch_group)
+
+            if (last_stitch_group is None or
+                    element.color != last_element.color or
+                    (self.options.connect == "layer" and last_layer != layer) or
+                    (self.options.connect == "group" and last_group != group)):
+                last_layer = layer
+                last_group = group
+                last_stitch_group = stitch_group[-1]
+                last_element = element
+                continue
+
+            start = last_stitch_group.stitches[-1]
             end = stitch_group[-1].stitches[0]
-            if last_stitch_group is not None and element.color == last_color:
-                start = last_stitch_group.stitches[-1]
-                self.generate_stroke(element, start, end)
+            self.generate_stroke(last_element, element, start, end)
 
+            last_group = group
+            last_layer = layer
             last_stitch_group = stitch_group[-1]
-            last_color = element.color
+            last_element = element
 
-    def generate_stroke(self, element, start, end):
+    def generate_stroke(self, last_element, element, start, end):
         node = element.node
         parent = node.getparent()
         index = parent.index(node)
@@ -47,14 +75,38 @@ class JumpToStroke(InkstitchExtension):
         collapse_len = self.metadata['collapse_len_mm'] or 3.0
         collapse_len *= PIXELS_PER_MM
         line = DirectedLineSegment((start.x, start.y), (end.x, end.y))
-        if collapse_len > line.length:
+        if self.options.min_jump > line.length:
             return
 
-        path = f'M {start.x}, {start.y} L {end.x}, {end.y}'
+        path = Path([(start.x, start.y), (end.x, end.y)])
+        # option: merge line with paths
+        merged = False
+        if self.options.merge and isinstance(last_element, Stroke) and last_element.node.TAG == "path":
+            path.transform(Transform(get_correction_transform(last_element.node)), True)
+            path = last_element.node.get_path() + path[1:]
+            last_element.node.set('d', str(path))
+            path.transform(-Transform(get_correction_transform(last_element.node)), True)
+            merged = True
+        if self.options.merge and isinstance(element, Stroke) and node.TAG == "path":
+            path.transform(Transform(get_correction_transform(node)), True)
+            path = path + node.get_path()[1:]
+            node.set('d', str(path))
+            # remove last element (since it is merged)
+            last_parent = last_element.node.getparent()
+            last_parent.remove(last_element.node)
+            # remove parent group if empty
+            if len(last_parent) == 0:
+                last_parent.getparent().remove(last_parent)
+            return
+        if merged:
+            return
+
+        # add simple stroke to connect elements
+        path.transform(Transform(get_correction_transform(node)), True)
         color = element.color
         style = f'stroke:{color};stroke-width:1px;stroke-dasharray:3, 1;fill:none;'
 
-        line = PathElement(d=path, style=style, transform=get_correction_transform(node))
+        line = PathElement(d=str(path), style=style)
         line.set(INKSTITCH_ATTRIBS['running_stitch_length_mm'], self.options.running_stitch_length_mm)
         line.set(INKSTITCH_ATTRIBS['running_stitch_tolerance_mm'], self.options.running_stitch_tolerance_mm)
         parent.insert(index, line)

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -11,8 +11,15 @@
             </submenu>
         </effects-menu>
     </effect>
+    <param name="minimum-jump-length" type="float" gui-text="Convert jumps longer than (mm)">3.0</param>
     <param name="stitch-length" type="float" gui-text="Running stitch length (mm)">2.5</param>
     <param name="tolerance" type="float" gui-text="Running stitch tolerance (mm)">2.0</param>
+    <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
+        <option value="all">all</option>
+        <option value="layer">in same layer</option>
+        <option value="group">in same group</option>
+    </param>
+    <param name="merge" type="bool" gui-text="Merge consecutive strokes">false</param>
     <script>
         {{ command_tag | safe }}
     </script>

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -17,14 +17,24 @@
                gui-text="Convert jumps not shorter than (mm)">3.0</param>
         <param name="maximum-jump-length" type="float" precision="2" min="0" max="10000"
                gui-text="Convert jumps not longer than (mm)">0</param>
-        <param name="stitch-length" type="float" gui-text="Running stitch length (mm)">2.5</param>
-        <param name="tolerance" type="float" gui-text="Running stitch tolerance (mm)">2.0</param>
         <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
             <option value="all">all</option>
             <option value="layer">in same layer</option>
             <option value="group">in same group</option>
         </param>
+        <label>Do not connect after</label>
+        <param name="exclude-trim" type="bool" indent="1" gui-text="Trim">true</param>
+        <param name="exclude-stop" type="bool" indent="1" gui-text="Stop">true</param>
+        <param name="exclude-force-lock-stitch" indent="1" type="bool" gui-text="Force lock stitch">true</param>
+      </page>
+      <page name="output-settings" gui-text="Output settings">
         <param name="merge" type="bool" gui-text="Merge consecutive strokes">false</param>
+        <spacer />
+        <separator />
+        <spacer />
+        <label>These settings only apply when merging is disabled</label>
+        <param name="stitch-length" type="float" indent="1" gui-text="Running stitch length (mm)">2.5</param>
+        <param name="tolerance" type="float" indent="1" gui-text="Running stitch tolerance (mm)">2.0</param>
       </page>
       <page name="info" gui-text="Help">
         <label appearance="header">This extension converts jump stithes to running stitches.</label>

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -11,16 +11,27 @@
             </submenu>
         </effects-menu>
     </effect>
-    <param name="minimum-jump-length" type="float" gui-text="Convert jumps not shorter than (mm)">3.0</param>
-    <param name="maximum-jump-length" type="float" gui-text="Convert jumps not longer than (mm)">0</param>
-    <param name="stitch-length" type="float" gui-text="Running stitch length (mm)">2.5</param>
-    <param name="tolerance" type="float" gui-text="Running stitch tolerance (mm)">2.0</param>
-    <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
-        <option value="all">all</option>
-        <option value="layer">in same layer</option>
-        <option value="group">in same group</option>
+    <param name="tab" type="notebook">
+      <page name="options" gui-text="Cutwork Options">
+        <param name="minimum-jump-length" type="float" precision="2" min="0" max="100"
+               gui-text="Convert jumps not shorter than (mm)">3.0</param>
+        <param name="maximum-jump-length" type="float" precision="2" min="0" max="10000"
+               gui-text="Convert jumps not longer than (mm)">0</param>
+        <param name="stitch-length" type="float" gui-text="Running stitch length (mm)">2.5</param>
+        <param name="tolerance" type="float" gui-text="Running stitch tolerance (mm)">2.0</param>
+        <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
+            <option value="all">all</option>
+            <option value="layer">in same layer</option>
+            <option value="group">in same group</option>
+        </param>
+        <param name="merge" type="bool" gui-text="Merge consecutive strokes">false</param>
+      </page>
+      <page name="info" gui-text="Help">
+        <label appearance="header">This extension converts jump stithes to running stitches.</label>
+        <label>Get more information on our website</label>
+        <label appearance="url">https://inkstitch.org/docs/stroke-tools/#jump-to-stroke</label>
+      </page>
     </param>
-    <param name="merge" type="bool" gui-text="Merge consecutive strokes">false</param>
     <script>
         {{ command_tag | safe }}
     </script>

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -11,7 +11,8 @@
             </submenu>
         </effects-menu>
     </effect>
-    <param name="minimum-jump-length" type="float" gui-text="Convert jumps longer than (mm)">3.0</param>
+    <param name="minimum-jump-length" type="float" gui-text="Convert jumps not shorter than (mm)">3.0</param>
+    <param name="maximum-jump-length" type="float" gui-text="Convert jumps not longer than (mm)">0</param>
     <param name="stitch-length" type="float" gui-text="Running stitch length (mm)">2.5</param>
     <param name="tolerance" type="float" gui-text="Running stitch tolerance (mm)">2.0</param>
     <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -12,7 +12,7 @@
         </effects-menu>
     </effect>
     <param name="tab" type="notebook">
-      <page name="options" gui-text="Cutwork Options">
+      <page name="options" gui-text="Options">
         <param name="minimum-jump-length" type="float" precision="2" min="0" max="100"
                gui-text="Convert jumps not shorter than (mm)">3.0</param>
         <param name="maximum-jump-length" type="float" precision="2" min="0" max="10000"


### PR DESCRIPTION
More options for jump to stroke:

* Min width
* Max width
* Connect only within groups or layers
* Do not connect after trim, stop or forced lock stitches
* Merge new strokes with previous/next stroke

Targets to help fixing font issues when used with specific preferences: #2729 
I could see more use cases for this as well.