### PR TITLE
Enable the expand option for contour fill

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -271,6 +271,7 @@ class FillStitch(EmbroideryElement):
                          ('fill_method', 'guided_fill'),
                          ('fill_method', 'meander_fill'),
                          ('fill_method', 'circular_fill'),
+                         ('fill_method', 'contour_fill'),
                          ('fill_method', 'tartan_fill'),
                          ('fill_method', 'linear_gradient_fill')])
     def expand(self):


### PR DESCRIPTION
Works anyway if it was set for an other fill type on the element. So why not show it?

Thanks @claudinepeyrat06 for the hint...