### PR TITLE
Disable darkmode symbols for windows

### DIFF
--- a/lib/gui/simulator/control_panel.py
+++ b/lib/gui/simulator/control_panel.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2024 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 import os
+from sys import platform
 
 import wx
 from wx.lib.intctrl import IntCtrl
@@ -194,7 +195,7 @@ class ControlPanel(wx.Panel):
         return wx.SystemSettings().GetAppearance().IsDark()
 
     def load_icon(self, icon_name):
-        if self.is_dark_theme():
+        if self.is_dark_theme() and platform != "win32":
             icon = wx.Image(os.path.join(self.icons_dir, f"{icon_name}_dark.png"))
         else:
             icon = wx.Image(os.path.join(self.icons_dir, f"{icon_name}.png"))

--- a/lib/gui/simulator/simulator_slider.py
+++ b/lib/gui/simulator/simulator_slider.py
@@ -129,7 +129,7 @@ class SimulatorSlider(wx.Panel):
             gc.DrawRectangle(start_x, height * self.color_bar_start,
                              end_x - start_x, height * self.color_bar_thickness)
 
-        if self.control_panel.is_dark_theme():
+        if self.is_dark_theme() and sys.platform != "win32":
             gc.SetPen(wx.Pen(wx.Colour(0, 0, 0), 1))
             gc.SetBrush(wx.Brush(wx.Colour(255, 255, 255)))
         else:


### PR DESCRIPTION
Darkmode doesn't work well on windows. They are working on it. Maybe with a later version of wxpython it will.

Reference: #3122