### PR TITLE
Multiple int param is expected to return int not str

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -146,7 +146,7 @@ class EmbroideryElement(object):
 
     # returns an array of multiple space separated int values
     @cache
-    def get_multiple_int_param(self, param, default="0"):
+    def get_multiple_int_param(self, param, default=0):
         params = self.get_param(param, default).split(" ")
         try:
             params = [int(param) for param in params if param]

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -101,7 +101,7 @@ class Stroke(EmbroideryElement):
         default=0,
         sort_index=3)
     def bean_stitch_repeats(self):
-        return self.get_multiple_int_param("bean_stitch_repeats", "0")
+        return self.get_multiple_int_param("bean_stitch_repeats", 0)
 
     @property
     @param('running_stitch_length_mm',


### PR DESCRIPTION
Prevent error message when people enter non int characters into the bean stitch param. Fallback to 0 not str(0)