### PR TITLE
Unlink clones: add option to group / not group resulting elements

### DIFF
--- a/lib/extensions/unlink_clone.py
+++ b/lib/extensions/unlink_clone.py
@@ -37,14 +37,7 @@ class UnlinkClone(InkstitchExtension):
             if isinstance(element, Clone):
                 resolved = element.resolve_clone(recursive=recursive)
                 if resolved[0].tag in SVG_SYMBOL_TAG:
-                    parent = cast(BaseElement, resolved[0].getparent())  # Safe assumption that this has a parent.
-                    group = self.get_group(parent)
-                    for child in resolved[0]:
-                        group.append(child)
-                    if self.options.add_group:
-                        parent.replace(resolved[0], group)
-                    else:
-                        resolved[0].delete()
+                    self._resolve_symbol(resolved)
                 clones_resolved.append((element.node, resolved[0]))
 
         for (clone, resolved_clone) in clones_resolved:
@@ -57,7 +50,15 @@ class UnlinkClone(InkstitchExtension):
                 command.connector.set(backlink_attrib, "#"+new_id)
             resolved_clone.set_id(new_id)
 
-    def get_group(self, parent):
+    def _resolve_symbol(self, resolved):
+        parent = cast(BaseElement, resolved[0].getparent())  # Safe assumption that this has a parent.
         if self.options.add_group:
-            return Group()
-        return parent
+            group = Group()
+        else:
+            group = parent
+        for child in resolved[0]:
+            group.append(child)
+        if self.options.add_group:
+            parent.replace(resolved[0], group)
+        else:
+            resolved[0].delete()

--- a/templates/unlink_clone.xml
+++ b/templates/unlink_clone.xml
@@ -6,7 +6,7 @@
         <page name="options" gui-text="Options">
             <param name="extension" type="string" gui-hidden="true">unlink_clone</param>
             <param name="recursive" type="boolean" gui-text="Recursive">true</param>
-            <param name="add-group" type="boolean" gui-text="Group unlinked elements">true</param>
+            <param name="add-group" type="boolean" gui-text="Group unlinked symbols">true</param>
         </page>
         <page name="info" gui-text="Help">
             <label>Unlink clones and apply the fill stitch angle.</label>

--- a/templates/unlink_clone.xml
+++ b/templates/unlink_clone.xml
@@ -6,6 +6,7 @@
         <page name="options" gui-text="Options">
             <param name="extension" type="string" gui-hidden="true">unlink_clone</param>
             <param name="recursive" type="boolean" gui-text="Recursive">true</param>
+            <param name="add-group" type="boolean" gui-text="Group unlinked elements">true</param>
         </page>
         <page name="info" gui-text="Help">
             <label>Unlink clones and apply the fill stitch angle.</label>


### PR DESCRIPTION
On user request.

When using a symbol library for patterns, it is useful to unlink directly to a path instead of wrapping it into a group as patterns only apply if the element is within the very same group. This is just saving one push of a shortcut key.