### PR TITLE
Ignore non-utf8 palette files

### DIFF
--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -39,7 +39,12 @@ class ThreadPalette(Set):
         """
 
         with open(palette_file, encoding='utf8') as palette:
-            line = palette.readline().strip()
+            try:
+                line = palette.readline().strip()
+            except UnicodeDecodeError:
+                # File has wrong encoding. Can't read this file
+                self.is_gimp_palette = False
+                return
 
             self.is_gimp_palette = True
             if line.lower() != "gimp palette":


### PR DESCRIPTION
This is an old branch and there could be better solutions to this than just ignoring non-utf8 encoded palette files.

But I just noticed, that this never was made a pull request and erroring out if there is any palette in the system which is not utf8 is a bad idea.