### PR TITLE
Fix multiple param values when default None

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -693,8 +693,8 @@ class Params(InkstitchExtension):
         else:
             getter = 'get_param'
 
-        values = [item for item in (getattr(node, getter)(
-            param.name, param.default) for node in nodes) if item is not None]
+        values = [item if item is not None else "" for item in (getattr(node, getter)(
+            param.name, param.default) for node in nodes)]
 
         return values
 


### PR DESCRIPTION
Fixes #2836

The only other possible value type (from string) seems to be boolean which is never None. So it might be ok to do it like that (@lexelby)?