### PR TITLE
Command translations

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -296,9 +296,10 @@ def ensure_symbol(svg, command):
 
 def add_group(document, node, command):
     parent = node.getparent()
+    description = _(get_command_description(command))
     group = inkex.Group(attrib={
         "id": generate_unique_id(document, "command_group"),
-        INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+        INKSCAPE_LABEL: _("Ink/Stitch Command") + f": {description}",
         "transform": get_correction_transform(node)
     })
     parent.insert(parent.index(node) + 1, group)
@@ -431,9 +432,10 @@ def add_layer_commands(layer, commands):
 
     for i, command in enumerate(commands):
         ensure_symbol(svg, command)
+        description = _(get_command_description(command))
         layer.append(inkex.Use(attrib={
             "id": generate_unique_id(svg, "use"),
-            INKSCAPE_LABEL: _("Ink/Stitch Command") + ": %s" % get_command_description(command),
+            INKSCAPE_LABEL: _("Ink/Stitch Command") + f": {description}",
             XLINK_HREF: "#inkstitch_%s" % command,
             "height": "100%",
             "width": "100%",

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from html import unescape
-
 from inkex import errormsg
 from lxml import etree
 
@@ -21,4 +19,4 @@ class Input(object):
             errormsg(msg)
             exit(0)
         stitch_plan = generate_stitch_plan(embroidery_file)
-        print(unescape(etree.tostring(stitch_plan).decode('utf-8')))
+        print(etree.tostring(stitch_plan).decode('utf-8'))

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from html import unescape
+
 from inkex import errormsg
 from lxml import etree
 
@@ -19,4 +21,4 @@ class Input(object):
             errormsg(msg)
             exit(0)
         stitch_plan = generate_stitch_plan(embroidery_file)
-        print(etree.tostring(stitch_plan).decode('utf-8'))
+        print(unescape(etree.tostring(stitch_plan).decode('utf-8')))

--- a/lib/extensions/input.py
+++ b/lib/extensions/input.py
@@ -4,6 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from html import unescape
+from sys import platform
 
 from inkex import errormsg
 from lxml import etree
@@ -21,4 +22,8 @@ class Input(object):
             errormsg(msg)
             exit(0)
         stitch_plan = generate_stitch_plan(embroidery_file)
-        print(unescape(etree.tostring(stitch_plan).decode('utf-8')))
+        out = etree.tostring(stitch_plan).decode('utf-8')
+        if platform == "win32":
+            print(out)
+        else:
+            print(unescape(out))

--- a/lib/svg/rendering.py
+++ b/lib/svg/rendering.py
@@ -234,8 +234,8 @@ def render_stitch_plan(svg, stitch_plan, realistic=False, visual_commands=True, 
 
     for i, color_block in enumerate(stitch_plan):
         group = inkex.Group(attrib={
-            'id': '__color_block_%d__' % i,
-            INKSCAPE_LABEL: "color block %d" % (i + 1)
+            'id': f'__color_block_{i}__',
+            INKSCAPE_LABEL: f"color block {(i + 1)}"
         })
         layer.append(group)
         if realistic:


### PR DESCRIPTION
* Command labels haven't been translated
* Windows doesn't need the unescape method when importing embroidery files