### PR TITLE
Experimental realistic stitch preview branch

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -23,6 +23,7 @@ class StitchPlanPreview(InkstitchExtension):
         self.arg_parser.add_argument("-i", "--insensitive", type=Boolean, default=False, dest="insensitive")
         self.arg_parser.add_argument("-c", "--visual-commands", type=Boolean, default="symbols", dest="visual_commands")
         self.arg_parser.add_argument("-o", "--overwrite", type=Boolean, default=True, dest="overwrite")
+        self.arg_parser.add_argument("-r", "--realistic", type=Boolean, default=True, dest="realistic")
 
     def effect(self):
         # delete old stitch plan
@@ -33,7 +34,7 @@ class StitchPlanPreview(InkstitchExtension):
             return
 
         svg = self.document.getroot()
-        realistic = False
+        realistic = self.options.realistic
         visual_commands = self.options.visual_commands
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -43,17 +43,17 @@ stitch_height = 1.398
 # to add enough padding on the long sides of the stitch would waste a ton
 # of space on the short sides and significantly slow down rendering.
 
-# The specific extent of the whiskers (0.45 parallel to the stitch, 0.1 perpendicular)
-# was found by experimentation. It seems to work without artifacting.
+# The specific extent of the whiskers (0.55 parallel to the stitch, 0.1 perpendicular)
+# was found by experimentation. It seems to work with almost no artifacting.
 stitch_path = (
     "M0,0"  # Start point
-    "l0.45,-0.1,-0.45,0.1"  # Bottom-right whisker
-    "c0.4,0,0.46,0.4,0.46,0.7c0,0.3,-0.16,0.70,-0.46,0.70"  # Right endcap
-    "l0.45,0.1,-0.45,-0.1"  # Top-right whisker
+    "l0.55,-0.1,-0.55,0.1"  # Bottom-right whisker
+    "c0.613,0,0.613,1.4,0,1.4" # Right endcap
+    "l0.55,0.1,-0.55,-0.1"  # Top-right whisker
     "h-%s"  # Stitch length
-    "l-0.45,0.1,0.45,-0.1"  # Top-left whisker
-    "c-0.4,0,-0.46,-0.4,-0.46,-0.7c0,-0.3,0.16,-0.7,0.46,-0.7"  # Left endcap
-    "l-0.45,-0.1,0.45,0.1"  # Bottom-left whisker
+    "l-0.55,0.1,0.55,-0.1"  # Top-left whisker
+    "c-0.613,0,-0.613,-1.4,0,-1.4" # Left endcap
+    "l-0.55,-0.1,0.55,0.1"  # Bottom-left whisker
     "z")  # return to start
 
 # The filter needs the xmlns:inkscape declaration, or Inkscape will display a parse error

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -60,13 +60,12 @@ realistic_filter = """
          id="feSpecularLighting1973"
          result="result2"
          specularConstant="0.78"
-         surfaceScale="3"
+         surfaceScale="1.5"
          specularExponent="2.5">
-        <fePointLight
-           id="fePointLight1975"
-           z="10"
-           y="0"
-           x="12" />
+        <feDistantLight
+           id="feDistantLight1975"
+           azimuth="125"
+           elevation="20" />
       </feSpecularLighting>
       <feComposite
          in2="SourceAlpha"
@@ -74,10 +73,10 @@ realistic_filter = """
          operator="atop" />
       <feComposite
          in2="SourceGraphic"
-         id="feComposite1981"
+         id="feComposite1982"
          operator="arithmetic"
-         k2="1"
-         k3="1"
+         k2="0.8"
+         k3="1.2"
          result="result3"
          k1="0"
          k4="0" />

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -49,7 +49,8 @@ realistic_filter = """
        width="1.02"
        y="-0.01"
        height="1.02"
-       inkscape:auto-region="false">
+       inkscape:auto-region="false"
+       xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
       <feGaussianBlur
          edgeMode="none"
          stdDeviation="0.9"

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -74,16 +74,17 @@ realistic_filter = """
          stdDeviation="0.9"
          id="feGaussianBlur1542-6"
          in="SourceAlpha" />
-      <feDiffuseLighting
+      <feSpecularLighting
          id="feSpecularLighting1973"
          result="result2"
-         diffuseConstant="0.78"
-         surfaceScale="1.5">
+         surfaceScale="1.5"
+         specularConstant="0.78"
+         specularExponent="2.5">
         <feDistantLight
            id="feDistantLight1975"
            azimuth="-125"
            elevation="20" />
-      </feDiffuseLighting>
+      </feSpecularLighting>
       <feComposite
          in2="SourceAlpha"
          id="feComposite1981"
@@ -114,17 +115,18 @@ def realistic_stitch(start, end):
 
     stitch_length = max(0, stitch_length - 0.2 * PIXELS_PER_MM)
 
-    # create the path by filling in the length in the template
-    path = inkex.Path(stitch_path % stitch_length).to_arrays()
-
     # rotate the path to match the stitch
     rotation_center_x = -stitch_length / 2.0
     rotation_center_y = stitch_height / 2.0
 
-    path = inkex.Path(path).rotate(stitch_angle, (rotation_center_x, rotation_center_y))
+    transform = (
+        inkex.Transform()
+             .add_translate(stitch_center.x - rotation_center_x, stitch_center.y - rotation_center_y)
+             .add_rotate(stitch_angle, (rotation_center_x, rotation_center_y))
+    )
 
-    # move the path to the location of the stitch
-    path = inkex.Path(path).translate(stitch_center.x - rotation_center_x, stitch_center.y - rotation_center_y)
+    # create the path by filling in the length in the template, and transforming it as above
+    path = inkex.Path(stitch_path % stitch_length).transform(transform, True)
 
     return str(path)
 

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -72,6 +72,15 @@ realistic_filter = """
          in2="SourceAlpha"
          id="feComposite1981"
          operator="atop" />
+      <feComposite
+         in2="SourceGraphic"
+         id="feComposite1981"
+         operator="arithmetic"
+         k2="1"
+         k3="1"
+         result="result3"
+         k1="0"
+         k4="0" />
     </filter>
 """
 

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -85,10 +85,6 @@ realistic_filter = """
            azimuth="-125"
            elevation="20" />
       </feSpecularLighting>
-      <feGaussianBlur
-         edgeMode="none"
-         stdDeviation="0.2"
-         id="feGaussianBlur1542-7" />
       <feComposite
          in2="SourceAlpha"
          id="feComposite1981"
@@ -217,7 +213,7 @@ def color_block_to_paths(color_block, svg, destination, visual_commands):
             path.set(INKSTITCH_ATTRIBS['stop_after'], 'true')
 
 
-def render_stitch_plan(svg, stitch_plan, realistic=False, visual_commands=True):
+def render_stitch_plan(svg, stitch_plan, realistic=False, visual_commands=True) -> inkex.Group:
     layer = svg.findone(".//*[@id='__inkstitch_stitch_plan__']")
     if layer is None:
         layer = inkex.Group(attrib={
@@ -253,3 +249,5 @@ def render_stitch_plan(svg, stitch_plan, realistic=False, visual_commands=True):
 
         filter_document = inkex.load_svg(realistic_filter)
         svg.defs.append(filter_document.getroot())
+
+    return layer

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -48,11 +48,11 @@ stitch_height = 1.398
 stitch_path = (
     "M0,0"  # Start point
     "l0.55,-0.1,-0.55,0.1"  # Bottom-right whisker
-    "c0.613,0,0.613,1.4,0,1.4" # Right endcap
+    "c0.613,0,0.613,1.4,0,1.4"  # Right endcap
     "l0.55,0.1,-0.55,-0.1"  # Top-right whisker
     "h-%s"  # Stitch length
     "l-0.55,0.1,0.55,-0.1"  # Top-left whisker
-    "c-0.613,0,-0.613,-1.4,0,-1.4" # Left endcap
+    "c-0.613,0,-0.613,-1.4,0,-1.4"  # Left endcap
     "l-0.55,-0.1,0.55,0.1"  # Bottom-left whisker
     "z")  # return to start
 

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -60,7 +60,7 @@ realistic_filter = """
          result="result2"
          specularConstant="0.78"
          surfaceScale="3"
-         specularExponent="1">
+         specularExponent="2.5">
         <fePointLight
            id="fePointLight1975"
            z="10"

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -19,8 +19,8 @@ from .units import PIXELS_PER_MM, get_viewbox_transform
 #
 # It's 0.32mm high, which is the approximate thickness of common machine
 # embroidery threads.
-# 1.216 pixels = 0.32mm
-stitch_height = 1.216
+# 1.398 pixels = 0.37mm
+stitch_height = 1.398
 
 # This vector path starts at the upper right corner of the stitch shape and
 # proceeds counter-clockwise and contains a placeholder (%s) for the stitch
@@ -48,11 +48,11 @@ stitch_height = 1.216
 stitch_path = (
     "M0,0"  # Start point
     "l0.45,-0.1,-0.45,0.1"  # Bottom-right whisker
-    "c0.4,0,0.4,0.3,0.4,0.6c0,0.3,-0.1,0.6,-0.4,0.6"  # Right endcap
+    "c0.4,0,0.46,0.4,0.46,0.7c0,0.3,-0.16,0.70,-0.46,0.70"  # Right endcap
     "l0.45,0.1,-0.45,-0.1"  # Top-right whisker
     "h-%s"  # Stitch length
     "l-0.45,0.1,0.45,-0.1"  # Top-left whisker
-    "c-0.4,0,-0.4,-0.3,-0.4,-0.6c0,-0.3,0.1,-0.6,0.4,-0.6"  # Left endcap
+    "c-0.4,0,-0.46,-0.4,-0.46,-0.7c0,-0.3,0.16,-0.7,0.46,-0.7"  # Left endcap
     "l-0.45,-0.1,0.45,0.1"  # Bottom-left whisker
     "z")  # return to start
 
@@ -85,6 +85,10 @@ realistic_filter = """
            azimuth="-125"
            elevation="20" />
       </feSpecularLighting>
+      <feGaussianBlur
+         edgeMode="none"
+         stdDeviation="0.2"
+         id="feGaussianBlur1542-7" />
       <feComposite
          in2="SourceAlpha"
          id="feComposite1981"

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -24,7 +24,7 @@
     <param name="insensitive" type="boolean" gui-text="Lock"
            gui-description="Make stitch plan insensitive to mouse interactions">false</param>
     <param name="visual-commands" type="boolean" gui-text="Display command symbols">false</param>
-    <param name="realistic" type="boolean" gui-text="Realistic output">false</param>
+    <param name="realistic" type="boolean" gui-text="Realistic rendering">false</param>
     <spacer />
     <separator />
     <spacer />

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -24,6 +24,7 @@
     <param name="insensitive" type="boolean" gui-text="Lock"
            gui-description="Make stitch plan insensitive to mouse interactions">false</param>
     <param name="visual-commands" type="boolean" gui-text="Display command symbols">false</param>
+    <param name="realistic" type="boolean" gui-text="Realistic output">false</param>
     <spacer />
     <separator />
     <spacer />

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -17,12 +17,10 @@
         <option value="lower_opacity">Lower opacity</option>
     </param>
     <param name="render-mode" type="optiongroup" appearance="combo" gui-text="Render Mode"
-        gui-description="The numbers by the realistic modes indicate the resolution which the realistic mode will be rendered to.">
+        gui-description="Realistic modes will render to a raster image for performance reasons. Realistic Vector may cause Inkscape to slow down for complex designs.">
         <option value="simple">Simple</option>
-        <option value="realistic-2">Realistic x2</option>
-        <option value="realistic-4">Realistic x4</option>
-        <option value="realistic-8">Realistic x8</option>
-        <option value="realistic-16">Realistic x16</option>
+        <option value="realistic-8">Realistic</option>
+        <option value="realistic-16">Realistic High Quality</option>
         <option value="realistic-vector">Realistic Vector (slow)</option>
     </param>
     <spacer />

--- a/templates/stitch_plan_preview.xml
+++ b/templates/stitch_plan_preview.xml
@@ -16,6 +16,15 @@
         <option value="hidden">Hidden</option>
         <option value="lower_opacity">Lower opacity</option>
     </param>
+    <param name="render-mode" type="optiongroup" appearance="combo" gui-text="Render Mode"
+        gui-description="The numbers by the realistic modes indicate the resolution which the realistic mode will be rendered to.">
+        <option value="simple">Simple</option>
+        <option value="realistic-2">Realistic x2</option>
+        <option value="realistic-4">Realistic x4</option>
+        <option value="realistic-8">Realistic x8</option>
+        <option value="realistic-16">Realistic x16</option>
+        <option value="realistic-vector">Realistic Vector (slow)</option>
+    </param>
     <spacer />
     <separator />
     <spacer />
@@ -24,7 +33,6 @@
     <param name="insensitive" type="boolean" gui-text="Lock"
            gui-description="Make stitch plan insensitive to mouse interactions">false</param>
     <param name="visual-commands" type="boolean" gui-text="Display command symbols">false</param>
-    <param name="realistic" type="boolean" gui-text="Realistic rendering">false</param>
     <spacer />
     <separator />
     <spacer />


### PR DESCRIPTION
A first attempt at adding realistic stitch preview to the stitch preview, which might be a start for #2770. Beyond just plumbing in the "realistic" option into the extension, the current filter causes Inkscape's rendering to lag significantly because it's fairly complex. I optimized/simplified the filter to one that runs much quicker, mainly by cutting down the number of steps and manually specifying a bounding box for the filter. The end result looks slightly different, but hopefully still acceptable:

Current:
![current_realistic](https://github.com/inkstitch/inkstitch/assets/5505503/00b98d98-14d9-4e6d-beec-962f55d58fe1)
New:
![new_realistic](https://github.com/inkstitch/inkstitch/assets/5505503/6611e7a8-bdfa-4399-8d15-80074f2c6ee1)

If you drag around the preview stitch plans, the stitch plan in `new_realistic.svg` (generated with this patch's filter) can be dragged with less lag than `realistic.svg` (using the current realistic filter).
[previews.zip](https://github.com/inkstitch/inkstitch/files/14971800/previews.zip)

There is a snag though, in that if you don't specify `inkscape:auto-region="false"`, [Inkscape will recalculate the region (see issue #6667 in Inkscape)](https://gitlab.com/inkscape/inbox/-/issues/6667) - in this case going from 102% the size of the region to 640% of the size, making the calculations more expensive then they need to be. Unfortunately, if you *do* specify the size, it puts up an error message because Inkscape apparently doesn't recognize its own `inkscape:auto-region` parameter when parsing extension output. [I've opened inkscape #10227 to follow up on this.](https://gitlab.com/inkscape/inbox/-/issues/10227)

![errormessage](https://github.com/inkstitch/inkstitch/assets/5505503/fa5ca72c-0bfd-4389-bc04-cefa273b449a)

So that remains a blocker of sorts: If we remove the `inkscape:auto-region` parameter it runs slowly: better than the current filter, but far slower than we'd probably want given it has to process something like 36x the pixels. With that parameter, it performs reasonably even with ~5000 realistic fill stitches on-screen.