### PR TITLE
Auto-run/Redwork: keep stroke width

### DIFF
--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -148,6 +148,7 @@ class Redwork(InkstitchExtension):
             transform=transform,
             d=path
         )
+        element.apply_transform()
 
         element.label = label
         element.set('inkstitch:running_stitch_length_mm', self.options.redwork_running_stitch_length_mm)

--- a/lib/stitches/utils/autoroute.py
+++ b/lib/stitches/utils/autoroute.py
@@ -230,11 +230,12 @@ def remove_from_parent(node):
         node.getparent().remove(node)
 
 
-def create_new_group(parent, insert_index, label):
+def create_new_group(parent, insert_index, label, correction_transform=True):
     group = inkex.Group(attrib={
         INKSCAPE_LABEL: label,
-        "transform": get_correction_transform(parent, child=True)
     })
+    if correction_transform:
+        group.transform = get_correction_transform(parent, child=True)
     parent.insert(insert_index, group)
 
     return group


### PR DESCRIPTION
Fixes #2986

When we scale the group with an extension, the line width scales with it - no matter the custom inkscape setting. We can counter act the effect applying the transforms to the element paths directly.