### PR TITLE
add a tooltip to split method param

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -150,6 +150,7 @@ class SatinColumn(EmbroideryElement):
     @param('split_method',
            _('Split Method'),
            type='combo',
+           tooltip=_('Display needle penetration points in simulator to see the effect of each split method.'),
            default=0,
            options=_split_methods,
            sort_index=93)


### PR DESCRIPTION
it is hard to explain  the different split methods in a tooltip, but i think  that it could help some users  to know that activating the  needle penetration points really helps seeing the difference between the  three methods.