### PR TITLE
Several fixes

### DIFF
--- a/lib/extensions/outline.py
+++ b/lib/extensions/outline.py
@@ -60,12 +60,12 @@ class Outline(InkstitchExtension):
         return d
 
     def element_to_outline(self, element):
+        element_id = element.label or element.get_id()
         if element.tag_name == 'g':
             for element in element.iterdescendants(SVG_PATH_TAG):
                 self.element_to_outline(element)
             return
         elif element.tag_name != 'path':
-            element_id = element.label or element.get_id()
             errormsg(_("{element_id} is not a path element. "
                        "This extension is designed to generate an outline of an embroidery pattern.").format(element_id=element_id))
             return

--- a/lib/gui/lettering_font_sample.py
+++ b/lib/gui/lettering_font_sample.py
@@ -157,9 +157,15 @@ class FontSampleFrame(wx.Frame):
             "Extensions > Ink/Stitch > Font Management > Update Glyphlist"
             % font.marked_custom_font_name
         )
-        if len(font.available_glyphs) != len(font_variant.glyphs):
+
+        self.duplicate_warning(font)
+
+        # font variant glyph list length falls short if a single quote sign is available
+        # let's add it in the length comparison
+        if len(set(font.available_glyphs)) != len(font_variant.glyphs):
             errormsg(update_glyphlist_warning)
             printed_warning = True
+
         for glyph in font.available_glyphs:
             glyph_obj = font_variant[glyph]
             if glyph_obj is None:
@@ -188,6 +194,14 @@ class FontSampleFrame(wx.Frame):
         # render text and close
         font.render_text(text, self.layer, variant=direction, back_and_forth=False)
         self.GetTopLevelParent().Close()
+
+    def duplicate_warning(self, font):
+        # warn about duplicated glyphs
+        if len(set(font.available_glyphs)) != len(font.available_glyphs):
+            duplicated_glyphs = " ".join(
+                [glyph for glyph in set(font.available_glyphs) if font.available_glyphs.count(glyph) > 1]
+            )
+            errormsg(_("Found duplicated glyphs in font file: {duplicated_glyphs}").format(duplicated_glyphs=duplicated_glyphs))
 
     def cancel(self, event):
         self.GetTopLevelParent().Close()

--- a/lib/gui/lettering_font_sample.py
+++ b/lib/gui/lettering_font_sample.py
@@ -44,7 +44,7 @@ class FontSampleFrame(wx.Frame):
         scale_spinner_label = wx.StaticText(self.settings, label=_("Scale (%)"))
         self.scale_spinner = wx.SpinCtrl(self.settings, wx.ID_ANY, min=0, max=1000, initial=100)
         max_line_width_label = wx.StaticText(self.settings, label=_("Max. line width"))
-        self.max_line_width = wx.SpinCtrl(self.settings, wx.ID_ANY, min=0, max=5000, initial=500)
+        self.max_line_width = wx.SpinCtrl(self.settings, wx.ID_ANY, min=0, max=5000, initial=180)
 
         grid_settings_sizer.Add(direction_label, 0, wx.ALIGN_LEFT, 0)
         grid_settings_sizer.Add(self.direction, 0, wx.EXPAND, 0)

--- a/lib/gui/tartan/code_panel.py
+++ b/lib/gui/tartan/code_panel.py
@@ -31,7 +31,7 @@ class CodePanel(wx.Panel):
 
         code_sizer.Add(tt_unit_sizer, 0, wx.ALL, 10)
 
-        load_button = wx.Button(self, label="Apply Code")
+        load_button = wx.Button(self, label=_("Apply Code"))
         load_button.Bind(wx.EVT_BUTTON, self._load_palette_code)
         load_palette_sizer.Add(load_button, 0, wx.ALL, 10)
 


### PR DESCRIPTION
* Fix untranslatable string in tartan code panel
* font sampling: warn about duplicated glyphs in font file
* font sampling: change default line length
* outline: prevent element_id to be referenced before assignment