### PR TITLE
auto-fill pull compensation

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -609,7 +609,7 @@ class FillStitch(EmbroideryElement):
         sort_index=26)
     @cache
     def pull_compensation_px(self):
-        return self.get_split_mm_param_as_px("pull_compensation_mm", (0, 0))
+        return np.maximum(self.get_split_mm_param_as_px("pull_compensation_mm", (0, 0)), 0)
 
     @property
     @param(
@@ -624,7 +624,7 @@ class FillStitch(EmbroideryElement):
         sort_index=27)
     @cache
     def pull_compensation_percent(self):
-        return self.get_split_float_param("pull_compensation_percent", (0, 0))
+        return np.maximum(self.get_split_float_param("pull_compensation_percent", (0, 0)), 0)
 
     @property
     def color(self):

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -596,6 +596,37 @@ class FillStitch(EmbroideryElement):
         return self.get_float_param('herringbone_width_mm', 0)
 
     @property
+    @param(
+        'pull_compensation_mm',
+        _('Pull compensation'),
+        tooltip=_('Fill stitch can pull the fabric together, resulting in a shape narrower than you draw in Inkscape. '
+                  'This setting expands each row of stitches outward from the center of the row by a fixed length. '
+                  'Two values separated by a space may be used for an asymmetric effect.'),
+        select_items=[('fill_method', 'auto_fill')],
+        unit=_('mm (each side)'),
+        type='float',
+        default=0,
+        sort_index=26)
+    @cache
+    def pull_compensation_px(self):
+        return self.get_split_mm_param_as_px("pull_compensation_mm", (0, 0))
+
+    @property
+    @param(
+        'pull_compensation_percent',
+        _('Pull compensation percentage'),
+        tooltip=_('Additional pull compensation which varies as a percentage of row width. '
+                  'Two values separated by a space may be used for an asymmetric effect.'),
+        select_items=[('fill_method', 'auto_fill')],
+        unit=_('% (each side)'),
+        type='float',
+        default=0,
+        sort_index=27)
+    @cache
+    def pull_compensation_percent(self):
+        return self.get_split_float_param("pull_compensation_percent", (0, 0))
+
+    @property
     def color(self):
         # SVG spec says the default fill is black
         return self.get_style("fill", "#000000")
@@ -1026,6 +1057,8 @@ class FillStitch(EmbroideryElement):
                 self.enable_random_stitches,
                 self.random_stitch_length_jitter,
                 self.random_seed,
+                self.pull_compensation_px,
+                self.pull_compensation_percent / 100,
             )
         )
         return [stitch_group]

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -140,11 +140,7 @@ def adjust_shape_for_pull_compensation(shape, angle, row_spacing, pull_compensat
     buffered_lines = [line.buffer(buffer_amount) for line in lines]
 
     polygon = unary_union(buffered_lines)
-    exterior = smooth_path(polygon.exterior.coords, 0.2)
-    min_hole_area = row_spacing ** 2
-    interiors = [smooth_path(interior.coords) for interior in polygon.interiors if shgeo.Polygon(interior).area > min_hole_area]
-
-    return make_valid(shgeo.Polygon(exterior, interiors))
+    return make_valid(polygon)
 
 
 def apply_pull_compensation(segments, pull_compensation_px, pull_compensation_percent):

--- a/lib/stitches/auto_fill.py
+++ b/lib/stitches/auto_fill.py
@@ -11,7 +11,7 @@ from typing import Iterator
 
 import networkx
 from shapely import geometry as shgeo
-from shapely import segmentize
+from shapely import make_valid, segmentize
 from shapely.ops import snap, unary_union
 from shapely.strtree import STRtree
 
@@ -20,11 +20,11 @@ from ..stitch_plan import Stitch
 from ..svg import PIXELS_PER_MM
 from ..utils import cache
 from ..utils.clamp_path import clamp_path_to_polygon
-from ..utils.geometry import Point as InkstitchPoint, offset_points
+from ..utils.geometry import Point as InkstitchPoint
 from ..utils.geometry import (ensure_multi_line_string,
-                              line_string_to_point_list)
-from ..utils.prng import join_args
+                              line_string_to_point_list, offset_points)
 from ..utils.list import is_all_zeroes
+from ..utils.prng import join_args
 from ..utils.smoothing import smooth_path
 from ..utils.threading import check_stop_flag
 from .fill import intersect_region_with_grating, stitch_row
@@ -144,7 +144,7 @@ def adjust_shape_for_pull_compensation(shape, angle, row_spacing, pull_compensat
     min_hole_area = row_spacing ** 2
     interiors = [smooth_path(interior.coords) for interior in polygon.interiors if shgeo.Polygon(interior).area > min_hole_area]
 
-    return shgeo.Polygon(exterior, interiors)
+    return make_valid(shgeo.Polygon(exterior, interiors))
 
 
 def apply_pull_compensation(segments, pull_compensation_px, pull_compensation_percent):

--- a/lib/stitches/fill.py
+++ b/lib/stitches/fill.py
@@ -112,10 +112,10 @@ def intersect_region_with_grating(shape, angle, row_spacing, end_row_spacing=Non
     # Now get a unit vector rotated to the requested angle.  I use -angle
     # because shapely rotates clockwise, but my geometry textbooks taught
     # me to consider angles as counter-clockwise from the X axis.
-    direction = InkstitchPoint(1, 0).rotate(-angle)
+    direction = InkstitchPoint(-1, 0).rotate(-angle)
 
     # and get a normal vector
-    normal = direction.rotate(math.pi / 2)
+    normal = direction.rotate(-math.pi / 2)
 
     # I'll start from the center, move in the normal direction some amount,
     # and then walk left and right half_length in each direction to create

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -197,6 +197,37 @@ def cut_path(points, length):
     return [Point(*point) for point in subpath.coords]
 
 
+def offset_points(pos1, pos2, offset_px, offset_proportional):
+    """Expand or contract two points about their midpoint.
+
+    This is useful for pull compensation and insetting underlay.
+    """
+
+    distance = (pos1 - pos2).length()
+
+    if distance < 0.0001:
+        # if they're the same point, we don't know which direction
+        # to offset in, so we have to just return the points
+        return pos1, pos2
+
+    # calculate the offset for each side
+    offset_a = offset_px[0] + (distance * offset_proportional[0])
+    offset_b = offset_px[1] + (distance * offset_proportional[1])
+    offset_total = offset_a + offset_b
+
+    # don't contract beyond the midpoint, or we'll start expanding
+    if offset_total < -distance:
+        scale = -distance / offset_total
+        offset_a = offset_a * scale
+        offset_b = offset_b * scale
+
+    # convert offset to float before using because it may be a numpy.float64
+    out1 = pos1 + (pos1 - pos2).unit() * float(offset_a)
+    out2 = pos2 + (pos2 - pos1).unit() * float(offset_b)
+
+    return out1, out2
+
+
 class Point:
     def __init__(self, x: typing.Union[float, numpy.float64], y: typing.Union[float, numpy.float64]):
         self.x = float(x)

--- a/lib/utils/list.py
+++ b/lib/utils/list.py
@@ -21,3 +21,7 @@ def poprandom(sequence, rng=_rng):
         sequence[index] = last_item
 
     return item
+
+
+def is_all_zeroes(sequence):
+    return all(item == 0 for item in sequence)


### PR DESCRIPTION
fixes #1776 #179 #2865 

This is an attempt at adding pull compensation for fill stitch.  It adds two new parameters for auto-fill: "pull compensation" and "pull compensation percentage".  They work in the way described by @danielkschneider in #178.

Implementing this turned out to be super-weird!  It seemed like I could just expand each row of stitching, easy as that.  However, doing that caused a _ton_ of problems with travel stitch.

Instead, this code internally builds a new fill shape with the pull compensation applied.  It does this by creating fake stitch rows and applying pull compensation to them, and then thickening them and combining them together into a new shape.  It smooths the resulting shape a bit to avoid a bumpy outline.
