### PR TITLE
unit: prevent zerodivision error for zero length segments

### DIFF
--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -303,6 +303,8 @@ class Point:
 
     def unit(self):
         length = self.length()
+        if length == 0:
+            return self.__class__(0, 0)
         return self.__class__(self.x / length, self.y / length)
 
     def angle(self):


### PR DESCRIPTION
Fixes: #3267

Not ideal, but ... better than an error message I suppose ...