### PR TITLE
Windows code sign off

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,20 +304,11 @@ jobs:
           make dist
         env:
           BUILD: windows
-      #- uses: dlemstra/code-sign-action@v1
-      #  with:
-      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-      #    folder: 'dist'
-      #    recursive: true
       - shell: bash
         run: |
           bash bin/build-windows-installer
         env:
           BUILD: windows
-      #- uses: dlemstra/code-sign-action@v1
-      #  with:
-      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-      #    folder: 'artifacts'
       - uses: actions/upload-artifact@v4
         with:
           name: inkstitch-windows32
@@ -372,20 +363,11 @@ jobs:
           make dist
         env:
           BUILD: windows
-      #- uses: dlemstra/code-sign-action@v1
-      #  with:
-      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-      #    folder: 'dist'
-      #    recursive: true
       - shell: bash
         run: |
           bash bin/build-windows-installer
         env:
           BUILD: windows
-      #- uses: dlemstra/code-sign-action@v1
-      #  with:
-      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-      #    folder: 'artifacts'
       - uses: actions/upload-artifact@v4
         with:
           name: inkstitch-windows64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,20 +304,20 @@ jobs:
           make dist
         env:
           BUILD: windows
-      - uses: dlemstra/code-sign-action@v1
-        with:
-          certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-          folder: 'dist'
-          recursive: true
+      #- uses: dlemstra/code-sign-action@v1
+      #  with:
+      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
+      #    folder: 'dist'
+      #    recursive: true
       - shell: bash
         run: |
           bash bin/build-windows-installer
         env:
           BUILD: windows
-      - uses: dlemstra/code-sign-action@v1
-        with:
-          certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-          folder: 'artifacts'
+      #- uses: dlemstra/code-sign-action@v1
+      #  with:
+      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
+      #    folder: 'artifacts'
       - uses: actions/upload-artifact@v4
         with:
           name: inkstitch-windows32
@@ -372,20 +372,20 @@ jobs:
           make dist
         env:
           BUILD: windows
-      - uses: dlemstra/code-sign-action@v1
-        with:
-          certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-          folder: 'dist'
-          recursive: true
+      #- uses: dlemstra/code-sign-action@v1
+      #  with:
+      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
+      #    folder: 'dist'
+      #    recursive: true
       - shell: bash
         run: |
           bash bin/build-windows-installer
         env:
           BUILD: windows
-      - uses: dlemstra/code-sign-action@v1
-        with:
-          certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
-          folder: 'artifacts'
+      #- uses: dlemstra/code-sign-action@v1
+      #  with:
+      #    certificate: '${{ secrets.INKSTITCH_CODE_SIGNING_CERTIFICATE }}'
+      #    folder: 'artifacts'
       - uses: actions/upload-artifact@v4
         with:
           name: inkstitch-windows64


### PR DESCRIPTION
As we do not have a valid license at the moment and need to rework the signing process anyway, let's remove the old signing code, so the windows builds at least don't fail.