### PR TITLE
Fix invalid clip paths

### DIFF
--- a/lib/svg/clip.py
+++ b/lib/svg/clip.py
@@ -14,5 +14,8 @@ def get_clip_path(node):
     transform = node.composed_transform()
     clip.transform = transform
     clip_element = EmbroideryElement(clip)
-    clip_element.paths.sort(key=lambda point_list: Polygon(point_list).area, reverse=True)
-    return MultiPolygon([(clip_element.paths[0], clip_element.paths[1:])])
+    clip_paths = [path for path in clip_element.paths if len(path) > 3]
+    clip_paths.sort(key=lambda point_list: Polygon(point_list).area, reverse=True)
+    if clip_paths:
+        return MultiPolygon([(clip_paths[0], clip_paths[1:])])
+    return MultiPolygon()


### PR DESCRIPTION
Fixes part of #2748

It doesn't seem to recognize the path effect in that one though (inversed clip), while in other example files it would work. I think that would be on inkex to fix. But for an error report we'd need to analyse the issue a little bit better.