### PR TITLE
only style-check staged changes

### DIFF
--- a/bin/git-pre-commit-hook
+++ b/bin/git-pre-commit-hook
@@ -7,11 +7,18 @@
 # DO NOT SYMLINK
 # DO NOT SYMLINK (why? security risk)
 
+check_errors() {
+    errors="$("$@")"
+
+    if [ "$?" != "0" ]; then
+        echo "$errors"
+        exit 1
+    fi
+}
+
 cd $(dirname "$0")/../..
 
-errors=$(git diff --cached | bin/style-check --diff 2>&1)
+check_errors git stash --keep-index
+check_errors git diff --cached | bin/style-check 2>&1
+check_errors git stash pop
 
-if [ "$?" != "0" ]; then
-    echo "$errors"
-    exit 1
-fi


### PR DESCRIPTION
This change makes it so that the git pre-commit hook only style-checks changes you're actually trying to commit rather than other changes you may be working on or even random python files you have lying around.