### PR TITLE
Batch lettering: fix template confusions gui-text / gui-description

### DIFF
--- a/templates/batch_lettering.xml
+++ b/templates/batch_lettering.xml
@@ -18,7 +18,7 @@
                 <spacer />
                 <param name="font" type="string" gui-text="Font name"></param>
                 <param name="scale" type="int" gui-text="Scale (%)" min="1" max="800"
-                       gui-text="The scale value must be within the scale range of the specified font.">100</param>
+                       gui-description="The scale value must be within the scale range of the specified font.">100</param>
                 <param name="color-sort" type="optiongroup" appearance="combo" gui-text="Color sort">
                    <option value="off">Off</option>
                    <option value="all">Whole text</option>


### PR DESCRIPTION
Just a simple stupid mistake, nothing big.