### PR TITLE
Multi shape tartan jumps

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -431,7 +431,7 @@ class FillStitch(EmbroideryElement):
                   'stitch routing. When enabled the last section will end at the defined spot.'),
         type='boolean',
         sort_index=33,
-        select_items=[('fill_method', 'linear_gradient_fill')],
+        select_items=[('fill_method', 'linear_gradient_fill'), ('fill_method', 'tartan_fill')],
         default=False
      )
     def stop_at_ending_point(self):
@@ -962,20 +962,20 @@ class FillStitch(EmbroideryElement):
                 fill_shapes = self.fill_shape(shape)
                 for i, fill_shape in enumerate(fill_shapes.geoms):
                     if self.fill_method == 'contour_fill':
-                        stitch_groups.extend(self.do_contour_fill(fill_shape, previous_stitch_group, start))
+                        stitch_groups.extend(self.do_contour_fill(fill_shape, start))
                     elif self.fill_method == 'guided_fill':
-                        stitch_groups.extend(self.do_guided_fill(fill_shape, previous_stitch_group, start, end))
+                        stitch_groups.extend(self.do_guided_fill(fill_shape, start, end))
                     elif self.fill_method == 'meander_fill':
                         stitch_groups.extend(self.do_meander_fill(fill_shape, shape, i, start, end))
                     elif self.fill_method == 'circular_fill':
-                        stitch_groups.extend(self.do_circular_fill(fill_shape, previous_stitch_group, start, end))
+                        stitch_groups.extend(self.do_circular_fill(fill_shape, start, end))
                     elif self.fill_method == 'linear_gradient_fill':
-                        stitch_groups.extend(self.do_linear_gradient_fill(fill_shape, previous_stitch_group, start, end))
+                        stitch_groups.extend(self.do_linear_gradient_fill(fill_shape, start, end))
                     elif self.fill_method == 'tartan_fill':
-                        stitch_groups.extend(self.do_tartan_fill(fill_shape, previous_stitch_group, start, end))
+                        stitch_groups.extend(self.do_tartan_fill(fill_shape, start, end))
                     else:
                         # auto_fill
-                        stitch_groups.extend(self.do_auto_fill(fill_shape, previous_stitch_group, start, end))
+                        stitch_groups.extend(self.do_auto_fill(fill_shape, start, end))
                     if stitch_groups:
                         previous_stitch_group = stitch_groups[-1]
 
@@ -1052,7 +1052,7 @@ class FillStitch(EmbroideryElement):
             starting_point = underlay.stitches[-1]
         return [stitch_groups, starting_point]
 
-    def do_auto_fill(self, shape, last_stitch_group, starting_point, ending_point):
+    def do_auto_fill(self, shape, starting_point, ending_point):
         stitch_group = StitchGroup(
             color=self.color,
             tags=("auto_fill", "auto_fill_top"),
@@ -1081,7 +1081,7 @@ class FillStitch(EmbroideryElement):
         )
         return [stitch_group]
 
-    def do_contour_fill(self, polygon, last_stitch_group, starting_point):
+    def do_contour_fill(self, polygon, starting_point):
         if not starting_point:
             starting_point = (0, 0)
         starting_point = shgeo.Point(starting_point)
@@ -1135,12 +1135,12 @@ class FillStitch(EmbroideryElement):
 
         return stitch_groups
 
-    def do_guided_fill(self, shape, last_stitch_group, starting_point, ending_point):
+    def do_guided_fill(self, shape, starting_point, ending_point):
         guide_line = self._get_guide_lines()
 
         # No guide line: fallback to normal autofill
         if not guide_line:
-            return self.do_auto_fill(shape, last_stitch_group, starting_point, ending_point)
+            return self.do_auto_fill(shape, starting_point, ending_point)
 
         stitch_group = StitchGroup(
             color=self.color,
@@ -1190,7 +1190,7 @@ class FillStitch(EmbroideryElement):
         )
         return [stitch_group]
 
-    def do_circular_fill(self, shape, last_stitch_group, starting_point, ending_point):
+    def do_circular_fill(self, shape, starting_point, ending_point):
         # get target position
         command = self.get_command('target_point')
         if command:
@@ -1229,8 +1229,8 @@ class FillStitch(EmbroideryElement):
         )
         return [stitch_group]
 
-    def do_linear_gradient_fill(self, shape, last_stitch_group, start, end):
+    def do_linear_gradient_fill(self, shape, start, end):
         return linear_gradient_fill(self, shape, start, end)
 
-    def do_tartan_fill(self, shape, last_stitch_group, start, end):
+    def do_tartan_fill(self, shape, start, end):
         return tartan_fill(self, shape, start, end)

--- a/lib/gui/lettering/option_panel.py
+++ b/lib/gui/lettering/option_panel.py
@@ -72,8 +72,8 @@ class LetteringOptionsPanel(wx.Panel):
         font_selector_box = wx.BoxSizer(wx.HORIZONTAL)
         font_selector_box.Add(self.font_chooser, 4, wx.EXPAND | wx.TOP | wx.BOTTOM | wx.RIGHT, 10)
         font_selector_sizer.Add(font_selector_box, 0, wx.EXPAND | wx.LEFT | wx.TOP | wx.RIGHT, 10)
-        font_selector_sizer.Add(self.font_description, 1, wx.EXPAND | wx.ALL, 10)
-        font_selector_sizer.Add(font_description_sizer, 1, wx.EXPAND | wx.ALL, 10)
+        font_selector_sizer.Add(self.font_description, 0, wx.EXPAND | wx.ALL, 10)
+        font_selector_sizer.Add(font_description_sizer, 0, wx.EXPAND | wx.ALL, 10)
         outer_sizer.Add(font_selector_sizer, 0, wx.EXPAND | wx.LEFT | wx.TOP | wx.RIGHT, 10)
 
         # options

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -549,6 +549,8 @@ class Font(object):
                     for element in element_list:
                         path += element.get("d", "")
                 grouped_elements[0][0].set("d", path)
+                if grouped_elements[0][0].get("inkstitch:fill_method", False) in ['tartan_fill', 'linear_gradient_fill']:
+                    grouped_elements[0][0].set('inkstitch:stop_at_ending_point', True)
                 color_group.append(grouped_elements[0][0])
                 group.append(color_group)
                 continue

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -105,10 +105,11 @@
       </page>
       <page name="info" gui-text="Help">
           <label appearance="header">Generates font.json which can be used by the lettering tool.</label>
-          <label>The generated file can be viewed and updated with a standard text editor tool.</label>
+          <label>The generated file can be updated with Extensions > Ink/Stitch > Font Management > Edit JSON.</label>
           <spacer />
           <label>More information on our website</label>
           <label appearance="url">https://inkstitch.org/docs/font-tools/#generate-json</label>
+          <label appearance="url">https://inkstitch.org/docs/font-tools/#edit-json</label>
       </page>
     </param>
 


### PR DESCRIPTION
The jumps in a tartan shape were always adapted to a single shape.
But to reduce color changes, people like to combine multiple shapes.
Start and end should be adapted as well in that case.