### PR TITLE
actions setup git for windows sdk, enable "msgfmt" command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,10 @@ jobs:
           python-version: '3.8.x'
           architecture: 'x86'
       - uses: microsoft/setup-msbuild@v2
+      - name: Setup Git for Windows SDK
+        uses: git-for-windows/setup-git-for-windows-sdk@v1.10.0
+        with:
+          flavor: build-installers
       - name: install dependencies
         shell: bash
         run: |
@@ -170,6 +174,10 @@ jobs:
           python-version: '3.8.x'
           architecture: 'x64'
       - uses: microsoft/setup-msbuild@v2
+      - name: Setup Git for Windows SDK
+        uses: git-for-windows/setup-git-for-windows-sdk@v1.10.0
+        with:
+          flavor: build-installers
       - name: install dependencies
         shell: bash
         run: |


### PR DESCRIPTION
**Hi, dear friends, recently, I find that the installation package for windows from github action, all language translation can not be see, after seeing the log, output said "msgfmt" command not found**
![Snipaste_2024-04-16_15-37-02](https://github.com/inkstitch/inkstitch/assets/49285033/57259bda-2338-4248-923c-3be27b223006)

**But I remember the translation is correct last year, why this year msgfmt become disapear, after searching for a while, I think maybe this is the reason**
![Snipaste_2024-04-18_12-36-51](https://github.com/inkstitch/inkstitch/assets/49285033/c45395b3-6c8b-45ec-9765-d8acaf801755)
![Snipaste_2024-04-18_14-28-47](https://github.com/inkstitch/inkstitch/assets/49285033/0fa2df4c-8597-418c-bb70-abd92068eef4)
**then I found that this github action can set up this git sdk with mingw-w64-git, after adding this step to build.yaml, now I can see the translation (◕‿◕)** 
![Snipaste_2024-04-18_12-39-07](https://github.com/inkstitch/inkstitch/assets/49285033/577bfa29-d273-4fa3-9fc7-08141b8dba39)
![Snipaste_2024-04-18_14-39-24](https://github.com/inkstitch/inkstitch/assets/49285033/6fe2d6e7-33b0-4f41-a0f4-63c6aaf5f3e6)
![Snipaste_2024-04-18_14-41-34](https://github.com/inkstitch/inkstitch/assets/49285033/3bbb1db2-a6a5-4d37-8eeb-ac52c568460a)
