### PR TITLE
Lettering: do not add commands on command connectors

### DIFF
--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -519,9 +519,9 @@ class Font(object):
             for value in elements.values():
                 self._add_trim_to_element(Stroke(value), use_trim_symbols)
         else:
-            # find the last path that does not carry a marker and add a trim there
+            # find the last path that does not carry a marker or belongs to a visual command and add a trim there
             for path_child in group.iterdescendants(EMBROIDERABLE_TAGS):
-                if not has_marker(path_child):
+                if not has_marker(path_child) and not path_child.get_id().startswith('command_connector'):
                     path = path_child
                 element = Stroke(path)
             self._add_trim_to_element(element, use_trim_symbols)


### PR DESCRIPTION
If the font uses commands, it may happen, that trim commands end up on the connectors of these commands.
We shouldn't do that :D