### PR TITLE
Avoid RuntimeError by closing params with CallAfter

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -608,7 +608,7 @@ class SettingsPanel(wx.Panel):
         self.apply(event)
 
     def close(self):
-        self.GetTopLevelParent().Close()
+        wx.CallAfter(self.GetTopLevelParent().Close)
 
     def cancel(self, event):
         if self.cancel_hook:


### PR DESCRIPTION
... hopefully that's a cleaner exit ...