### PR TITLE
Use colormath2 instead of colormath

### DIFF
--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -5,9 +5,9 @@
 
 from collections.abc import Set
 
-from colormath.color_conversions import convert_color
-from colormath.color_diff import delta_e_cie1994
-from colormath.color_objects import LabColor, sRGBColor
+from colormath2.color_conversions import convert_color
+from colormath2.color_diff import delta_e_cie1994
+from colormath2.color_objects import LabColor, sRGBColor
 
 from .color import ThreadColor
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,10 +24,7 @@ requests
 # tomli is built as tomllib in python 3.11 and higher
 tomli
 
-# colormath - last official release: 3.0.0
-# we need already submitted fixes - so let's grab them from the github repository
-colormath @ git+https://github.com/gtaylor/python-colormath.git@4a076831fd5136f685aa7143db81eba27b2cd19a
-
+colormath2
 flask>=2.2.0
 fonttools
 trimesh>=3.15.2


### PR DESCRIPTION
colormath is no longer maintained or updated on PyPI.