### PR TITLE
Update update build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -45,7 +45,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp39-cp39-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -84,7 +84,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -117,7 +117,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp312-cp312-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -250,7 +250,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10.x'
+          python-version: '3.11.x'
           architecture: 'x64'
           cache: 'pip'
       - uses: microsoft/setup-msbuild@v2
@@ -355,7 +355,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -424,7 +424,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -445,7 +445,7 @@ jobs:
       - name: download linux64
         uses: actions/download-artifact@v4
         with:
-          name: 'inkstitch-linux64
+          name: 'inkstitch-linux64'
           path: 'artifacts/'
       - name: download linux32
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp39-cp39-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -117,7 +117,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp312-cp312-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,8 +218,10 @@ jobs:
 
           # for signing rpm
           apt-get install -y rpm
-          # test install geos
-          ./bin/build-linux
+      - name: build shapely
+        shell: bash
+        run: |
+          bin/build-linux
       - name: install/build python dependencies
         if: steps.build-venv-cache.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - "v*"
 jobs:
-  linux64-old:
+  linux64:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -73,87 +73,11 @@ jobs:
         run: |
           make dist
         env:
-          BUILD: linux-old
+          BUILD: linux64
           INKSTITCH_GPG_KEY: ${{ secrets.INKSTITCH_GPG_KEY }}
       - uses: actions/upload-artifact@v4
         with:
-          name: inkstitch-linux64-old
-          path: artifacts
-
-  linux64-new:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.x'
-          cache: 'pip'
-      - name: install dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo gem install fpm
-          python -m pip install --upgrade pip
-          python -m pip install wheel
-
-          sudo apt-get install gettext
-
-          # for wxPython
-          sudo apt install libnotify4
-          sudo apt install glib-networking libsdl2-dev libsdl2-2.0-0
-
-          # for PyGObject
-          sudo apt install libgirepository1.0-dev libcairo2-dev
-
-          # for shapely
-          sudo apt install build-essential libgtk-3-dev cmake
-
-          # for sigining
-          sudo apt install rpm
-
-          # for numpy
-          sudo apt install  gfortran libopenblas-dev liblapack-dev pkg-config
-
-          uname -a
-          python --version
-          python -m pip --version
-          python -m pip debug
-
-          python -m pip install pycairo
-          python -m pip install PyGObject==3.50.0
-          python -m pip install numpy --no-binary numpy
-
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
-
-          python -m pip install -r requirements.txt
-          # for networkx
-          python -m pip install pandas
-          python -m pip install pyarrow
-
-          python -m pip install pyinstaller
-
-          echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
-      - name: Tests
-        shell: bash
-        run: |
-          pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
-      - shell: bash
-        run: |
-          make dist
-        env:
-          BUILD: linux-new
-          INKSTITCH_GPG_KEY: ${{ secrets.INKSTITCH_GPG_KEY }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: inkstitch-linux64-new
+          name: inkstitch-linux64
           path: artifacts
 
   linux32:
@@ -305,12 +229,8 @@ jobs:
         shell: bash
         run: |
           echo release_policy="release-signing" >> $GITHUB_ENV
-      - name: Set siging policy to test
-        if: ${{ ! startsWith(github.ref, 'refs/tags/v*') }}
-        shell: bash
-        run: |
-          echo release_policy="test-signing" >> $GITHUB_ENV
       - name: upload-unsigned-exe
+        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
         id: upload-unsigned-exe
         uses: actions/upload-artifact@v4
         with:
@@ -318,6 +238,7 @@ jobs:
           path: |
             dist/inkstitch/bin/inkstitch.exe
       - name: Sign-exe
+        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
         id: Sign-exe
         uses: signpath/github-action-submit-signing-request@v1.1
         with:
@@ -329,6 +250,7 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: 'signed-artifacts'
       - name: Copy signed exe to dist
+        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
         shell: bash
         run: |
             mv  -f signed-artifacts/inkstitch.exe dist/inkstitch/bin/inkstitch.exe
@@ -338,12 +260,14 @@ jobs:
         env:
           BUILD: windows
       - name: upload-unsigned-installer
+        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
         id: upload-unsigned-installer
         uses: actions/upload-artifact@v4
         with:
           name: inkstitch-windows64-installer
           path: artifacts
       - name: Sign-installer
+        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
         id: Sign-installer
         uses: signpath/github-action-submit-signing-request@v1.1
         with:
@@ -518,15 +442,10 @@ jobs:
             echo "prerelease=true" >> $GITHUB_ENV
             echo "title=development build of $branch" >> $GITHUB_ENV
           fi
-      - name: download linux64-old
+      - name: download linux64
         uses: actions/download-artifact@v4
         with:
-          name: 'inkstitch-linux64-old'
-          path: 'artifacts/'
-      - name: download linux64-new
-        uses: actions/download-artifact@v4
-        with:
-          name: 'inkstitch-linux64-new'
+          name: 'inkstitch-linux64
           path: 'artifacts/'
       - name: download linux32
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           make dist
         env:
-          BUILD: linux64
+          BUILD: linux
           INKSTITCH_GPG_KEY: ${{ secrets.INKSTITCH_GPG_KEY }}
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - "v*"
 jobs:
   linux64-old:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +45,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -77,7 +77,7 @@ jobs:
           path: artifacts
 
   linux64-new:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -211,6 +211,7 @@ jobs:
           # for signing rpm
           apt-get install -y rpm
       - name: install/build python dependencies
+        if: steps.build-venv-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           bash bin/build-linux32-venv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
           apt-get install -y libgirepository1.0-dev libcairo2-dev
 
           # for shapely
-          apt-get install -y build-essential libgtk-3-dev libgeos-dev cmake
+          apt-get install -y build-essential libgtk-3-dev cmake
 
           # for numpy
           apt-get install -y libopenblas-dev liblapack-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,7 +424,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [linux32, linux64-old, linux64-new, windows64, macx86, macarm64]
+    needs: [linux32, linux64, windows64, macx86, macarm64]
     if: always()
     steps:
       - name: determine release info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,7 +488,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [linux32, linux64-old, linux64-new, windows32, windows64, macx86, macarm64]
+    needs: [linux32, linux64-old, linux64-new, windows64, macx86, macarm64]
     if: always()
     steps:
       - name: determine release info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,8 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.11.x'
           cache: 'pip'
-      - uses: actions/cache@v4
-        id: geos-build-cache
-        with:
-          path: geos/build
-          key: ${{ runner.os }}-20.04-geos-build-${{ hashFiles('**/bin/build-linux') }}
-          restore-keys: |
-            ${{ runner.os }}-20.04-geos-build-
-
       - name: install dependencies
         shell: bash
         run: |
@@ -43,7 +35,7 @@ jobs:
           sudo apt install libgirepository1.0-dev libcairo2-dev
 
           # for shapely
-          sudo apt install build-essential libgtk-3-dev
+          sudo apt install build-essential libgtk-3-dev cmake
 
           uname -a
           python --version
@@ -63,9 +55,6 @@ jobs:
           python -m pip install pyinstaller
 
           echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
-      - shell: bash
-        run: |
-          bin/build-linux
       - name: Tests
         shell: bash
         run: |
@@ -95,7 +84,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -115,7 +104,7 @@ jobs:
           sudo apt install libgirepository1.0-dev libcairo2-dev
 
           # for shapely
-          sudo apt install build-essential libgtk-3-dev libgeos-dev cmake
+          sudo apt install build-essential libgtk-3-dev cmake
 
           # for sigining
           sudo apt install rpm
@@ -253,127 +242,6 @@ jobs:
         with:
           name: inkstitch-linux32
           path: artifacts
-  windows32:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8.x'
-          architecture: 'x86'
-          cache: 'pip'
-      - uses: actions/cache@v4
-        id: geos-build-cache
-        with:
-          path: geos
-          key: win32-geos-build-${{ hashFiles('**/bin/build-geos-win.cmd') }}
-          restore-keys: |
-            win32-geos-build-
-      - uses: microsoft/setup-msbuild@v2
-      - name: Setup Git for Windows SDK
-        uses: git-for-windows/setup-git-for-windows-sdk@v1.10.0
-        with:
-          flavor: build-installers
-      - name: install dependencies
-        shell: bash
-        run: |
-          git config --system core.longpaths true
-          python -m pip install --upgrade pip
-          python -m pip install wheel
-          # inkex has pillow as a requirement and defaults to the latest release.
-          # for windows we need to pin to the latest possible version for 32 bit
-          python -m pip install pillow==9.5.0
-          # Numpy version for older cpu compatibility
-          python -m pip install numpy==1.23.1
-          pip install wxPython
-          python -m pip install -r requirements.txt
-          # for networkx
-          python -m pip install pandas
-
-          python -m pip install pyinstaller
-
-          echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
-      - name: install geos 32
-        shell: cmd
-        run: |
-          SET BUILD32="1"
-          bin\build-geos-win.cmd
-      - name: Tests
-        shell: bash
-        run: |
-          pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
-      - shell: bash
-        run: |
-          make dist
-        env:
-          BUILD: windows
-      - name: upload-unsigned-exe
-        id: upload-unsigned-exe
-        uses: actions/upload-artifact@v4
-        with:
-          name: inkstitch-windows32-exe
-          path: |
-            dist/inkstitch/bin/inkstitch.exe
-      - name: Set siging policy to release
-        if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
-        shell: bash
-        run: |
-          echo release_policy="release-signing" >> $GITHUB_ENV
-      - name: Set siging policy to test
-        if: ${{ ! startsWith(github.ref, 'refs/tags/v*') }}
-        shell: bash
-        run: |
-          echo release_policy="test-signing" >> $GITHUB_ENV
-      - name: Sign-exe
-        id: Sign-exe
-        uses: signpath/github-action-submit-signing-request@v1.1
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '6b880880-2af8-4cf3-a8e7-1b4977c593df'
-          project-slug: 'inkstitch'
-          signing-policy-slug: '${{ env.release_policy }}'
-          github-artifact-id: '${{ steps.upload-unsigned-exe.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed-artifacts'
-      - name: Copy signed exe to dist
-        shell: bash
-        run: |
-            mv  -f signed-artifacts/inkstitch.exe dist/inkstitch/bin/inkstitch.exe
-      - shell: bash
-        run: |
-          bash bin/build-windows-installer
-        env:
-          BUILD: windows
-      - name: upload-unsigned-installer
-        id: upload-unsigned-installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: inkstitch-windows32-installer
-          path: artifacts
-      - name: Sign-installer
-        id: Sign-installer
-        uses: signpath/github-action-submit-signing-request@v1.1
-        with:
-          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '6b880880-2af8-4cf3-a8e7-1b4977c593df'
-          project-slug: 'inkstitch'
-          signing-policy-slug: '${{ env.release_policy }}'
-          artifact-configuration-slug: 'windows-installer-config'
-          github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
-          wait-for-completion: true
-          output-artifact-directory: 'signed-artifacts'
-      - uses: actions/upload-artifact@v4
-        with:
-          name: inkstitch-windows32
-          path: signed-artifacts
   windows64:
     runs-on: windows-2019
     steps:
@@ -382,16 +250,9 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8.x'
+          python-version: '3.11.x'
           architecture: 'x64'
           cache: 'pip'
-      - uses: actions/cache@v4
-        id: geos-build-cache
-        with:
-          path: geos
-          key: win64-geos-build-${{ hashFiles('**/bin/build-geos-win.cmd') }}
-          restore-keys: |
-            win64-geos-build-
       - uses: microsoft/setup-msbuild@v2
       - name: Setup Git for Windows SDK
         uses: git-for-windows/setup-git-for-windows-sdk@v1.10.0
@@ -412,10 +273,6 @@ jobs:
           python -m pip install pyinstaller
 
           echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
-      - name: install geos 64
-        shell: cmd
-        run: |
-          bin\build-geos-win.cmd
       - name: Tests
         shell: bash
         run: |
@@ -498,7 +355,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.x'
+          python-version: '3.11.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -664,12 +521,6 @@ jobs:
         with:
           name: 'inkstitch-linux32'
           path: 'artifacts/'
-      - name: download windows32
-        uses: actions/download-artifact@v4
-        with:
-          name: 'inkstitch-windows32'
-          path: 'signed-artifacts/'
-        if: always()
       - name: download windows64
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,6 @@ jobs:
           # for signing rpm
           apt-get install -y rpm
       - name: install/build python dependencies
-        if: steps.build-venv-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
           bash bin/build-linux32-venv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
           # for shapely
           sudo apt install build-essential libgtk-3-dev cmake
 
+          # for numpy
+          sudo apt install  gfortran libopenblas-dev liblapack-dev pkg-config
+
           uname -a
           python --version
           python -m pip --version
@@ -44,6 +47,7 @@ jobs:
 
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
+          python -m pip install numpy --no-binary numpy
 
           python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 
@@ -109,6 +113,9 @@ jobs:
           # for sigining
           sudo apt install rpm
 
+          # for numpy
+          sudo apt install  gfortran libopenblas-dev liblapack-dev pkg-config
+
           uname -a
           python --version
           python -m pip --version
@@ -116,6 +123,7 @@ jobs:
 
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
+          python -m pip install numpy --no-binary numpy
 
           python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,6 +218,8 @@ jobs:
 
           # for signing rpm
           apt-get install -y rpm
+          # test install geos
+          ./bin/build-linux
       - name: install/build python dependencies
         if: steps.build-venv-cache.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.x'
+          python-version: '3.9.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -45,7 +45,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.2-cp39-cp39-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -84,7 +84,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.x'
+          python-version: '3.12.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -117,7 +117,7 @@ jobs:
           python -m pip install pycairo
           python -m pip install PyGObject==3.50.0
 
-          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
+          python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxPython-4.2.2-cp312-cp312-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
           # for networkx
@@ -250,7 +250,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.x'
+          python-version: '3.10.x'
           architecture: 'x64'
           cache: 'pip'
       - uses: microsoft/setup-msbuild@v2
@@ -355,7 +355,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.x'
+          python-version: '3.9.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash
@@ -424,7 +424,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11.x'
+          python-version: '3.9.x'
           cache: 'pip'
       - name: install dependencies
         shell: bash

--- a/bin/build-linux
+++ b/bin/build-linux
@@ -4,11 +4,11 @@ set -e
 mkdir $HOME/geos-build
 GEOS_PATH=$HOME/geos-build
 # Downloading geos
-curl -L -O  https://github.com/libgeos/geos/releases/download/3.12.2/geos-3.12.2.tar.bz2
+curl -L -O  https://github.com/libgeos/geos/releases/download/3.13.1/geos-3.13.1.tar.bz2
 
 # uzipping geos into the geos directory
 mkdir -p geos && cd geos
-tar -xf ../geos-3.12.2.tar.bz2 --strip-components=1
+tar -xf ../geos-3.13.1.tar.bz2 --strip-components=1
 # Building geos
 mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX:PATH=$GEOS_PATH -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF ..
 make && make install
@@ -27,6 +27,7 @@ if [ ! -z "$CI" ]; then
 fi
 
 cd ../..
-python -m pip uninstall -y shapely
-python -m pip cache remove shapely
-python -m pip install -v shapely --no-binary shapely
+# disabled for linux32 build to run virtualenv properly
+#python -m pip uninstall -y shapely
+#python -m pip cache remove shapely
+#python -m pip install -v shapely --no-binary shapely

--- a/bin/build-linux
+++ b/bin/build-linux
@@ -31,6 +31,6 @@ cd ../..
 #python -m pip uninstall -y shapely
 #python -m pip cache remove shapely
 #python -m pip install -v shapely --no-binary shapely
-virtualenv/bin/pip uninstall -y shapely
-virtualenv/bin/pip cache remove shapely
-virtualenv/bin/pip install -v shapely
+#virtualenv/bin/pip uninstall -y shapely
+#virtualenv/bin/pip cache remove shapely
+#virtualenv/bin/pip install -v shapely

--- a/bin/build-linux
+++ b/bin/build-linux
@@ -31,3 +31,6 @@ cd ../..
 #python -m pip uninstall -y shapely
 #python -m pip cache remove shapely
 #python -m pip install -v shapely --no-binary shapely
+virtualenv/bin/pip uninstall -y shapely
+virtualenv/bin/pip cache remove shapely
+virtualenv/bin/pip install -v shapely

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -13,8 +13,8 @@ virtualenv/bin/pip install pycairo
 virtualenv/bin/pip install PyGObject==3.50.0
 
 virtualenv/bin/pip install wxPython
-# build and install geos for shapely
-./bin/build-linux
+# install geos for shapely
+virtualenv/bin/pip install -v shapely
 
 virtualenv/bin/pip install -r requirements.txt
 

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -14,10 +14,7 @@ virtualenv/bin/pip install PyGObject==3.50.0
 
 virtualenv/bin/pip install wxPython
 # build and install geos for shapely
-bash bin/build-linux
-virtualenv/bin/pip uninstall -y shapely
-virtualenv/bin/pip cache remove shapely
-virtualenv/bin/pip install -v shapely --no-binary shapely
+./bin/build-linux
 
 virtualenv/bin/pip install -r requirements.txt
 

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -15,6 +15,8 @@ virtualenv/bin/pip install PyGObject==3.50.0
 virtualenv/bin/pip install wxPython
 # build and install geos for shapely
 bash bin/build-linux
+virtualenv/bin/pip uninstall -y shapely
+virtualenv/bin/pip pip cache remove shapely
 virtualenv/bin/pip install -v shapely --no-binary shapely
 
 virtualenv/bin/pip install -r requirements.txt

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -13,8 +13,12 @@ virtualenv/bin/pip install pycairo
 virtualenv/bin/pip install PyGObject==3.50.0
 
 virtualenv/bin/pip install wxPython
-          
+# build and install geos for shapely
+bash bin/build-linux
+virtualenv/bin/pip install -v shapely --no-binary shapely
+
 virtualenv/bin/pip install -r requirements.txt
+
 # for networkx
 virtualenv/bin/pip install pandas
 

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -16,7 +16,7 @@ virtualenv/bin/pip install wxPython
 # build and install geos for shapely
 bash bin/build-linux
 virtualenv/bin/pip uninstall -y shapely
-virtualenv/bin/pip pip cache remove shapely
+virtualenv/bin/pip cache remove shapely
 virtualenv/bin/pip install -v shapely --no-binary shapely
 
 virtualenv/bin/pip install -r requirements.txt

--- a/bin/build-python
+++ b/bin/build-python
@@ -5,15 +5,10 @@ info_year=$( date "+%Y" )
 # PyInstaller v6.x rearranges folder configuration causing broken builds, This re-enables old onedir layout.
 pyinstaller_args+="--contents-directory . "
 
-# We need to use the precompiled bootloader linked with graphical Mac OS X
-# libraries if we develop a GUI application for Mac:
-if [ "$BUILD" = "osx" -o "$BUILD" = "windows" ]; then
-    pyinstaller_args+="--windowed "
-fi
-
 # output useful debugging info that helps us trace library dependency issues
 pyinstaller_args+="--log-level DEBUG "
 
+# Setting up pyinstaller arguments for each OS.
 # This adds bundle identifier in reverse DSN format for macos
 if [ "$BUILD" = "osx" ]; then
     pyinstaller_args+="--osx-bundle-identifier org.inkstitch.app "
@@ -22,18 +17,15 @@ if [ "$BUILD" = "osx" ]; then
         echo "Dev or Local Build"
     else
         bash bin/import-macos-keys
-    python -m PyInstaller $pyinstaller_args inkstitch.py;
     fi
 elif [ "$BUILD" = "linux" ] || [ "$BUILD" = "linux-new" ] || [ "$BUILD" = "linux-old" ]; then
     pyinstaller_args+="--hidden-import gi.repository.Gtk "
     pyinstaller_args+="--add-binary /lib/x86_64-linux-gnu/libcrypt.so.1:. "
     pyinstaller_args+="--add-binary /lib/x86_64-linux-gnu/libnsl.so.1:. "
-    python -m PyInstaller $pyinstaller_args --strip inkstitch.py;
 elif [ "$BUILD" = "linux32" ]; then
     pyinstaller_args+="--hidden-import gi.repository.Gtk "
     pyinstaller_args+="--add-binary /lib/i386-linux-gnu/libcrypt.so.1:. "
     pyinstaller_args+="--add-binary /lib/i386-linux-gnu/libnsl.so.1:. "
-    python -m PyInstaller $pyinstaller_args --strip inkstitch.py;
 elif [ "$BUILD" = "windows" ]; then
 	if [[ "$VERSION" =~ ^v[0-9][.0-9]+$ ]]; then
 		# setting the file and product version for release
@@ -51,9 +43,16 @@ elif [ "$BUILD" = "windows" ]; then
 	sed -i'' 's/1.1.1/'"${VERSION#v}"'/' installer_scripts/file_version_info.txt
 	sed -i'' 's/1234/'"${info_year}"'/' installer_scripts/file_version_info.txt
   	# sets icon to inkstitch.exe
-  pyinstaller_args+="-i images/inkstitch/win/inkstitch.ico "
+	pyinstaller_args+="-i images/inkstitch/win/inkstitch.ico "
 	pyinstaller_args+="--version-file  installer_scripts/file_version_info.txt "
-    python -m PyInstaller $pyinstaller_args inkstitch.py
+fi
+
+# Finally we build for each os with the finalized settings
+if [ "$BUILD" = "osx" -o "$BUILD" = "windows" ]; then
+    pyinstaller_args+="--windowed "
+    python -m PyInstaller $pyinstaller_args inkstitch.py;
+else
+    python -m PyInstaller $pyinstaller_args --strip inkstitch.py;
 fi
 
 # pyinstaller put a whole mess of libraries under dist/inkstitch.  We'd like

--- a/bin/build-python
+++ b/bin/build-python
@@ -18,7 +18,7 @@ if [ "$BUILD" = "osx" ]; then
     else
         bash bin/import-macos-keys
     fi
-elif [ "$BUILD" = "linux" ] || [ "$BUILD" = "linux-new" ] || [ "$BUILD" = "linux-old" ]; then
+elif [ "$BUILD" = "linux" ]; then
     pyinstaller_args+="--hidden-import gi.repository.Gtk "
     pyinstaller_args+="--add-binary /lib/x86_64-linux-gnu/libcrypt.so.1:. "
     pyinstaller_args+="--add-binary /lib/x86_64-linux-gnu/libnsl.so.1:. "

--- a/bin/build-windows-installer
+++ b/bin/build-windows-installer
@@ -11,14 +11,7 @@ copyright_year="#define COPYRIGHT \""${info_year}"\""
 version_block="#define VERSION \""${VERSION}"\""
 sed -i'' -e '/;inkstitch-year/ a\'$'\n'"${copyright_year}"'' win/win_build.iss
 sed -i'' -e '/;inkstitch-version/ a\'$'\n'"${version_block}"'' win/win_build.iss
-# set installer to stop 64bit version to be installed in 32bit Windows
-if [[ ${ARCH} == "64bit" ]]; then
-		echo "64"
-	sed -i'' -e '/;arch-allowed/ a\'$'\n'"ArchitecturesAllowed=x64 arm64"'' win/win_build.iss
-else
-		echo "32"
-	sed -i'' -e '/;arch-allowed/ a\'$'\n'"ArchitecturesAllowed=x86 x64 arm64"'' win/win_build.iss
-fi
+sed -i'' -e '/;arch-allowed/ a\'$'\n'"ArchitecturesAllowed=x64 arm64"'' win/win_build.iss
 
 iscc win/win_build.iss
 mv  win/inkstitch.exe artifacts/inkstitch-${VERSION}-${OS}-${ARCH}.exe
@@ -28,8 +21,13 @@ if [[ -d "../signed-artifacts" ]]; then
 	DIRECTORY="signed-artifacts"
 	echo "Found signed artifacts"
 else
-	DIRECTORY="artifacts"
-	echo "No signed artifacts found, local build"
+	if [[! -d "../signed-artifacts" ]]; then
+		DIRECTORY="signed-artifacts"
+		echo "Created signed artifacts"
+	else
+		DIRECTORY="artifacts"
+		echo "No signed artifacts found, local build"
+	fi
 fi
 
 # The python zipfile command line utility can't handle directories

--- a/bin/build-windows-installer
+++ b/bin/build-windows-installer
@@ -21,7 +21,7 @@ if [[ -d "../signed-artifacts" ]]; then
 	DIRECTORY="signed-artifacts"
 	echo "Found signed artifacts"
 else
-	if [[! -d "../signed-artifacts" ]]; then
+	if [[ ! -d "../signed-artifacts" ]]; then
 		DIRECTORY="signed-artifacts"
 		echo "Created signed artifacts"
 	else


### PR DESCRIPTION
Removed geos source build from most OS builds accept linux32-bit
Removed windows 32-bit build because Inkscape 1.4 support only 64-bit and minimum requirement of windows 8.1
Updated linux-old to ubuntu-22.04 for ubuntu-20.04 will be deprecated and linux-new updated to ubuntu-latest or ubuntu-24.04
Added if conditions to build.yml to set windows signing policy for release or dev build.
Added numpy build from source for linux build to fix issue of broken build due to pyinstaller strip process. 