### PR TITLE
Tartan stroke distance

### DIFF
--- a/lib/gui/tartan/customize_panel.py
+++ b/lib/gui/tartan/customize_panel.py
@@ -121,8 +121,8 @@ class CustomizePanel(ScrolledPanel):
         position.Bind(wx.EVT_LEFT_DOWN, self._move_stripe_start)
         position.Bind(wx.EVT_LEFT_UP, self._move_stripe_end)
 
-        visibility = wx.CheckBox(self)
-        visibility.SetToolTip(_("Stitch this stripe"))
+        visibility = wx.CheckBox(self, style=wx.CHK_3STATE | wx.CHK_ALLOW_3RD_STATE_FOR_USER)
+        visibility.SetToolTip(_("Checked: stitch this stripe | Minus: spacer for strokes only | Disabled: spacer for fill and stroke"))
         visibility.SetValue(True)
         visibility.Bind(wx.EVT_CHECKBOX, self._update_stripes_event)
 
@@ -135,7 +135,7 @@ class CustomizePanel(ScrolledPanel):
         colorpicker.SetToolTip(_("Select stripe color"))
         colorpicker.Bind(wx.EVT_COLOURPICKER_CHANGED, self._update_color)
 
-        stripe_width = wx.SpinCtrlDouble(self, min=0.01, max=500, initial=5, style=wx.SP_WRAP)
+        stripe_width = wx.SpinCtrlDouble(self, min=0.0, max=500, initial=5, style=wx.SP_WRAP)
         stripe_width.SetDigits(2)
         stripe_width.SetToolTip(_("Set stripe width (mm)"))
         stripe_width.Bind(wx.EVT_SPINCTRLDOUBLE, self._update_stripes_event)
@@ -152,7 +152,7 @@ class CustomizePanel(ScrolledPanel):
         stripesizer.Add(remove_button, 0, wx.CENTER | wx.TOP, 5)
 
         if stripe is not None:
-            visibility.SetValue(stripe['render'])
+            visibility.Set3StateValue(stripe['render'])
             colorinfo.SetLabel(wx.Colour(stripe['color']).GetAsString(wx.C2S_HTML_SYNTAX))
             colorpicker.SetColour(wx.Colour(stripe['color']))
             stripe_width.SetValue(stripe['width'])

--- a/lib/gui/tartan/customize_panel.py
+++ b/lib/gui/tartan/customize_panel.py
@@ -123,7 +123,7 @@ class CustomizePanel(ScrolledPanel):
 
         visibility = wx.CheckBox(self, style=wx.CHK_3STATE | wx.CHK_ALLOW_3RD_STATE_FOR_USER)
         visibility.SetToolTip(_("Checked: stitch this stripe | Minus: spacer for strokes only | Disabled: spacer for fill and stroke"))
-        visibility.SetValue(True)
+        visibility.Set3StateValue(1)
         visibility.Bind(wx.EVT_CHECKBOX, self._update_stripes_event)
 
         # hidden label used for linked colors

--- a/lib/tartan/palette.py
+++ b/lib/tartan/palette.py
@@ -58,7 +58,7 @@ class Palette:
         for i, outer_sizer in enumerate(sizers):
             stripes = []
             for stripe_sizer in outer_sizer.Children:
-                stripe = {'render': True, 'color': '#000000', 'width': '5'}
+                stripe = {'render': 1, 'color': '#000000', 'width': '5'}
                 stripe_info = stripe_sizer.GetSizer()
                 for color in stripe_info.GetChildren():
                     widget = color.GetWindow()
@@ -150,7 +150,13 @@ class Palette:
             width = float(width) * self.tt_unit
             if not color:
                 color = '#000000'
-                render = '?'
+                render = 0
+            elif render == '?':
+                render = 0
+            elif render == '*':
+                render = 2
+            else:
+                render = 1
             stripes.append({'render': render, 'color': color, 'width': float(width)})
         self.palette_stripes[0] = stripes
 
@@ -179,7 +185,7 @@ class Palette:
                 if not color:
                     color = '#000000'
                     render = 0
-                if render == '?':
+                elif render == '?':
                     render = 0
                 elif render == '*':
                     render = 2

--- a/lib/tartan/utils.py
+++ b/lib/tartan/utils.py
@@ -55,6 +55,7 @@ def stripes_to_shapes(
 
     left = minx
     top = miny
+    add_to_stroke = 0
     i = -1
     while True:
         i += 1
@@ -68,19 +69,28 @@ def stripes_to_shapes(
             right = left + width
             bottom = top + width
 
-            if (top > maxy and weft) or (left > maxx and not weft):
+            if ((top > maxy and weft) or (left > maxx and not weft) or
+                    (add_to_stroke > maxy and weft) or (add_to_stroke > maxx and not weft)):
                 return _merge_polygons(shapes, outline, intersect_outline)
 
-            if not stripe['render']:
+            if stripe['render'] == 0:
                 left = right
                 top = bottom
+                add_to_stroke = 0
+                continue
+            elif stripe['render'] == 2:
+                add_to_stroke += width
                 continue
 
             shape_dimensions = [top, bottom, left, right, minx, miny, maxx, maxy]
             if width <= min_stripe_width * PIXELS_PER_MM:
+                shape_dimensions[0] += add_to_stroke
+                shape_dimensions[2] += add_to_stroke
                 linestrings = _get_linestrings(outline, shape_dimensions, rotation, rotation_center, weft)
                 shapes[stripe['color']].extend(linestrings)
+                add_to_stroke += width
                 continue
+            add_to_stroke = 0
 
             polygon = _get_polygon(shape_dimensions, rotation, rotation_center, weft)
             shapes[stripe['color']].append(polygon)
@@ -252,9 +262,9 @@ def get_tartan_stripes(settings: dict) -> Tuple[list, list]:
         warp = []
     if palette.get_palette_width(settings['scale'], settings['min_stripe_width'], 1) == 0:
         weft = []
-    if len([stripe for stripe in warp if stripe['render'] is True]) == 0:
+    if len([stripe for stripe in warp if stripe['render'] == 1]) == 0:
         warp = []
-    if len([stripe for stripe in weft if stripe['render'] is True]) == 0:
+    if len([stripe for stripe in weft if stripe['render'] == 1]) == 0:
         weft = []
 
     if palette.equal_warp_weft:

--- a/lib/tartan/utils.py
+++ b/lib/tartan/utils.py
@@ -56,6 +56,7 @@ def stripes_to_shapes(
     left = minx
     top = miny
     add_to_stroke = 0
+    add_to_fill = 0
     i = -1
     while True:
         i += 1
@@ -74,8 +75,8 @@ def stripes_to_shapes(
                 return _merge_polygons(shapes, outline, intersect_outline)
 
             if stripe['render'] == 0:
-                left = right
-                top = bottom
+                left = right + add_to_stroke
+                top = bottom + add_to_stroke
                 add_to_stroke = 0
                 continue
             elif stripe['render'] == 2:
@@ -84,6 +85,7 @@ def stripes_to_shapes(
 
             shape_dimensions = [top, bottom, left, right, minx, miny, maxx, maxy]
             if width <= min_stripe_width * PIXELS_PER_MM:
+                add_to_fill = add_to_stroke
                 shape_dimensions[0] += add_to_stroke
                 shape_dimensions[2] += add_to_stroke
                 linestrings = _get_linestrings(outline, shape_dimensions, rotation, rotation_center, weft)
@@ -92,10 +94,15 @@ def stripes_to_shapes(
                 continue
             add_to_stroke = 0
 
+            # add the space of the lines to the following object to avoid bad symmetry
+            shape_dimensions[1] += add_to_fill
+            shape_dimensions[3] += add_to_fill
+
             polygon = _get_polygon(shape_dimensions, rotation, rotation_center, weft)
             shapes[stripe['color']].append(polygon)
-            left = right
-            top = bottom
+            left = right + add_to_fill
+            top = bottom + add_to_fill
+            add_to_fill = 0
 
 
 def _merge_polygons(


### PR DESCRIPTION
Instead of just rendering consecutive strokes on top of each other, allow them to define a distance value to the next stroke.
The rendering checkbox is turned into a three state checkbox:

* Checked: stitch this stripe 
* Middle: spacer for strokes only
* Disabled: spacer for fill and stroke