### PR TITLE
LPE-Satins: take transforms into account (for path specific lpe satins only)

### DIFF
--- a/lib/extensions/stroke_to_lpe_satin.py
+++ b/lib/extensions/stroke_to_lpe_satin.py
@@ -62,6 +62,8 @@ class StrokeToLpeSatin(InkstitchExtension):
 
         for element in self.elements:
             if self.options.path_specific:
+                element_transform = element.node.composed_transform()
+                pattern_path = str(inkex.Path(pattern_path).transform(-element_transform, True))
                 lpe = self._create_lpe_element(pattern, pattern_path, pattern_node_type, copy_type, element)
             if isinstance(element, SatinColumn):
                 self._process_satin_column(element, lpe, pattern_path, copy_type)


### PR DESCRIPTION
This will of course only apply when the extension is run again.

Doesn't work for not path specific lpe satins (of course - how could it work when they have different transforms).