### PR TITLE
Redwork: remove command also from selection list

### DIFF
--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -97,7 +97,8 @@ class Redwork(InkstitchExtension):
             if command:
                 # remove command symbol
                 command_group = command.connector.getparent()
-                self.svg.selection.pop(command_group.get_id())
+                if command_group in self.svg.selection:
+                    self.svg.selection.pop(command_group.get_id())
                 command_group.delete()
                 # return the first occurence directly
                 return command.target_point

--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -97,6 +97,7 @@ class Redwork(InkstitchExtension):
             if command:
                 # remove command symbol
                 command_group = command.connector.getparent()
+                self.svg.selection.pop(command_group.get_id())
                 command_group.delete()
                 # return the first occurence directly
                 return command.target_point


### PR DESCRIPTION
We cannot get a parent of an already deleted element - which could mean trouble when the command was last in rendering order.