### PR TITLE
Clone: fix clone of grouped clones

### DIFF
--- a/lib/elements/clone.py
+++ b/lib/elements/clone.py
@@ -262,7 +262,6 @@ def clone_with_fixup(parent: BaseElement, node: BaseElement) -> BaseElement:
             node.set(attr, id_map.get(val, val))
 
     for n in ret.iter():
-        fixup_id_attr(n, XLINK_HREF)
         fixup_id_attr(n, CONNECTION_START)
         fixup_id_attr(n, CONNECTION_END)
 


### PR DESCRIPTION
Issue #3260 shows an issue concerning clones (along other issues). Clones of grouped clone of clones seem to be problematic if we fixup the clones href. If we don't everything seems to work fine. I couldn't find a use case when it doesn't.

@capellancitizen do you know what this was needed for?

Simplified sample file for this issue:

![clone_of_grouped_clone](https://github.com/user-attachments/assets/1d063bb2-de4a-4665-88d4-10e5a345e2b3)
