### PR TITLE
Element info: take pattern into account

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -774,7 +774,7 @@ class FillStitch(EmbroideryElement):
         paths.sort(key=lambda point_list: shgeo.Polygon(point_list).area, reverse=True)
         shape = shgeo.MultiPolygon([(paths[0], paths[1:])])
         if self.node.style('fill-rule') == 'nonzero':
-            shape = shape.buffer(0)
+            shape = ensure_multi_polygon(shape.buffer(0))
         return shape
 
     @property

--- a/lib/extensions/element_info.py
+++ b/lib/extensions/element_info.py
@@ -40,7 +40,7 @@ class ElementInfo(InkstitchExtension):
         app.MainLoop()
 
     def _element_info(self, element, previous_stitch_group, next_element):
-        stitch_groups = element.to_stitch_groups(previous_stitch_group)
+        stitch_groups = element.embroider(previous_stitch_group, next_element)
         stitch_plan = stitch_groups_to_stitch_plan(
             stitch_groups,
             collapse_len=self.metadata['collapse_len_mm'],


### PR DESCRIPTION
Patterns were not included in the stitch length calculations.
Using embroider instead of to_stitch_groups solves the problem easily.