### PR TITLE
Default min stitch length 0 to 0.1 (as previously)

### DIFF
--- a/lib/gui/preferences.py
+++ b/lib/gui/preferences.py
@@ -47,7 +47,7 @@ class PreferencesFrame(wx.Frame):
             value=str(metadata['collapse_len_mm'] or global_settings['default_collapse_len_mm']),
             style=wx.ALIGN_RIGHT | wx.SP_ARROW_KEYS
         )
-        self.minimum_jump_stitch_length.SetDigits(1)
+        self.minimum_jump_stitch_length.SetDigits(2)
         this_svg_grid.Add(self.minimum_jump_stitch_length, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         label_2 = wx.StaticText(self.this_svg_page, wx.ID_ANY, _("mm"))
@@ -64,7 +64,7 @@ class PreferencesFrame(wx.Frame):
             value=str(metadata['min_stitch_len_mm'] or global_settings['default_min_stitch_len_mm']),
             style=wx.ALIGN_RIGHT | wx.SP_ARROW_KEYS
         )
-        self.minimum_stitch_length.SetDigits(1)
+        self.minimum_stitch_length.SetDigits(2)
         this_svg_grid.Add(self.minimum_stitch_length, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         label_4 = wx.StaticText(self.this_svg_page, wx.ID_ANY, _("mm"))
@@ -95,7 +95,7 @@ class PreferencesFrame(wx.Frame):
             value=str(global_settings['default_collapse_len_mm']),
             style=wx.ALIGN_RIGHT | wx.SP_ARROW_KEYS
         )
-        self.default_minimum_jump_stitch_length.SetDigits(1)
+        self.default_minimum_jump_stitch_length.SetDigits(2)
         global_grid_sizer.Add(self.default_minimum_jump_stitch_length, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         label_6 = wx.StaticText(self.global_page, wx.ID_ANY, _("mm"))
@@ -111,7 +111,7 @@ class PreferencesFrame(wx.Frame):
             value=str(global_settings['default_min_stitch_len_mm']),
             style=wx.ALIGN_RIGHT | wx.SP_ARROW_KEYS
         )
-        self.default_minimum_stitch_length.SetDigits(1)
+        self.default_minimum_stitch_length.SetDigits(2)
         global_grid_sizer.Add(self.default_minimum_stitch_length, 0, wx.ALIGN_CENTER_VERTICAL, 0)
 
         label_8 = wx.StaticText(self.global_page, wx.ID_ANY, _("mm"))

--- a/lib/utils/settings.py
+++ b/lib/utils/settings.py
@@ -7,7 +7,7 @@ from .paths import get_user_dir
 # These settings are the defaults for SVG metadata settings of the same name in
 # lib.extensions.base.InkstitchMetadata
 DEFAULT_METADATA = {
-    "min_stitch_len_mm": 0,
+    "min_stitch_len_mm": 0.1,
     "collapse_len_mm": 3,
 }
 


### PR DESCRIPTION
Previously duplicated stitches have been removed with default settings, I think we should keep it like that :)
In fact I rather had a default value of 0.3, but well, let's keep it with the previous default.