### PR TITLE
Lettering: skip font with corrupt json file

### DIFF
--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -91,7 +91,19 @@ class Font(object):
             with open(os.path.join(self.path, "font.json"), encoding="utf-8-sig") as metadata_file:
                 self.metadata = json.load(metadata_file)
         except IOError:
-            pass
+            path = os.path.join(self.path, "font.json")
+            msg = _("JSON file missing. Expected a JSON file at the following location:")
+            msg += f"\n{path}\n\n"
+            msg += _("Generate the JSON file through:\nExtensions > Ink/Stitch > Font Management > Generate JSON...")
+            msg += '\n\n'
+            inkex.errormsg(msg)
+        except json.decoder.JSONDecodeError as exception:
+            path = os.path.join(self.path, "font.json")
+            msg = _("Corrupt JSON file")
+            msg += f" ({exception}):\n{path}\n\n"
+            msg += _("Regenerate the JSON file through:\nExtensions > Ink/Stitch > Font Management > Generate JSON...")
+            msg += '\n\n'
+            inkex.errormsg(msg)
 
     def _load_license(self):
         try:

--- a/lib/lettering/utils.py
+++ b/lib/lettering/utils.py
@@ -23,6 +23,8 @@ def get_font_list():
             continue
 
         for font_dir in font_dirs:
+            if not os.path.isdir(os.path.join(font_path, font_dir)) or font_dir.startswith('.'):
+                continue
             font = Font(os.path.join(font_path, font_dir))
             if font.marked_custom_font_name == "" or font.marked_custom_font_id == "":
                 continue


### PR DESCRIPTION
It's not nice of Ink/Stitch to not show the lettering tool when just one json file is corrupt.
Let's rather skip the file and inform about it.

Fixes #3057 