### PR TITLE
Fix split text extension

### DIFF
--- a/lib/extensions/palette_split_text.py
+++ b/lib/extensions/palette_split_text.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2022 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from re import findall
 from tempfile import TemporaryDirectory
 
 import inkex
@@ -38,8 +39,10 @@ class PaletteSplitText(InkstitchExtension):
             with TemporaryDirectory(prefix="inkscape-command") as tmpdir:
                 svg_file = inkex.command.write_svg(text.root, tmpdir, "input.svg")
                 bbox = inkscape(svg_file, "-X", "-Y", "-W", "-H", query_id=text.get_id())
-                bbox = list(map(text.root.viewport_to_unit, bbox.splitlines()))
-                bbox = inkex.BoundingBox.new_xywh(*bbox[1:])
+                # output can contain other information, so let's filter out the requested numbers
+                bbox = findall(r"(?m)^-?\d+\.?\d*$", bbox)
+                bbox = list(map(text.root.viewport_to_unit, bbox))
+                bbox = inkex.BoundingBox.new_xywh(*bbox)
 
             x = bbox.left
             y = bbox.bottom


### PR DESCRIPTION
`text.get_inkscape_bbox()` uses the inkscape command internally which will lead to the same issues as we have seen in the stitch plan preview png output (running the command with release versions and bounding box output possibly returns additional information.

We could rewrite the hole extension one day, since inkscape now wraps every text line into a tspan which already has positional information in them. So we possibly really don't need the bounding_box information anymore. But for now I think we can just add a fix.