### PR TITLE
Use get_user_directory by default

### DIFF
--- a/lib/utils/inkscape.py
+++ b/lib/utils/inkscape.py
@@ -10,15 +10,17 @@ from inkex.utils import get_user_directory
 
 
 def guess_inkscape_config_path():
-    if getattr(sys, 'frozen', None):
-        if get_user_directory() is not None:
-            path = split(get_user_directory())[0]
-        else:
-            path = realpath(sys._MEIPASS.split('extensions', 1)[0])
-            if sys.platform == "win32":
-                import win32api
-                # This expands ugly things like EXTENS~1
-                path = win32api.GetLongPathName(path)
+    if get_user_directory() is not None:
+        path = split(get_user_directory())[0]
+    elif getattr(sys, 'frozen', None):
+        path = realpath(sys._MEIPASS.split('extensions', 1)[0])
+        if sys.platform == "win32":
+            import win32api
+            # This expands ugly things like EXTENS~1
+            path = win32api.GetLongPathName(path)
     else:
-        path = expanduser("~/.config/inkscape")
+        if sys.platform == "darwin":
+            path = expanduser("~/Library/Application Support/org.inkscape.Inkscape/config/inkscape")
+        else:
+            path = expanduser("~/.config/inkscape")
     return path


### PR DESCRIPTION
Fixes guess_inkscape_config_path for manual macOS installations (path location has changed).