### PR TITLE
hide Sew Stack from releases

### DIFF
--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -18,6 +18,10 @@ from ..update import update_inkstitch_document
 class InkstitchExtension(inkex.EffectExtension):
     """Base class for Inkstitch extensions.  Not intended for direct use."""
 
+    # Set to True to hide this extension from release builds of Ink/Stitch.  It will
+    # only be available in development installations.
+    DEVELOPMENT_ONLY = False
+
     def load(self, *args, **kwargs):
         document = super().load(*args, **kwargs)
         update_inkstitch_document(document)

--- a/lib/extensions/sew_stack_editor.py
+++ b/lib/extensions/sew_stack_editor.py
@@ -531,6 +531,8 @@ class SewStackPanel(wx.Panel):
 
 
 class SewStackEditor(InkstitchExtension):
+    DEVELOPMENT_ONLY = True
+
     def __init__(self, *args, **kwargs):
         self.cancelled = False
         InkstitchExtension.__init__(self, *args, **kwargs)

--- a/lib/inx/extensions.py
+++ b/lib/inx/extensions.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+import os
+
 import pyembroidery
 
 from ..commands import (COMMANDS, GLOBAL_COMMANDS, LAYER_COMMANDS,
@@ -45,6 +47,9 @@ def generate_extension_inx_files(alter_data):
 
     for extension in extensions:
         if extension is Input or extension is Output:
+            continue
+
+        if extension.DEVELOPMENT_ONLY and 'BUILD' in os.environ:
             continue
 
         name = extension.name()


### PR DESCRIPTION
This adds a DEVELOPMENT_ONLY attribute to extension classes that hides them from release builds.  This way we can work on upcoming extensions but not include them in published releases.  For starters, we'll hide the Sew Stack extension since it's a work in progress.