### PR TITLE
Shift command position of commands with connector lines a little bit out

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -416,14 +416,14 @@ def add_symbol(document, group, command, pos):
     return symbol
 
 
-def get_command_pos(element, index, total):
+def get_command_pos(element, index, total, distance=10):
     # Put command symbols on the outline of the shape, spaced evenly around it.
 
     if element.name == "Stroke":
         shape = element.as_multi_line_string()
     else:
         shape = element.shape
-    polygon = ensure_multi_polygon(shape.buffer(0.01)).geoms[-1]
+    polygon = ensure_multi_polygon(shape.buffer(distance)).geoms[-1]
     outline = polygon.exterior
 
     # pick this item's spot around the outline and perturb it a bit to avoid
@@ -443,7 +443,10 @@ def add_commands(element, commands, pos=None):
         group = add_group(svg, element.node, command)
         position = pos
         if position is None:
-            position = get_command_pos(element, i, len(commands))
+            if command in HIDDEN_CONNECTOR_COMMANDS:
+                position = get_command_pos(element, i, len(commands), 0.1)
+            else:
+                position = get_command_pos(element, i, len(commands))
 
         symbol = add_symbol(svg, group, command, position)
         add_connector(svg, symbol, command, element)

--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -4,7 +4,6 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import colorsys
-import re
 
 from inkex import Color
 from pyembroidery.EmbThread import EmbThread
@@ -34,7 +33,7 @@ class ThreadColor(object):
             self.rgb = (color.get_red(), color.get_green(), color.get_blue())
             return
         elif isinstance(color, str):
-            self.rgb = Color(color).to('rgb').get_values(False)
+            self.rgb = tuple(Color(color).to('rgb').get_values(False))
         elif isinstance(color, (list, tuple)):
             self.rgb = tuple(color)
         else:


### PR DESCRIPTION
It doesn't make sense for all commands to end up on the outline.