### PR TITLE
Rename "convert to" extensions

### DIFF
--- a/lib/extensions/__init__.py
+++ b/lib/extensions/__init__.py
@@ -12,8 +12,6 @@ from .batch_lettering import BatchLettering
 from .break_apart import BreakApart
 from .cleanup import Cleanup
 from .commands_scale_symbols import CommandsScaleSymbols
-from .convert_to_satin import ConvertToSatin
-from .convert_to_stroke import ConvertToStroke
 from .cut_satin import CutSatin
 from .cutwork_segmentation import CutworkSegmentation
 from .density_map import DensityMap
@@ -60,6 +58,7 @@ from .remove_duplicated_points import RemoveDuplicatedPoints
 from .remove_embroidery_settings import RemoveEmbroiderySettings
 from .reorder import Reorder
 from .satin_multicolor import SatinMulticolor
+from .satin_to_stroke import SatinToStroke
 from .select_elements import SelectElements
 from .selection_to_anchor_line import SelectionToAnchorLine
 from .selection_to_guide_line import SelectionToGuideLine
@@ -69,6 +68,7 @@ from .simulator import Simulator
 from .stitch_plan_preview import StitchPlanPreview
 from .stitch_plan_preview_undo import StitchPlanPreviewUndo
 from .stroke_to_lpe_satin import StrokeToLpeSatin
+from .stroke_to_satin import StrokeToSatin
 from .tartan import Tartan
 from .test_swatches import TestSwatches
 from .thread_list import ThreadList
@@ -88,8 +88,6 @@ extensions = [
     BreakApart,
     Cleanup,
     CommandsScaleSymbols,
-    ConvertToSatin,
-    ConvertToStroke,
     CutSatin,
     CutworkSegmentation,
     DensityMap,
@@ -136,6 +134,7 @@ extensions = [
     RemoveEmbroiderySettings,
     Reorder,
     SatinMulticolor,
+    SatinToStroke,
     SelectElements,
     SelectionToAnchorLine,
     SelectionToGuideLine,
@@ -145,6 +144,7 @@ extensions = [
     StitchPlanPreview,
     StitchPlanPreviewUndo,
     StrokeToLpeSatin,
+    StrokeToSatin,
     Tartan,
     TestSwatches,
     ThreadList,

--- a/lib/extensions/satin_to_stroke.py
+++ b/lib/extensions/satin_to_stroke.py
@@ -11,7 +11,7 @@ from ..svg import get_correction_transform
 from .base import InkstitchExtension
 
 
-class ConvertToStroke(InkstitchExtension):
+class SatinToStroke(InkstitchExtension):
     """Convert a satin column into a running stitch."""
 
     def __init__(self, *args, **kwargs):

--- a/lib/extensions/stroke_to_satin.py
+++ b/lib/extensions/stroke_to_satin.py
@@ -25,7 +25,7 @@ class SelfIntersectionError(Exception):
     pass
 
 
-class ConvertToSatin(InkstitchExtension):
+class StrokeToSatin(InkstitchExtension):
     """Convert a line to a satin column of the same width."""
 
     def effect(self):

--- a/templates/satin_to_stroke.xml
+++ b/templates/satin_to_stroke.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>Convert Satin to Stroke</name>
-    <id>org.{{ id_inkstitch }}.convert_to_stroke</id>
-    <param name="extension" type="string" gui-hidden="true">convert_to_stroke</param>
+    <name>Satin to Stroke</name>
+    <id>org.{{ id_inkstitch }}.satin_to_stroke</id>
+    <param name="extension" type="string" gui-hidden="true">satin_to_stroke</param>
 
     <param name="notebook" type="notebook">
         <page name="options" gui-text="Options">

--- a/templates/stroke_to_satin.xml
+++ b/templates/stroke_to_satin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension translationdomain="inkstitch" xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>Convert Line to Satin</name>
-    <id>org.{{ id_inkstitch }}.convert_to_satin</id>
-    <param name="extension" type="string" gui-hidden="true">convert_to_satin</param>
+    <name>Stroke to Satin</name>
+    <id>org.{{ id_inkstitch }}.stroke_to_satin</id>
+    <param name="extension" type="string" gui-hidden="true">stroke_to_satin</param>
     <effect>
         <object-type>all</object-type>
         <icon>{{ icon_path }}inx/to_satin.svg</icon>


### PR DESCRIPTION
Since we have various types of conversions between stitch types I think "convert to satin" and "convert to stroke" is not the right terminology anymore.