### PR TITLE
Command symbol size

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -337,7 +337,7 @@ def ensure_symbol(svg, command):
     defs = svg.defs
     if defs.find(path) is None:
         symbol = deepcopy(symbol_defs().find(path))
-        symbol.transform = 'scale(0.2)'
+        symbol.transform = 'scale(0.25)'
         defs.append(symbol)
 
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -338,6 +338,7 @@ def ensure_symbol(svg, command):
     if defs.find(path) is None:
         symbol = deepcopy(symbol_defs().find(path))
         symbol.transform = 'scale(0.25)'
+        symbol.style['opacity'] = 0.7
         defs.append(symbol)
 
 

--- a/lib/extensions/commands_scale_symbols.py
+++ b/lib/extensions/commands_scale_symbols.py
@@ -15,7 +15,7 @@ class CommandsScaleSymbols(InkstitchExtension):
 
     def effect(self):
         # by default commands are scaled down to 0.2
-        size = 0.2 * self.options.size / 100
+        size = 0.25 * self.options.size / 100
 
         # scale symbols
         svg = self.document.getroot()

--- a/templates/commands_scale_symbols.xml
+++ b/templates/commands_scale_symbols.xml
@@ -3,7 +3,7 @@
     <name>Scale Command Symbols</name>
     <id>org.{{ id_inkstitch }}.commands_scale_symbols</id>
     <param name="extension" type="string" gui-hidden="true">commands_scale_symbols</param>
-    <param name="size" type="int" min="0" max="200" gui-text="Size (%)" appearance="full">100</param>
+    <param name="size" type="int" min="0" max="400" gui-text="Size (%)" appearance="full">100</param>
     <effect>
         <object-type>all</object-type>
         <icon>{{ icon_path }}inx/commands_scale.svg</icon>


### PR DESCRIPTION
Maybe this was just a little bit too small...
Also sets a slight opacity for the commands so it is possible to see through while positioning.