### PR TITLE
No error on empty d

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -415,9 +415,6 @@ class EmbroideryElement(object):
         else:
             d = self.node.get("d", "")
 
-        if not d:
-            self.fatal(_("Object %(id)s has an empty 'd' attribute.  Please delete this object from your document.") % dict(id=self.node.get("id")))
-
         return inkex.Path(d).to_superpath()
 
     @cache


### PR DESCRIPTION
I don't see any reason why we should error out on empty d objects anymore.
There will be a warning when they run troubleshoot objects, but other than that we can just ignore the element...

Fixes #2817