### PR TITLE
Add remove duplicated points extension

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -51,6 +51,7 @@ from .png_simple import PngSimple
 from .preferences import Preferences
 from .print_pdf import Print
 from .redwork import Redwork
+from .remove_duplicated_points import RemoveDuplicatedPoints
 from .remove_embroidery_settings import RemoveEmbroiderySettings
 from .reorder import Reorder
 from .satin_multicolor import SatinMulticolor
@@ -118,6 +119,7 @@ __all__ = extensions = [About,
                         Preferences,
                         Print,
                         Redwork,
+                        RemoveDuplicatedPoints,
                         RemoveEmbroiderySettings,
                         Reorder,
                         SatinMulticolor,

--- a/lib/extensions/remove_duplicated_points.py
+++ b/lib/extensions/remove_duplicated_points.py
@@ -1,0 +1,55 @@
+# Authors: see git history
+#
+# Copyright (c) 2024 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from collections import deque
+
+from inkex import Path, Transform, errormsg
+from shapely import MultiPoint, Point
+
+from ..elements import EmbroideryElement
+from ..i18n import _
+from ..svg import get_correction_transform
+from .base import InkstitchExtension
+
+
+class RemoveDuplicatedPoints(InkstitchExtension):
+    '''
+    This extension will remove duplicated points within the given range
+    '''
+    def __init__(self, *args, **kwargs):
+        InkstitchExtension.__init__(self, *args, **kwargs)
+        self.arg_parser.add_argument("--notebook")
+        self.arg_parser.add_argument("-n", "--num_points", type=int, default=10, dest="num_points")
+        self.arg_parser.add_argument("-d", "--distance", type=float, default=0.01, dest="distance")
+
+    def effect(self):
+        if not self.get_elements():
+            return
+
+        if not self.svg.selection:
+            errormsg(_("Please select one or more strokes."))
+            return
+
+        visited_nodes = []
+        for element in self.elements:
+            if element.node.get_id() in visited_nodes:
+                continue
+            visited_nodes.append(element.node.get_id())
+            if element.node.TAG != 'path':
+                # convert objects into paths
+                node = element.node.to_path_element()
+                element.node.getparent().replace(element.node, node)
+                element = EmbroideryElement(node)
+            new_paths = []
+            for path in element.paths:
+                new_path = []
+                for point in path:
+                    # do compare with more than 10 points
+                    points = deque(new_path, maxlen=self.options.num_points)
+                    if not points or Point(point).distance(MultiPoint(points)) > self.options.distance:
+                        new_path.append(point)
+                new_paths.append(new_path)
+            transform = -element.node.transform @ Transform(get_correction_transform(element.node))
+            element.node.set('d', str(Path(new_paths[0]).transform(transform)))

--- a/templates/remove_duplicated_points.xml
+++ b/templates/remove_duplicated_points.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+    <name>Remove duplicated points</name>
+    <id>org.{{ id_inkstitch }}.remove_duplicated_points</id>
+    <param name="extension" type="string" gui-hidden="true">remove_duplicated_points</param>
+
+    <param name="notebook" type="notebook">
+        <page name="options" gui-text="Options">
+            <param name="num_points" type="int" min="1" max="5000"
+                   gui-text="Remove point if repeated within this number of consecutive points">10</param>
+            <param name="distance" type="float" precision="2" min="0" max="500"
+                   gui-text="Distance tolerance">0.01</param>
+        </page>
+        <page name="info" gui-text="Help">
+            <label>
+                This extension removes duplicated points from selected elements.
+            </label>
+            <spacer />
+            <label>
+                It is most useful for manual paths (straight lines), since it will increase node count on Bézier curves. 
+                One possible usecase is to convert a bean stitch path from an embroidery file back into a simple line.
+            </label>
+            <spacer />
+            <label>More information on our website</label>
+            <label appearance="url">https://inkstitch.org/docs/edit/#remove-duplicated-points</label>
+        </page>
+    </param>
+
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu name="{{ menu_inkstitch }}" translatable="no">
+                <submenu name="Edit" />
+            </submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        {{ command_tag | safe }}
+    </script>
+</inkscape-extension>


### PR DESCRIPTION
On request... it can help (for example) to remove bean stitches from stitch plans and turn them into simple lines.