### PR TITLE
Add object based min stitch length

### DIFF
--- a/lib/api/stitch_plan.py
+++ b/lib/api/stitch_plan.py
@@ -20,8 +20,8 @@ def get_stitch_plan():
         metadata = g.extension.get_inkstitch_metadata()
         collapse_len = metadata['collapse_len_mm']
         min_stitch_len = metadata['min_stitch_len_mm']
-        patches = g.extension.elements_to_stitch_groups(g.extension.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+        stitch_groups = g.extension.elements_to_stitch_groups(g.extension.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         return jsonify(stitch_plan)
     except InkstitchException as exc:
         return jsonify({"error_message": str(exc)}), 500

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -598,6 +598,10 @@ class EmbroideryElement(object):
                     stitch_groups[-1].trim_after = self.has_command("trim") or self.trim_after
                     stitch_groups[-1].stop_after = self.has_command("stop") or self.stop_after
 
+                for stitch_group in stitch_groups:
+                    stitch_group.min_jump_stitch_length = self.min_jump_stitch_length
+                    stitch_group.set_minimum_stitch_length(self.min_stitch_length)
+
                 self._save_cached_stitch_groups(stitch_groups, previous_stitch)
 
         debug.log(f"ending {self.node.get('id')} {self.node.get(INKSCAPE_LABEL)}")

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -219,6 +219,17 @@ class EmbroideryElement(object):
         return width * self.stroke_scale
 
     @property
+    @param('min_stitch_length_mm',
+           _('Minimum stitch length'),
+           tooltip=_('Overwrite global minimum stitch length setting. Shorter stitches than that will be removed.'),
+           type='float',
+           default=None,
+           sort_index=49)
+    @cache
+    def min_stitch_length(self):
+        return self.get_float_param("min_stitch_length_mm")
+
+    @property
     @param('ties',
            _('Allow lock stitches'),
            tooltip=_('Tie thread at the beginning and/or end of this object. '
@@ -472,7 +483,7 @@ class EmbroideryElement(object):
 
         return lock_start, lock_end
 
-    def to_stitch_groups(self, last_patch):
+    def to_stitch_groups(self, last_stitch_group):
         raise NotImplementedError("%s must implement to_stitch_groups()" % self.__class__.__name__)
 
     @debug.time

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -224,10 +224,21 @@ class EmbroideryElement(object):
            tooltip=_('Overwrite global minimum stitch length setting. Shorter stitches than that will be removed.'),
            type='float',
            default=None,
-           sort_index=49)
+           sort_index=48)
     @cache
     def min_stitch_length(self):
         return self.get_float_param("min_stitch_length_mm")
+
+    @property
+    @param('min_jump_stitch_length_mm',
+           _('Minimum jump stitch length'),
+           tooltip=_('Overwrite global minimum jump stitch length setting. Shorter distances to the next object will have no lock stitches.'),
+           type='float',
+           default=None,
+           sort_index=49)
+    @cache
+    def min_jump_stitch_length(self):
+        return self.get_float_param("min_jump_stitch_length_mm")
 
     @property
     @param('ties',

--- a/lib/elements/empty_d_object.py
+++ b/lib/elements/empty_d_object.py
@@ -27,5 +27,5 @@ class EmptyDObject(EmbroideryElement):
     def shape(self):
         return
 
-    def to_stitch_groups(self, last_patch):
+    def to_stitch_groups(self, last_stitch_group):
         return []

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -954,7 +954,7 @@ class FillStitch(EmbroideryElement):
             tags=("meander_fill", "meander_fill_top"),
             stitches=meander_fill(self, shape, original_shape, i, starting_point, ending_point),
             force_lock_stitches=self.force_lock_stitches,
-            lock_stitches=self.lock_stitches,
+            lock_stitches=self.lock_stitches
         )
         return [stitch_group]
 
@@ -983,14 +983,15 @@ class FillStitch(EmbroideryElement):
             ending_point,
             self.underpath,
             target
-        ),
+        )
 
         stitch_group = StitchGroup(
             color=self.color,
             tags=("circular_fill", "auto_fill_top"),
             stitches=stitches,
             force_lock_stitches=self.force_lock_stitches,
-            lock_stitches=self.lock_stitches,)
+            lock_stitches=self.lock_stitches
+        )
         return [stitch_group]
 
     def do_linear_gradient_fill(self, shape, last_stitch_group, start, end):

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -802,6 +802,7 @@ class FillStitch(EmbroideryElement):
                                    self.skip_last)
         return [StitchGroup(stitches=stitch_list,
                             min_stitch_length=self.min_stitch_length,
+                            min_jump_stitch_length=self.min_jump_stitch_length,
                             color=self.color,
                             force_lock_stitches=self.force_lock_stitches,
                             lock_stitches=self.lock_stitches) for stitch_list in stitch_lists]
@@ -855,7 +856,9 @@ class FillStitch(EmbroideryElement):
                 ending_point,
                 self.underpath
             ),
-            min_stitch_length=self.min_stitch_length)
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
+        )
         return [stitch_group]
 
     def do_contour_fill(self, polygon, last_stitch_group, starting_point):
@@ -898,6 +901,7 @@ class FillStitch(EmbroideryElement):
             tags=("auto_fill", "auto_fill_top"),
             stitches=stitches,
             min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches)
         stitch_groups.append(stitch_group)
@@ -931,7 +935,8 @@ class FillStitch(EmbroideryElement):
                 self.underpath,
                 self.guided_fill_strategy
             ),
-            min_stitch_length=self.min_stitch_length
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
         )
         return [stitch_group]
 
@@ -953,6 +958,7 @@ class FillStitch(EmbroideryElement):
             tags=("meander_fill", "meander_fill_top"),
             stitches=meander_fill(self, shape, original_shape, i, starting_point, ending_point),
             min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches,
         )
@@ -990,6 +996,7 @@ class FillStitch(EmbroideryElement):
             tags=("circular_fill", "auto_fill_top"),
             stitches=stitches,
             min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches,)
         return [stitch_group]

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -792,20 +792,23 @@ class FillStitch(EmbroideryElement):
             return stitch_groups
 
     def do_legacy_fill(self):
-        stitch_lists = legacy_fill(self.shape,
-                                   self.angle,
-                                   self.row_spacing,
-                                   self.end_row_spacing,
-                                   self.max_stitch_length,
-                                   self.flip,
-                                   self.staggers,
-                                   self.skip_last)
-        return [StitchGroup(stitches=stitch_list,
-                            min_stitch_length=self.min_stitch_length,
-                            min_jump_stitch_length=self.min_jump_stitch_length,
-                            color=self.color,
-                            force_lock_stitches=self.force_lock_stitches,
-                            lock_stitches=self.lock_stitches) for stitch_list in stitch_lists]
+        stitch_lists = legacy_fill(
+            self.shape,
+            self.angle,
+            self.row_spacing,
+            self.end_row_spacing,
+            self.max_stitch_length,
+            self.flip,
+            self.staggers,
+            self.skip_last
+        )
+
+        return [StitchGroup(
+            stitches=stitch_list,
+            color=self.color,
+            force_lock_stitches=self.force_lock_stitches,
+            lock_stitches=self.lock_stitches
+        ) for stitch_list in stitch_lists]
 
     def do_underlay(self, shape, starting_point):
         color = self.color
@@ -829,8 +832,7 @@ class FillStitch(EmbroideryElement):
                     self.fill_underlay_skip_last,
                     starting_point,
                     underpath=self.underlay_underpath
-                ),
-                min_stitch_length=self.min_stitch_length
+                )
             )
             stitch_groups.append(underlay)
             starting_point = underlay.stitches[-1]
@@ -855,9 +857,7 @@ class FillStitch(EmbroideryElement):
                 starting_point,
                 ending_point,
                 self.underpath
-            ),
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
+            )
         )
         return [stitch_group]
 
@@ -900,8 +900,6 @@ class FillStitch(EmbroideryElement):
             color=self.color,
             tags=("auto_fill", "auto_fill_top"),
             stitches=stitches,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches)
         stitch_groups.append(stitch_group)
@@ -934,9 +932,7 @@ class FillStitch(EmbroideryElement):
                 ending_point,
                 self.underpath,
                 self.guided_fill_strategy
-            ),
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
+            )
         )
         return [stitch_group]
 
@@ -957,8 +953,6 @@ class FillStitch(EmbroideryElement):
             color=self.color,
             tags=("meander_fill", "meander_fill_top"),
             stitches=meander_fill(self, shape, original_shape, i, starting_point, ending_point),
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches,
         )
@@ -995,8 +989,6 @@ class FillStitch(EmbroideryElement):
             color=self.color,
             tags=("circular_fill", "auto_fill_top"),
             stitches=stitches,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches,)
         return [stitch_group]

--- a/lib/elements/image.py
+++ b/lib/elements/image.py
@@ -29,5 +29,5 @@ class ImageObject(EmbroideryElement):
     def validation_warnings(self):
         yield ImageTypeWarning(self.center())
 
-    def to_stitch_groups(self, last_patch):
+    def to_stitch_groups(self, last_stitch_group):
         return []

--- a/lib/elements/marker.py
+++ b/lib/elements/marker.py
@@ -28,5 +28,5 @@ class MarkerObject(EmbroideryElement):
         repr_point = next(inkex.Path(self.parse_path()).end_points)
         yield MarkerWarning(repr_point)
 
-    def to_stitch_groups(self, last_patch):
+    def to_stitch_groups(self, last_stitch_group):
         return []

--- a/lib/elements/polyline.py
+++ b/lib/elements/polyline.py
@@ -94,10 +94,13 @@ class Polyline(EmbroideryElement):
     def validation_warnings(self):
         yield PolylineWarning(self.path[0][0][0])
 
-    def to_stitch_groups(self, last_patch):
-        patch = StitchGroup(color=self.color, lock_stitches=(None, None))
+    def to_stitch_groups(self, last_stitch_group):
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length, lock_stitches=(None, None))
 
         for stitch in self.stitches:
-            patch.add_stitch(Point(*stitch))
+            stitch_group.add_stitch(Point(*stitch))
 
-        return [patch]
+        if self.minimum_stitch_length is not None:
+            stitch_group.add_tag(f'custom_min_stitch_length:{self.minimum_stitch_length}')
+
+        return [stitch_group]

--- a/lib/elements/polyline.py
+++ b/lib/elements/polyline.py
@@ -95,12 +95,9 @@ class Polyline(EmbroideryElement):
         yield PolylineWarning(self.path[0][0][0])
 
     def to_stitch_groups(self, last_stitch_group):
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length, lock_stitches=(None, None))
+        stitch_group = StitchGroup(color=self.color, lock_stitches=(None, None))
 
         for stitch in self.stitches:
             stitch_group.add_stitch(Point(*stitch))
-
-        if self.minimum_stitch_length is not None:
-            stitch_group.add_tag(f'custom_min_stitch_length:{self.minimum_stitch_length}')
 
         return [stitch_group]

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1146,7 +1146,8 @@ class SatinColumn(EmbroideryElement):
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_contour_underlay"),
             stitches=first_side,
-            min_stitch_length=self.min_stitch_length)
+            min_stitch_length=self.min_stitch_length
+        )
 
         self.add_running_stitches(first_side[-1], second_side[0], stitch_group)
         stitch_group.stitches += second_side
@@ -1174,7 +1175,8 @@ class SatinColumn(EmbroideryElement):
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_center_walk"),
             stitches=stitches,
-            min_stitch_length=self.min_stitch_length)
+            min_stitch_length=self.min_stitch_length
+        )
 
     def do_zigzag_underlay(self):
         # zigzag underlay, usually done at a much lower density than the
@@ -1187,7 +1189,10 @@ class SatinColumn(EmbroideryElement):
         # "German underlay" described here:
         #   http://www.mrxstitch.com/underlay-what-lies-beneath-machine-embroidery/
 
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length
+        )
 
         pairs = self.plot_points_on_rails(self.zigzag_underlay_spacing / 2.0,
                                           -self.zigzag_underlay_inset_px,
@@ -1224,7 +1229,11 @@ class SatinColumn(EmbroideryElement):
 
         # print >> dbg, "satin", self.zigzag_spacing, self.pull_compensation
 
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
+        )
 
         # pull compensation is automatically converted from mm to pixels by get_float_param
         pairs = self.plot_points_on_rails(
@@ -1276,7 +1285,11 @@ class SatinColumn(EmbroideryElement):
         #
         # _|_|_|_|_|_|_|_|_|_|_|_|
 
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
+        )
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1326,7 +1339,11 @@ class SatinColumn(EmbroideryElement):
         #   _   _   _   _   _   _
         # _| |_| |_| |_| |_| |_| |
 
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
+        )
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1369,7 +1386,11 @@ class SatinColumn(EmbroideryElement):
         return stitch_group
 
     def do_zigzag(self):
-        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length
+        )
 
         # calculate pairs at double the requested density
         pairs = self.plot_points_on_rails(
@@ -1534,10 +1555,13 @@ class SatinColumn(EmbroideryElement):
         # beziers.  The boundary points between beziers serve as "checkpoints",
         # allowing the user to control how the zigzags flow around corners.
 
-        stitch_group = StitchGroup(color=self.color,
-                                   min_stitch_length=self.min_stitch_length,
-                                   force_lock_stitches=self.force_lock_stitches,
-                                   lock_stitches=self.lock_stitches)
+        stitch_group = StitchGroup(
+            color=self.color,
+            min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
+            force_lock_stitches=self.force_lock_stitches,
+            lock_stitches=self.lock_stitches
+        )
 
         if self.center_walk_underlay:
             stitch_group += self.do_center_walk()
@@ -1565,9 +1589,6 @@ class SatinColumn(EmbroideryElement):
 
         if not stitch_group.stitches:
             return []
-
-        if self.minimum_stitch_length is not None:
-            stitch_group.add_tag(f'custom_min_stitch_length:{self.minimum_stitch_length}')
 
         return [stitch_group]
 

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1145,7 +1145,8 @@ class SatinColumn(EmbroideryElement):
         stitch_group = StitchGroup(
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_contour_underlay"),
-            stitches=first_side)
+            stitches=first_side,
+            min_stitch_length=self.min_stitch_length)
 
         self.add_running_stitches(first_side[-1], second_side[0], stitch_group)
         stitch_group.stitches += second_side
@@ -1172,7 +1173,8 @@ class SatinColumn(EmbroideryElement):
         return StitchGroup(
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_center_walk"),
-            stitches=stitches)
+            stitches=stitches,
+            min_stitch_length=self.min_stitch_length)
 
     def do_zigzag_underlay(self):
         # zigzag underlay, usually done at a much lower density than the
@@ -1185,7 +1187,7 @@ class SatinColumn(EmbroideryElement):
         # "German underlay" described here:
         #   http://www.mrxstitch.com/underlay-what-lies-beneath-machine-embroidery/
 
-        patch = StitchGroup(color=self.color)
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
 
         pairs = self.plot_points_on_rails(self.zigzag_underlay_spacing / 2.0,
                                           -self.zigzag_underlay_inset_px,
@@ -1206,12 +1208,12 @@ class SatinColumn(EmbroideryElement):
                 if last_point.distance(point) > max_len:
                     split_points = running_stitch.split_segment_even_dist(last_point, point, max_len)
                     for p in split_points:
-                        patch.add_stitch(p)
+                        stitch_group.add_stitch(p)
             last_point = point
-            patch.add_stitch(point)
+            stitch_group.add_stitch(point)
 
-        patch.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
-        return patch
+        stitch_group.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
+        return stitch_group
 
     def do_satin(self):
         # satin: do a zigzag pattern, alternating between the paths.  The
@@ -1222,7 +1224,7 @@ class SatinColumn(EmbroideryElement):
 
         # print >> dbg, "satin", self.zigzag_spacing, self.pull_compensation
 
-        patch = StitchGroup(color=self.color)
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
 
         # pull compensation is automatically converted from mm to pixels by get_float_param
         pairs = self.plot_points_on_rails(
@@ -1248,25 +1250,25 @@ class SatinColumn(EmbroideryElement):
                 split_points, _ = self.get_split_points(
                     last_point, a, last_short_point, a_short, max_stitch_length, last_count,
                     length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
-                patch.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
+                stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
 
-            patch.add_stitch(a_short)
-            patch.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
+            stitch_group.add_stitch(a_short)
+            stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
 
             split_points, last_count = self.get_split_points(
                 a, b, a_short, b_short, max_stitch_length, None,
                 length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
-            patch.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
+            stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
 
-            patch.add_stitch(b_short)
-            patch.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
+            stitch_group.add_stitch(b_short)
+            stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
             last_point = b
             last_short_point = b_short
 
         if self._center_walk_is_odd():
-            patch.stitches = list(reversed(patch.stitches))
+            stitch_group.stitches = list(reversed(stitch_group.stitches))
 
-        return patch
+        return stitch_group
 
     def do_e_stitch(self):
         # e stitch: do a pattern that looks like the letter "E".  It looks like
@@ -1274,7 +1276,7 @@ class SatinColumn(EmbroideryElement):
         #
         # _|_|_|_|_|_|_|_|_|_|_|_|
 
-        patch = StitchGroup(color=self.color)
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1302,21 +1304,21 @@ class SatinColumn(EmbroideryElement):
             # zigzag spacing is wider than stitch length, subdivide
             if last_point is not None and max_stitch_length is not None and self.zigzag_spacing > max_stitch_length:
                 points, _ = self.get_split_points(last_point, left, last_point, left, max_stitch_length)
-                patch.add_stitches(points)
+                stitch_group.add_stitches(points)
 
-            patch.add_stitch(a_short, ("edge", "left"))
-            patch.add_stitches(split_points, ("split_stitch",))
-            patch.add_stitch(b_short, ("edge",))
-            patch.add_stitches(split_points[::-1], ("split_stitch",))
-            patch.add_stitch(a_short, ("edge",))
+            stitch_group.add_stitch(a_short, ("edge", "left"))
+            stitch_group.add_stitches(split_points, ("split_stitch",))
+            stitch_group.add_stitch(b_short, ("edge",))
+            stitch_group.add_stitches(split_points[::-1], ("split_stitch",))
+            stitch_group.add_stitch(a_short, ("edge",))
 
             last_point = a_short
 
         if self._center_walk_is_odd():
-            patch.stitches = list(reversed(patch.stitches))
+            stitch_group.stitches = list(reversed(stitch_group.stitches))
 
-        patch.add_tags(("satin_column", "e_stitch"))
-        return patch
+        stitch_group.add_tags(("satin_column", "e_stitch"))
+        return stitch_group
 
     def do_s_stitch(self):
         # S stitch: do a pattern that looks like the letter "S".  It looks like
@@ -1324,7 +1326,7 @@ class SatinColumn(EmbroideryElement):
         #   _   _   _   _   _   _
         # _| |_| |_| |_| |_| |_| |
 
-        patch = StitchGroup(color=self.color)
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1357,17 +1359,17 @@ class SatinColumn(EmbroideryElement):
             if last_point is not None and max_stitch_length is not None and self.zigzag_spacing > max_stitch_length:
                 initial_points, _ = self.get_split_points(last_point, points[0], last_point, points[0], max_stitch_length)
 
-            patch.add_stitches(points)
+            stitch_group.add_stitches(points)
             last_point = points[-1]
 
         if self._center_walk_is_odd():
-            patch.stitches = list(reversed(patch.stitches))
+            stitch_group.stitches = list(reversed(stitch_group.stitches))
 
-        patch.add_tags(("satin", "s_stitch"))
-        return patch
+        stitch_group.add_tags(("satin", "s_stitch"))
+        return stitch_group
 
     def do_zigzag(self):
-        patch = StitchGroup(color=self.color)
+        stitch_group = StitchGroup(color=self.color, min_stitch_length=self.min_stitch_length)
 
         # calculate pairs at double the requested density
         pairs = self.plot_points_on_rails(
@@ -1401,24 +1403,24 @@ class SatinColumn(EmbroideryElement):
                 split_points, _ = self.get_split_points(
                     last_point, a, last_point_short, a_short, max_stitch_length, None,
                     length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
-                patch.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
+                stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
 
-            patch.add_stitch(a_short)
+            stitch_group.add_stitch(a_short)
 
             split_points, _ = self.get_split_points(
                 a, b, a_short, b_short, max_stitch_length, None,
                 length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
-            patch.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
+            stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
 
-            patch.add_stitch(b_short)
+            stitch_group.add_stitch(b_short)
 
             last_point = b
             last_point_short = b_short
 
         if self._center_walk_is_odd():
-            patch.stitches = list(reversed(patch.stitches))
+            stitch_group.stitches = list(reversed(stitch_group.stitches))
 
-        return patch
+        return stitch_group
 
     def get_split_points(self, *args, **kwargs):
         if self.split_method == "default":
@@ -1526,13 +1528,14 @@ class SatinColumn(EmbroideryElement):
         stitch_group += next_stitch_group
         return stitch_group
 
-    def to_stitch_groups(self, last_patch=None):
+    def to_stitch_groups(self, last_stitch_group=None):
         # Stitch a variable-width satin column, zig-zagging between two paths.
         # The algorithm will draw zigzags between each consecutive pair of
         # beziers.  The boundary points between beziers serve as "checkpoints",
         # allowing the user to control how the zigzags flow around corners.
 
         stitch_group = StitchGroup(color=self.color,
+                                   min_stitch_length=self.min_stitch_length,
                                    force_lock_stitches=self.force_lock_stitches,
                                    lock_stitches=self.lock_stitches)
 
@@ -1562,6 +1565,9 @@ class SatinColumn(EmbroideryElement):
 
         if not stitch_group.stitches:
             return []
+
+        if self.minimum_stitch_length is not None:
+            stitch_group.add_tag(f'custom_min_stitch_length:{self.minimum_stitch_length}')
 
         return [stitch_group]
 

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1145,8 +1145,7 @@ class SatinColumn(EmbroideryElement):
         stitch_group = StitchGroup(
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_contour_underlay"),
-            stitches=first_side,
-            min_stitch_length=self.min_stitch_length
+            stitches=first_side
         )
 
         self.add_running_stitches(first_side[-1], second_side[0], stitch_group)
@@ -1174,8 +1173,7 @@ class SatinColumn(EmbroideryElement):
         return StitchGroup(
             color=self.color,
             tags=("satin_column", "satin_column_underlay", "satin_center_walk"),
-            stitches=stitches,
-            min_stitch_length=self.min_stitch_length
+            stitches=stitches
         )
 
     def do_zigzag_underlay(self):
@@ -1189,10 +1187,7 @@ class SatinColumn(EmbroideryElement):
         # "German underlay" described here:
         #   http://www.mrxstitch.com/underlay-what-lies-beneath-machine-embroidery/
 
-        stitch_group = StitchGroup(
-            color=self.color,
-            min_stitch_length=self.min_stitch_length
-        )
+        stitch_group = StitchGroup(color=self.color)
 
         pairs = self.plot_points_on_rails(self.zigzag_underlay_spacing / 2.0,
                                           -self.zigzag_underlay_inset_px,
@@ -1229,11 +1224,7 @@ class SatinColumn(EmbroideryElement):
 
         # print >> dbg, "satin", self.zigzag_spacing, self.pull_compensation
 
-        stitch_group = StitchGroup(
-            color=self.color,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
-        )
+        stitch_group = StitchGroup(color=self.color)
 
         # pull compensation is automatically converted from mm to pixels by get_float_param
         pairs = self.plot_points_on_rails(
@@ -1285,11 +1276,7 @@ class SatinColumn(EmbroideryElement):
         #
         # _|_|_|_|_|_|_|_|_|_|_|_|
 
-        stitch_group = StitchGroup(
-            color=self.color,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
-        )
+        stitch_group = StitchGroup(color=self.color)
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1339,11 +1326,7 @@ class SatinColumn(EmbroideryElement):
         #   _   _   _   _   _   _
         # _| |_| |_| |_| |_| |_| |
 
-        stitch_group = StitchGroup(
-            color=self.color,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
-        )
+        stitch_group = StitchGroup(color=self.color)
 
         pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
@@ -1386,11 +1369,7 @@ class SatinColumn(EmbroideryElement):
         return stitch_group
 
     def do_zigzag(self):
-        stitch_group = StitchGroup(
-            color=self.color,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length
-        )
+        stitch_group = StitchGroup(color=self.color)
 
         # calculate pairs at double the requested density
         pairs = self.plot_points_on_rails(
@@ -1557,8 +1536,6 @@ class SatinColumn(EmbroideryElement):
 
         stitch_group = StitchGroup(
             color=self.color,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             force_lock_stitches=self.force_lock_stitches,
             lock_stitches=self.lock_stitches
         )

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -466,6 +466,7 @@ class Stroke(EmbroideryElement):
             self.color,
             stitches=repeated_stitches,
             min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
             lock_stitches=self.lock_stitches,
             force_lock_stitches=self.force_lock_stitches
         )
@@ -491,6 +492,7 @@ class Stroke(EmbroideryElement):
             tags=["ripple_stitch"],
             stitches=ripple_stitch(self),
             min_stitch_length=self.min_stitch_length,
+            min_jump_stitch_length=self.min_jump_stitch_length,
             lock_stitches=self.lock_stitches,
             force_lock_stitches=self.force_lock_stitches)
 
@@ -524,6 +526,7 @@ class Stroke(EmbroideryElement):
                         color=self.color,
                         stitches=path,
                         min_stitch_length=self.min_stitch_length,
+                        min_jump_stitch_length=self.min_jump_stitch_length,
                         lock_stitches=lock_stitches,
                         force_lock_stitches=self.force_lock_stitches
                     )
@@ -539,10 +542,6 @@ class Stroke(EmbroideryElement):
 
                 if stitch_group:
                     stitch_groups.append(stitch_group)
-
-        if self.minimum_stitch_length is not None:
-            for stitch_group in stitch_groups:
-                stitch_group.add_tag(f'custom_min_stitch_length:{self.minimum_stitch_length}')
 
         return stitch_groups
 

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -465,8 +465,6 @@ class Stroke(EmbroideryElement):
         return StitchGroup(
             self.color,
             stitches=repeated_stitches,
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             lock_stitches=self.lock_stitches,
             force_lock_stitches=self.force_lock_stitches
         )
@@ -491,8 +489,6 @@ class Stroke(EmbroideryElement):
             color=self.color,
             tags=["ripple_stitch"],
             stitches=ripple_stitch(self),
-            min_stitch_length=self.min_stitch_length,
-            min_jump_stitch_length=self.min_jump_stitch_length,
             lock_stitches=self.lock_stitches,
             force_lock_stitches=self.force_lock_stitches)
 
@@ -525,8 +521,6 @@ class Stroke(EmbroideryElement):
                     stitch_group = StitchGroup(
                         color=self.color,
                         stitches=path,
-                        min_stitch_length=self.min_stitch_length,
-                        min_jump_stitch_length=self.min_jump_stitch_length,
                         lock_stitches=lock_stitches,
                         force_lock_stitches=self.force_lock_stitches
                     )

--- a/lib/elements/text.py
+++ b/lib/elements/text.py
@@ -29,5 +29,5 @@ class TextObject(EmbroideryElement):
     def validation_warnings(self):
         yield TextTypeWarning(self.pointer())
 
-    def to_stitch_groups(self, last_patch):
+    def to_stitch_groups(self, last_stitch_group):
         return []

--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -124,16 +124,16 @@ class InkstitchExtension(inkex.EffectExtension):
         return False
 
     def elements_to_stitch_groups(self, elements):
-        patches = []
+        stitch_groups = []
         for element in elements:
-            if patches:
-                last_patch = patches[-1]
+            if stitch_groups:
+                last_stitch_group = stitch_groups[-1]
             else:
-                last_patch = None
+                last_stitch_group = None
 
-            patches.extend(element.embroider(last_patch))
+            stitch_groups.extend(element.embroider(last_stitch_group))
 
-        return patches
+        return stitch_groups
 
     def get_inkstitch_metadata(self):
         return InkStitchMetadata(self.svg)

--- a/lib/extensions/density_map.py
+++ b/lib/extensions/density_map.py
@@ -39,8 +39,8 @@ class DensityMap(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
         min_stitch_len = self.metadata['min_stitch_len_mm']
-        patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
 
         layer = svg.find(".//*[@id='__inkstitch_density_plan__']")
         color_groups = create_color_groups(layer)

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -54,8 +54,8 @@ class Output(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
         min_stitch_len = self.metadata['min_stitch_len_mm']
-        patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, disable_ties=self.settings.get('laser_mode', False),
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, disable_ties=self.settings.get('laser_mode', False),
                                                    min_stitch_len=min_stitch_len)
         ThreadCatalog().match_and_apply_palette(stitch_plan, self.metadata['thread-palette'])
 

--- a/lib/extensions/print_pdf.py
+++ b/lib/extensions/print_pdf.py
@@ -310,8 +310,8 @@ class Print(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
         min_stitch_len = self.metadata['min_stitch_len_mm']
-        patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         palette = ThreadCatalog().match_and_apply_palette(stitch_plan, self.get_inkstitch_metadata()['thread-palette'])
 
         overview_svg, color_block_svgs = self.render_svgs(stitch_plan, realistic=False)

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -38,8 +38,8 @@ class StitchPlanPreview(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
         min_stitch_len = self.metadata['min_stitch_len_mm']
-        patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         render_stitch_plan(svg, stitch_plan, realistic, visual_commands)
 
         # apply options

--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -54,8 +54,8 @@ class Zip(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
         min_stitch_len = self.metadata['min_stitch_len_mm']
-        patches = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(patches, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         ThreadCatalog().match_and_apply_palette(stitch_plan, self.get_inkstitch_metadata()['thread-palette'])
 
         if self.options.x_repeats != 1 or self.options.y_repeats != 1:

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -112,6 +112,7 @@ class ColorBlock(object):
 
         if min_stitch_len is None:
             min_stitch_len = 0.1
+        min_stitch_len *= PIXELS_PER_MM
 
         stitches = [self.stitches[0]]
         for stitch in self.stitches[1:]:
@@ -123,7 +124,8 @@ class ColorBlock(object):
                 pass
             else:
                 length = (stitch - stitches[-1]).length()
-                if length <= min_stitch_len * PIXELS_PER_MM:
+                min_length = stitch.min_stitch_length or min_stitch_len
+                if length <= min_length:
                     # duplicate stitch, skip this one
                     continue
 

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -11,7 +11,17 @@ from ..utils.geometry import Point
 class Stitch(Point):
     """A stitch is a Point with extra information telling how to sew it."""
 
-    def __init__(self, x, y=None, color=None, jump=False, stop=False, trim=False, color_change=False, tags=None):
+    def __init__(
+        self,
+        x, y=None,
+        color=None,
+        jump=False,
+        stop=False,
+        trim=False,
+        color_change=False,
+        min_stitch_length=None,
+        tags=None
+    ):
         # DANGER: if you add new attributes, you MUST also set their default
         # values in __new__() below.  Otherwise, cached stitch plans can be
         # loaded and create objects without those properties defined, because
@@ -37,6 +47,7 @@ class Stitch(Point):
         self._set('trim', trim, base_stitch)
         self._set('stop', stop, base_stitch)
         self._set('color_change', color_change, base_stitch)
+        self._set('min_stitch_length', min_stitch_length, base_stitch)
 
         self.tags = set()
         self.add_tags(tags or [])
@@ -52,13 +63,16 @@ class Stitch(Point):
         return instance
 
     def __repr__(self):
-        return "Stitch(%s, %s, %s, %s, %s, %s, %s)" % (self.x,
-                                                       self.y,
-                                                       self.color,
-                                                       "JUMP" if self.jump else " ",
-                                                       "TRIM" if self.trim else " ",
-                                                       "STOP" if self.stop else " ",
-                                                       "COLOR CHANGE" if self.color_change else " ")
+        return "Stitch(%s, %s, %s, %s, %s, %s, %s, %s)" % (
+            self.x,
+            self.y,
+            self.color,
+            self.min_stitch_length,
+            "JUMP" if self.jump else " ",
+            "TRIM" if self.trim else " ",
+            "STOP" if self.stop else " ",
+            "COLOR CHANGE" if self.color_change else " "
+        )
 
     def _set(self, attribute, value, base_stitch):
         # Set an attribute.  If the caller passed a Stitch object, use its value, unless
@@ -95,7 +109,17 @@ class Stitch(Point):
         return tag in self.tags
 
     def copy(self):
-        return Stitch(self.x, self.y, self.color, self.jump, self.stop, self.trim, self.color_change, self.tags)
+        return Stitch(
+            self.x,
+            self.y,
+            self.color,
+            self.jump,
+            self.stop,
+            self.trim,
+            self.color_change,
+            self.min_stitch_length,
+            self.tags
+        )
 
     def offset(self, offset: Point):
         out = self.copy()

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -17,8 +17,18 @@ class StitchGroup:
     between them by the stitch plan generation code.
     """
 
-    def __init__(self, color=None, stitches=None, min_stitch_length=False, trim_after=False,
-                 stop_after=False, lock_stitches=(None, None), force_lock_stitches=False, tags=None):
+    def __init__(
+        self,
+        color=None,
+        stitches=None,
+        min_stitch_length=False,
+        min_jump_stitch_length=False,
+        trim_after=False,
+        stop_after=False,
+        lock_stitches=(None, None),
+        force_lock_stitches=False,
+        tags=None
+    ):
         # DANGER: if you add new attributes, you MUST also set their default
         # values in __new__() below.  Otherwise, cached stitch plans can be
         # loaded and create objects without those properties defined, because
@@ -30,6 +40,7 @@ class StitchGroup:
         self.lock_stitches = lock_stitches
         self.force_lock_stitches = force_lock_stitches
         self.min_stitch_length = min_stitch_length
+        self.min_jump_stitch_length = min_jump_stitch_length
         self.stitches = []
 
         if stitches:

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -21,7 +21,6 @@ class StitchGroup:
         self,
         color=None,
         stitches=None,
-        min_stitch_length=False,
         min_jump_stitch_length=False,
         trim_after=False,
         stop_after=False,
@@ -39,7 +38,6 @@ class StitchGroup:
         self.stop_after = stop_after
         self.lock_stitches = lock_stitches
         self.force_lock_stitches = force_lock_stitches
-        self.min_stitch_length = min_stitch_length
         self.min_jump_stitch_length = min_jump_stitch_length
         self.stitches = []
 
@@ -70,6 +68,10 @@ class StitchGroup:
         # This method allows `len(stitch_group)` and `if stitch_group:
         return len(self.stitches)
 
+    def set_minimum_stitch_length(self, min_stitch_length):
+        for stitch in self.stitches:
+            stitch.min_stitch_length = min_stitch_length
+
     def add_stitches(self, stitches, tags=None):
         for stitch in stitches:
             self.add_stitch(stitch, tags=tags)
@@ -77,9 +79,7 @@ class StitchGroup:
     def add_stitch(self, stitch, tags=None):
         if not isinstance(stitch, Stitch):
             # probably a Point
-            stitch = Stitch(stitch, min_stitch_length=self.min_stitch_length, tags=tags)
-
-        stitch.min_stitch_length = self.min_stitch_length
+            stitch = Stitch(stitch, tags=tags)
         self.stitches.append(stitch)
 
     def reverse(self):

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -17,8 +17,8 @@ class StitchGroup:
     between them by the stitch plan generation code.
     """
 
-    def __init__(self, color=None, stitches=None, trim_after=False, stop_after=False,
-                 lock_stitches=(None, None), force_lock_stitches=False, tags=None):
+    def __init__(self, color=None, stitches=None, min_stitch_length=False, trim_after=False,
+                 stop_after=False, lock_stitches=(None, None), force_lock_stitches=False, tags=None):
         # DANGER: if you add new attributes, you MUST also set their default
         # values in __new__() below.  Otherwise, cached stitch plans can be
         # loaded and create objects without those properties defined, because
@@ -29,6 +29,7 @@ class StitchGroup:
         self.stop_after = stop_after
         self.lock_stitches = lock_stitches
         self.force_lock_stitches = force_lock_stitches
+        self.min_stitch_length = min_stitch_length
         self.stitches = []
 
         if stitches:
@@ -55,7 +56,7 @@ class StitchGroup:
             raise TypeError("StitchGroup can only be added to another StitchGroup")
 
     def __len__(self):
-        # This method allows `len(patch)` and `if patch:
+        # This method allows `len(stitch_group)` and `if stitch_group:
         return len(self.stitches)
 
     def add_stitches(self, stitches, tags=None):
@@ -65,8 +66,9 @@ class StitchGroup:
     def add_stitch(self, stitch, tags=None):
         if not isinstance(stitch, Stitch):
             # probably a Point
-            stitch = Stitch(stitch, tags=tags)
+            stitch = Stitch(stitch, min_stitch_length=self.min_stitch_length, tags=tags)
 
+        stitch.min_stitch_length = self.min_stitch_length
         self.stitches.append(stitch)
 
     def reverse(self):

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -55,6 +55,7 @@ SVG_OBJECT_TAGS = (SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG, SVG_RECT_TAG)
 INKSTITCH_ATTRIBS = {}
 inkstitch_attribs = [
     'min_stitch_length_mm',
+    'min_jump_stitch_length_mm',
     'ties',
     'force_lock_stitches',
     'lock_start',

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -54,6 +54,7 @@ SVG_OBJECT_TAGS = (SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG, SVG_RECT_TAG)
 
 INKSTITCH_ATTRIBS = {}
 inkstitch_attribs = [
+    'min_stitch_length_mm',
     'ties',
     'force_lock_stitches',
     'lock_start',


### PR DESCRIPTION
* Add minimum stitch length setting to elements
  I see people struggle with the global minimum stitch length setting as sometimes they'll need an other minimum stitch length setting for specific objects (which overwrites the global minimum stitch length setting. Let's take for example a tiny font that users include into their document. The tiny font was made for 60wt thread while the rest of the design aims 40wt thread. In this case I think font authors should be able to set the minimum stitch length for the glyphs (and prevent the underlay showing through). That's just an example of where I think this setting could be useful.

* add object based minimum jump stitch length (requested for fonts)

* rename patches to stitch_groups