### PR TITLE
Fixed jumps rendering when toggling on realistic preview with jump rendering disabled.

### DIFF
--- a/electron/src/renderer/assets/js/simulator.js
+++ b/electron/src/renderer/assets/js/simulator.js
@@ -95,32 +95,21 @@ export default {
         }
 
         setImmediate(()=> {
-          for (let i = 1; i < this.stitches.length; i++) {
-            if (i < this.currentStitch) {
-              this.realisticPaths[i].show()
-            } else {
-              this.realisticPaths[i].hide()
-            }
-          }
+          this.renderedStitch = 0
+          this.renderFrame()
 
           this.simulation.hide()
           this.realisticPreview.show()
         })
 
       } else {
-
-        for (let i = 1; i < this.stitches.length; i++) {
-          if (i < this.currentStitch) {
-            this.stitchPaths[i].show()
-          } else {
-            this.stitchPaths[i].hide()
-          }
-        }
+        this.renderedStitch = 0
+        this.renderFrame()
 
         this.simulation.show()
         this.realisticPreview.hide()
-
       }
+
       if (animating) {
         this.start()
       }


### PR DESCRIPTION
Fixes issue #2751

The path re-render on changing between realistic and non-realistic modes now just use `renderFrame` which already properly respects this flag: The previous behaviour didn't take it into account.