### PR TITLE
Fix jump to stroke transform glitch

### DIFF
--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -157,7 +157,7 @@ class JumpToStroke(InkstitchExtension):
         # option: merge line with paths
         merged = False
         if self._is_mergable(last_element, element):
-            path.transform(Transform(get_correction_transform(last_element.node)), True)
+            path.transform(Transform(get_correction_transform(last_element.node, True)), True)
             path = last_element.node.get_path() + path[1:]
             last_element.node.set('d', str(path))
             path.transform(-Transform(get_correction_transform(last_element.node)), True)


### PR DESCRIPTION
Jump to stroke shifted the merge path when the element had a transform itself.