### PR TITLE
Save color name into color description

### DIFF
--- a/lib/threads/catalog.py
+++ b/lib/threads/catalog.py
@@ -108,6 +108,7 @@ class _ThreadCatalog(Sequence):
             color_block.color.name = nearest.name
             color_block.color.number = nearest.number
             color_block.color.manufacturer = nearest.manufacturer
+            color_block.color.description = nearest.description
 
     def get_palette_by_name(self, name):
         for palette in self:

--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -63,7 +63,7 @@ class ThreadPalette(Set):
                     thread_name, thread_number = fields[3].strip().rsplit(" ", 1)
                     thread_name = thread_name.strip()
 
-                    thread = ThreadColor(thread_color, thread_name, thread_number, manufacturer=self.name)
+                    thread = ThreadColor(thread_color, thread_name, thread_number, manufacturer=self.name, description=thread_name)
                     self.threads[thread] = convert_color(sRGBColor(*thread_color, is_upscaled=True), LabColor)
                 except (ValueError, IndexError):
                     continue


### PR DESCRIPTION
It seems as if not all machines are able to catch up the color name and display it.
Saving the color name into the color description as well may help at least some users to see the actual color name.