### PR TITLE
Include all files of default variant for glyph list update

### DIFF
--- a/lib/extensions/lettering_update_json_glyphlist.py
+++ b/lib/extensions/lettering_update_json_glyphlist.py
@@ -30,8 +30,8 @@ class LetteringUpdateJsonGlyphlist(InkstitchExtension):
             return
         json_file = self._get_json_file(font_dir)
 
+        # glyphs
         font = Font(font_dir)
-        # get svg files for default variant of this font
         font._load_variants()
         glyphs = font.get_variant(font.default_variant).glyphs
         glyphs = list(glyphs.keys())
@@ -39,12 +39,13 @@ class LetteringUpdateJsonGlyphlist(InkstitchExtension):
         if not glyphs:
             return
 
+        # read json file
         with open(json_file, 'r') as font_data:
             data = json.load(font_data)
 
         data['glyphs'] = glyphs
 
-        # write data to font.json into the same directory as the font file
+        # write data to the.json file
         with open(json_file, 'w', encoding="utf8") as font_data:
             json.dump(data, font_data, indent=4, ensure_ascii=False)
 

--- a/templates/lettering_update_json_glyphlist.xml
+++ b/templates/lettering_update_json_glyphlist.xml
@@ -6,8 +6,7 @@
 
     <param name="notebook" type="notebook">
         <page name="options" gui-text="Options">
-            <param type="path" name="font-file" gui-text="SVG Font File" mode="file" filetypes="svg"/>
-            <param type="path" name="json-file" gui-text="JSON File" mode="file" filetypes="json"/>
+            <param type="path" name="font-dir" gui-text="Font Folder" mode="folder"/>
         </page>
         <page name="info" gui-text="Help">
             <label appearance="header">Updates the glyphlist in the json file.</label>


### PR DESCRIPTION
Until now it would only take one file, but fonts now-days can use a folder for each variants with various files.
So the glyph list update extension should be able to do that too.