### PR TITLE
Use non-accumulative command scaling

### DIFF
--- a/lib/extensions/commands_scale_symbols.py
+++ b/lib/extensions/commands_scale_symbols.py
@@ -11,18 +11,19 @@ from .base import InkstitchExtension
 class CommandsScaleSymbols(InkstitchExtension):
     def __init__(self, *args, **kwargs):
         InkstitchExtension.__init__(self, *args, **kwargs)
-        self.arg_parser.add_argument("-s", "--size", dest="size", type=float, default=1)
+        self.arg_parser.add_argument("-s", "--size", dest="size", type=int, default=100)
 
     def effect(self):
-        size = self.options.size
+        size = self.options.size / 100
 
+        # scale symbols
         svg = self.document.getroot()
         command_symbols = svg.xpath(".//svg:symbol[starts-with(@id,'inkstitch_')]", namespaces=NSS)
         for symbol in command_symbols:
-            transform = Transform(symbol.get('transform')).add_scale(size)
+            transform = Transform(f'scale({size})')
             symbol.set('transform', str(transform))
 
+        # scale markers
         markers = svg.xpath(".//svg:marker[starts-with(@id, 'inkstitch')]", namespaces=NSS)
         for marker in markers:
-            marker_size = float(marker.get('markerWidth', 0.5)) * size
-            marker.set('markerWidth', marker_size)
+            marker.set('markerWidth', str(size / 2))

--- a/lib/gui/request_update_svg_version.py
+++ b/lib/gui/request_update_svg_version.py
@@ -72,7 +72,7 @@ class RequestUpdate:
 
         app = wx.App()
         frame = RequestUpdateFrame(
-            title=_("Ink/Stitch"),
+            title="Ink/Stitch",
             on_cancel=self.cancel_update,
         )
         frame.Show()

--- a/templates/commands_scale_symbols.xml
+++ b/templates/commands_scale_symbols.xml
@@ -3,7 +3,7 @@
     <name>Scale Command Symbols</name>
     <id>org.{{ id_inkstitch }}.commands_scale_symbols</id>
     <param name="extension" type="string" gui-hidden="true">commands_scale_symbols</param>
-    <param name="size" type="float" precision="1" min="0" max="2" gui-text="Size" appearance="full">1.0</param>
+    <param name="size" type="int" min="0" max="200" gui-text="Size (%)" appearance="full">100</param>
     <effect>
         <object-type>all</object-type>
         <icon>{{ icon_path }}inx/commands_scale.svg</icon>


### PR DESCRIPTION
So all commands get the selected scale. Otherwise the method will also scale down commands which are already scaled. Most of the time that's not the desired action, but they aim for a unified command size.