### PR TITLE
auto fill gap fix

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -275,6 +275,19 @@ class FillStitch(EmbroideryElement):
         return self.get_float_param('expand_mm', 0)
 
     @property
+    @param('gap_fill_rows',
+           _('Gap Filling'),
+           tooltip=_('Add extra rows to compensate for gaps between sections caused by distortion.'
+                     'Rows are always added in pairs, so this number will be rounded up to the nearest multiple of 2.'),
+           unit='rows',
+           type='int',
+           default=0,
+           sort_index=21,
+           select_items=[('fill_method', 'auto_fill')])
+    def gap_fill_rows(self):
+        return self.get_int_param('gap_fill_rows', 0)
+
+    @property
     @param('angle',
            _('Angle of lines of stitches'),
            tooltip=_('The angle increases in a counter-clockwise direction.  0 is horizontal.  Negative angles are allowed.'),
@@ -1005,6 +1018,7 @@ class FillStitch(EmbroideryElement):
                 starting_point,
                 ending_point,
                 self.underpath,
+                self.gap_fill_rows,
                 self.enable_random_stitches,
                 self.random_stitch_length_jitter,
                 self.random_seed,

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -486,7 +486,7 @@ class FillStitch(EmbroideryElement):
            sort_index=44)
     def enable_random_stitches(self):
         return self.get_boolean_param('enable_random_stitches', False)
-    
+
     @property
     @param('random_stitch_length_jitter_percent',
            _('Random stitch length jitter'),

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -720,6 +720,7 @@ def remove_loops(path):
     for edge in path:
         if edge.is_segment():
             new_path.append(edge)
+            seen_nodes.clear()
             continue
 
         start, end = edge

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -80,6 +80,7 @@ def auto_fill(shape,
               starting_point,
               ending_point=None,
               underpath=True,
+              gap_fill_rows=0,
               enable_random=False,
               random_sigma=0.0,
               random_seed=""):
@@ -105,12 +106,19 @@ def auto_fill(shape,
         return fallback(shape, running_stitch_length, running_stitch_tolerance)
 
     path = find_stitch_path(fill_stitch_graph, travel_graph, starting_point, ending_point)
-    path = fill_gaps(path, 2)
+    path = fill_gaps(path, round_to_multiple_of_2(gap_fill_rows))
     result = path_to_stitches(shape, path, travel_graph, fill_stitch_graph, angle, row_spacing,
                               max_stitch_length, running_stitch_length, running_stitch_tolerance,
                               staggers, skip_last, underpath, enable_random, random_sigma, random_seed)
 
     return result
+
+
+def round_to_multiple_of_2(number):
+    if number % 2 == 1:
+        return number + 1
+    else:
+        return number
 
 
 def which_outline(shape, coords):
@@ -662,6 +670,9 @@ def fill_gaps(path, num_rows):
     row offset by the row spacing 2, 4, 6, or more times, always an even number
     so that we end up near the same spot.
     """
+
+    if num_rows <= 0:
+        return path
 
     # Problem: our algorithm in find_stitch_path() sometimes (often) adds
     # unnecessary loops of travel stitching.  We'll need to eliminate these for

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -108,6 +108,7 @@ inkstitch_attribs = [
     'tartan_angle',
     'enable_random_stitches',
     'random_stitch_length_jitter_percent',
+    'gap_fill_rows',
     # stroke
     'stroke_method',
     'bean_stitch_repeats',


### PR DESCRIPTION
A feature that's been requested so often: filling the gaps in fill stitch caused by distortion.  This branch finds the places where gaps can occur (where one section ends and it travels to another section) and continues on for a few extra rows to fill the gap.

Here's how it looks:

![image](https://github.com/inkstitch/inkstitch/assets/4446653/82a952c6-5bbc-4d6f-9978-757620e60451)
![image](https://github.com/inkstitch/inkstitch/assets/4446653/24193462-17e7-4599-bfb1-47e8b08aff13)

In this case, the extra 4 rows are marked in red.  Later on, when stitching comes back to this point, those repeated rows are doubled up.  In reality, fabric distortion means that some or all of those rows won't actually overlap.

The code does its best to continue the stagger pattern, although the distortion that creates the gap may also disrupt the stagger pattern.  I think it's probably going to look fine, but testing will be needed.

The parameter has the user specify the number of rows to add.  If they give an odd number, it's rounded up to the nearest even number.  I chose to do it this way instead of having them specify "1" to mean 2 rows, "2" to mean 4 rows, etc, because I wanted to open the door for future work in the UI.  Right now we don't have a way to do something like "enforce this value is even", but we might in the future.