### PR TITLE
Fix realistic stitch plan preview for inkscape versions 1.3 and 1.3.1

### DIFF
--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -5,7 +5,6 @@
 
 import sys
 from base64 import b64encode
-from os import environ
 from re import findall
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -136,7 +136,7 @@ class StitchPlanPreview(InkstitchExtension):
                     "export-do"  # Inkscape docs say this should be implicit at the end, but it doesn't seem to be.
                 ]))
 
-                # Extract numbers from returned string. It can include other information such as warnings the usage of AppImages
+                # Extract numbers from returned string. It can include other information such as warnings about the usage of AppImages
                 out = findall(r"\d+\.\d+", out)
 
                 # The query commands return positions in px, so we need to convert to uu.

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -121,7 +121,6 @@ class StitchPlanPreview(InkstitchExtension):
                 # however, layer.bounding_box() is pure python, so it can be very slow for more complex stitch previews.
                 # Instead, especially because we need to invoke Inkscape anyway to perform the rasterization, we get
                 # the bounding box with query commands before we perform the export. This is quite cheap.
-                environ["SELF_CALL"] = "true"  # needed for inkscape versions 1.3 and 1.3.1
                 out = inkscape(temp_svg_path, actions="; ".join([
                     f"select-by-id:{layer.get_id()}",
                     "query-x",
@@ -137,7 +136,7 @@ class StitchPlanPreview(InkstitchExtension):
                 ]))
 
                 # Extract numbers from returned string. It can include other information such as warnings about the usage of AppImages
-                out = findall(r"\d+\.\d+", out)
+                out = findall(r"(?m)^\d+\.?\d*$", out)
 
                 # The query commands return positions in px, so we need to convert to uu.
                 px_to_uu = svg.unittouu("1px")

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -135,7 +135,7 @@ class StitchPlanPreview(InkstitchExtension):
                 ]))
 
                 # Extract numbers from returned string. It can include other information such as warnings about the usage of AppImages
-                out = findall(r"(?m)^\d+\.?\d*$", out)
+                out = findall(r"(?m)^-?\d+\.?\d*$", out)
 
                 # The query commands return positions in px, so we need to convert to uu.
                 px_to_uu = svg.unittouu("1px")

--- a/lib/extensions/utils/inkex_command.py
+++ b/lib/extensions/utils/inkex_command.py
@@ -208,6 +208,7 @@ def inkscape(svg_file, *args, **kwargs):
         to `--export-id` and `--query-id`, by converting the call to the appropriate
         action sequence. The stdout is cleaned to resemble non-interactive mode.
     """
+    os.environ["SELF_CALL"] = "true"  # needed for inkscape versions 1.3 and 1.3.1
     actions = kwargs.get("actions", None)
     strip_stdout = False
     # Keep some safe margin to the 8191 character limit.


### PR DESCRIPTION
Inkscape versions 1.3 and 1.3.1 have a bug which prevents the realistic preview from working.
By setting the environment variable SELF_CALL we can fix the issue.