### PR TITLE
PDF Preview webpage now pings in worker (#2993)

### DIFF
--- a/print/resources/pingworker.js
+++ b/print/resources/pingworker.js
@@ -1,0 +1,9 @@
+function ping() {
+    fetch("/ping")
+        .then(() => setTimeout(ping, 1000))
+        .catch((e) => {
+            console.error(e);
+            postMessage("error");
+        })
+}
+setTimeout(ping, 1000);


### PR DESCRIPTION
A fix for the timeout that we saw in #2993: By moving the ping to a web worker, it can keep pinging even when the main thread is blocked. The better approach would probably be to not block the main thread in the first place (for example, by moving the rasterization task that blocks the main thread into either a web worker, or performing the rasterization in the extension in Inkscape instead), but that's more complex. Given we apparently plan on replacing this anyway, this simpler change lets us fix the issue of timing out and lets us keep the timeout short so the extension still closes in a prompt manner when the tab is closed.