### PR TITLE
Fix for windows installer

### DIFF
--- a/bin/build-distribution-archives
+++ b/bin/build-distribution-archives
@@ -1,7 +1,6 @@
 VERSION="${VERSION:-$(echo ${GITHUB_REF} | sed -e 's|refs/heads/||' -e 's|refs/tags/||' -e 's|/|-|g')}"
 OS="${BUILD:-$(uname)}"
 ARCH="$(uname -m)"
-mkdir artifacts
 
 if [ "$BUILD" = "osx" ]; then
     cp -a addons icons locales print LICENSE VERSION palettes symbols fonts tiles dbus inx dist/inkstitch.app/Contents/Resources
@@ -104,7 +103,7 @@ if [ "$BUILD" = "windows" ]; then
     fi
 fi
 
-if [ "$BUILD" = "linux" ] || [ "$BUILD" = "linux-new" ] || [ "$BUILD" = "linux-old" ] || [ "$BUILD" = "linux32" ]; then
+if [ "$BUILD" = "linux" ] || [ "$BUILD" = "linux32" ]; then
     if [[ "$VERSION" =~ ^v[0-9][.0-9]+$ ]]; then
         VERSION=${VERSION#v}
     else

--- a/bin/build-python
+++ b/bin/build-python
@@ -63,3 +63,4 @@ shopt -s dotglob
 mkdir dist/bin
 mv dist/inkstitch/* dist/bin
 mv dist/bin dist/inkstitch
+mkdir artifacts

--- a/bin/build-windows-installer
+++ b/bin/build-windows-installer
@@ -2,6 +2,20 @@
 VERSION="${VERSION:-$(echo ${GITHUB_REF} | sed -e 's|refs/heads/||' -e 's|refs/tags/||' -e 's|/|-|g')}"
 OS="${BUILD:-$(uname)}"
 ARCH=$(python -c "import platform; n = platform.architecture()[0]; print(n)")
+# Check for signed directory
+if [[ -d "signed-artifacts" ]]; then
+	DIRECTORY="signed-artifacts"
+	echo "Found signed artifacts"
+else
+	if [[ ! -d "signed-artifacts" ]] && [[ ! -z "${GITHUB_REF}" ]]; then
+		mkdir signed-artifacts
+		DIRECTORY="signed-artifacts"
+		echo "Created signed artifacts"
+	else
+		DIRECTORY="artifacts"
+		echo "No signed artifacts found, local build"
+	fi
+fi
 # Create windows installer
 mkdir win
 cp installer_scripts/template.iss win/win_build.iss
@@ -14,21 +28,10 @@ sed -i'' -e '/;inkstitch-version/ a\'$'\n'"${version_block}"'' win/win_build.iss
 sed -i'' -e '/;arch-allowed/ a\'$'\n'"ArchitecturesAllowed=x64 arm64"'' win/win_build.iss
 
 iscc win/win_build.iss
-mv  win/inkstitch.exe artifacts/inkstitch-${VERSION}-${OS}-${ARCH}.exe
+mv  win/inkstitch.exe ${DIRECTORY}/inkstitch-${VERSION}-${OS}-${ARCH}.exe
 cd dist
 echo "Creating zip"
-if [[ -d "../signed-artifacts" ]]; then
-	DIRECTORY="signed-artifacts"
-	echo "Found signed artifacts"
-else
-	if [[ ! -d "../signed-artifacts" ]]; then
-		DIRECTORY="signed-artifacts"
-		echo "Created signed artifacts"
-	else
-		DIRECTORY="artifacts"
-		echo "No signed artifacts found, local build"
-	fi
-fi
+
 
 # The python zipfile command line utility can't handle directories
 # containing files with UTF-8 names on Windows, so we use 7-zip instead.


### PR DESCRIPTION
Fix build process for windows installer, moved command to create artifacts folder to build-python script, removed references to linux-old and linux-new in build-distribution-archives script