### PR TITLE
Fix auto-route satin gap

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -795,7 +795,7 @@ class SatinColumn(EmbroideryElement):
 
         return self._csp_to_satin(self.csp)
 
-    def split(self, split_point):
+    def split(self, split_point, cut_points=None):
         """Split a satin into two satins at the specified point
 
         split_point is a point on or near one of the rails, not at one of the
@@ -813,13 +813,14 @@ class SatinColumn(EmbroideryElement):
         their transforms applied.
         """
 
-        cut_points = self._find_cut_points(split_point)
+        if cut_points is None:
+            cut_points = self.find_cut_points(split_point)
         path_lists = self._cut_rails(cut_points)
         self._assign_rungs_to_split_rails(path_lists)
         self._add_rungs_if_necessary(path_lists)
         return [self._path_list_to_satins(path_list) for path_list in path_lists]
 
-    def _find_cut_points(self, split_point):
+    def find_cut_points(self, split_point):
         """Find the points on each satin corresponding to the split point.
 
         split_point is a point that is near but not necessarily touching one

--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -70,12 +70,18 @@ class SatinSegment(object):
     def to_satin(self):
         satin = self.satin
 
+        # get cut points before actually cutting the satin to avoid
+        # rounding errors which may produce gaps in between the satins
         if self.start > 0.0:
-            before, satin = satin.split(self.start)
-
+            start = satin.find_cut_points(self.start)
         if self.end < 1.0:
-            satin, after = satin.split(
-                (self.end - self.start) / (1.0 - self.start))
+            end = satin.find_cut_points(self.end)
+
+        # cut satin
+        if self.start > 0.0:
+            before, satin = satin.split(None, cut_points=start)
+        if self.end < 1.0:
+            satin, after = satin.split(None, cut_points=end)
 
         if self.reverse:
             satin = satin.reverse()


### PR DESCRIPTION
It was reported that auto-route satin sometimes ended up with visible gaps between the pieces.
Looks as if this is due to rounding errors when we cut first one part of the satin (start) and then the other side of the satin (end).
This can be fixed if we find the cut points before actually cutting the satins.