### PR TITLE
Duplicate-consistant autoroute element selection

### DIFF
--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -160,9 +160,11 @@ class Redwork(InkstitchExtension):
     def _insert_element(self, index, path, group, style, transform, redwork=True):
         if redwork:
             path_id = self.svg.get_unique_id('redwork_')
+            path_type = 'redwork-top'
             label = _("Redwork") + f' {index}'
         else:
             path_id = self.svg.get_unique_id('underpath_')
+            path_type = 'redwork-underpath'
             label = _("Redwork Underpath") + f' {index}'
 
         element = PathElement(
@@ -175,6 +177,7 @@ class Redwork(InkstitchExtension):
 
         element.label = label
         element.set('inkstitch:running_stitch_length_mm', self.options.redwork_running_stitch_length_mm)
+        element.set('inkstitch:path_type', path_type)
 
         if redwork:
             element.set('inkstitch:bean_stitch_repeats', self.options.redwork_bean_stitch_repeats)

--- a/lib/extensions/select_elements.py
+++ b/lib/extensions/select_elements.py
@@ -163,9 +163,18 @@ class SelectElements(InkstitchExtension):
         element_id = element.node.get_id() or ''
         conditions = {
             'all': True,
-            'autorun-top': element_id.startswith('autorun') or element_id.startswith('redwork'),
-            'autorun-underpath': element_id.startswith('underpath'),
-            'autosatin-underpath': element_id.startswith('autosatinrun')}
+            'autorun-top': (
+                element_id.startswith('autorun') or  # legacy search, doesn't work when paths have been duplicated within Inkscape
+                element_id.startswith('redwork') or  # legacy search
+                element.node.get('inkstitch:path_type') == 'redwork-top' or
+                element.node.get('inkstitch:path_type') == 'autorun-top'),
+            'autorun-underpath': (
+                element_id.startswith('underpath') or  # legacy search
+                element.node.get('inkstitch:path_type') == 'redwork-underpath' or
+                element.node.get('inkstitch:path_type') == 'autorun-underpath'),
+            'autosatin-underpath': (
+                element_id.startswith('autosatinrun') or  # legacy search
+                element.node.get('inkstitch:path_type') == 'satin-underpath')}
         return conditions[self.options.running_stitch_condition]
 
     def _bean_stitch_repeats(self, element):

--- a/lib/stitches/auto_run.py
+++ b/lib/stitches/auto_run.py
@@ -273,14 +273,17 @@ def create_element(path, position, direction, element):
     if direction == "autorun":
         label = _("AutoRun %d") % index
         dasharray = 'none'
+        path_type = 'autorun-top'
     else:
         label = _("AutoRun Underpath %d") % index
         dasharray = '2 1.1'
+        path_type = 'autorun-underpath'
 
     node = inkex.PathElement()
     node.set("id", generate_unique_id(element.node, el_id))
     node.set(INKSCAPE_LABEL, label)
     node.set("d", path)
+    node.set("inkstitch:path_type", path_type)
     node.set("style", element.node.style)
     node.style["fill"] = 'none'
     node.style["stroke-dasharray"] = dasharray

--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -424,6 +424,8 @@ def _route_single_satin(elements, starting_point, keep_originals):
     stroke_width = convert_stroke_width(satin)
     run_element.node.style['stroke-width'] = stroke_width
 
+    run_element.node.set('inkstitch:path_type', 'satin-underpath')
+
     parent.insert(index, run_element.node)
     if not keep_originals:
         remove_original_elements([satin], True)
@@ -591,6 +593,7 @@ def name_elements(new_elements, preserve_order):
             element.node.set("id", generate_unique_id(element.node, "autosatin"))
         else:
             element.node.set("id", generate_unique_id(element.node, "autosatinrun"))
+            element.node.set("inkstitch:path_type", 'satin-underpath')
 
         if not (preserve_order and INKSCAPE_LABEL in element.node.attrib):
             if isinstance(element, SatinColumn):


### PR DESCRIPTION
When auto-route elements are duplicated within Inkscape, they will change their id. The label is translatable.
So it's best to introduce a specified attribute, so we can easily recognize these elements even after duplication.