### PR TITLE
Disconnect stroke and fill pull compensation param

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -195,7 +195,7 @@ class Stroke(EmbroideryElement):
         return max(self.get_float_param("zigzag_spacing_mm", 0.4), 0.01)
 
     @property
-    @param('pull_compensation_mm',
+    @param('stroke_pull_compensation_mm',
            _('Pull compensation'),
            tooltip=_('Zigzag stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape. '
                      'This widens the zigzag line width.'),
@@ -206,7 +206,7 @@ class Stroke(EmbroideryElement):
            sort_index=6)
     @cache
     def pull_compensation(self):
-        return self.get_float_param("pull_compensation_mm", 0)
+        return self.get_float_param("stroke_pull_compensation_mm", 0)
 
     @property
     @param('line_count',

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -199,14 +199,14 @@ class Stroke(EmbroideryElement):
            _('Pull compensation'),
            tooltip=_('Zigzag stitches pull the fabric together, resulting in a column narrower than you draw in Inkscape. '
                      'This widens the zigzag line width.'),
-           unit='mm',
+           unit=_('mm (each side)'),
            type='float',
            default=0,
            select_items=[('stroke_method', 'zigzag_stitch')],
            sort_index=6)
     @cache
     def pull_compensation(self):
-        return self.get_float_param("stroke_pull_compensation_mm", 0)
+        return self.get_split_mm_param_as_px("stroke_pull_compensation_mm", (0, 0))
 
     @property
     @param('line_count',

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -379,8 +379,8 @@ def zigzag_stitch(stitches, zigzag_spacing, stroke_width, pull_compensation):
     # of points in turn, and move perpendicular to them,
     # alternating left and right.
 
-    stroke_width = stroke_width + pull_compensation
-    offset = stroke_width / 2.0
+    offset1 = stroke_width / 2 + pull_compensation[0]
+    offset2 = stroke_width / 2 + pull_compensation[1]
 
     for i in range(len(stitches) - 1):
         start = stitches[i]
@@ -393,8 +393,8 @@ def zigzag_stitch(stitches, zigzag_spacing, stroke_width, pull_compensation):
         zigzag_direction = segment_direction.rotate_left()
 
         if i % 2 == 1:
-            zigzag_direction *= -1
-
-        stitches[i] += zigzag_direction * offset
+            stitches[i] += zigzag_direction * -offset1
+        else:
+            stitches[i] += zigzag_direction * offset2
 
     return stitches

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -157,6 +157,7 @@ inkstitch_attribs = [
     'zigzag_underlay_spacing_mm',
     'zigzag_underlay_max_stitch_length_mm',
     'e_stitch',
+    'stroke_pull_compensation_mm',
     'pull_compensation_mm',
     'pull_compensation_percent',
     'stroke_first',

--- a/lib/update.py
+++ b/lib/update.py
@@ -95,6 +95,15 @@ def _update_to(document, version, element):
 
 
 def _update_to_three(document, element):
+    if element.get_param('stroke_method', None) == 'zigzag_stitch':
+        # pull_compensation_mm shares the same attribute with fills and satins.
+        # However the fill and satin param is a sided property, while the stroke property is a simple float.
+        # An element can additionally (not recommended) carry both, a fill and a stroke which may lead to
+        # confusions with this attribute.
+        # So let's establish a specified pull compensation attribute for strokes (in fact this is zigzag only).
+        pull_comp_as_string = element.get_param('pull_compensation_mm', None)
+        if pull_comp_as_string is not None:
+            element.set_param('stroke_pull_compensation_mm', pull_comp_as_string)
     if element.get_boolean_param('satin_column', False):
         element.set_param('start_at_nearest_point', False)
         element.set_param('end_at_nearest_point', False)

--- a/lib/update.py
+++ b/lib/update.py
@@ -97,13 +97,20 @@ def _update_to(document, version, element):
 def _update_to_three(document, element):
     if element.get_param('stroke_method', None) == 'zigzag_stitch':
         # pull_compensation_mm shares the same attribute with fills and satins.
-        # However the fill and satin param is a sided property, while the stroke property is a simple float.
-        # An element can additionally (not recommended) carry both, a fill and a stroke which may lead to
+        # An element can carry both (not recommended), a fill and a stroke which may lead to
         # confusions with this attribute.
         # So let's establish a specified pull compensation attribute for strokes (in fact this is zigzag only).
+        # Get pull compensation as string as we don't want to receive px values
         pull_comp_as_string = element.get_param('pull_compensation_mm', None)
-        if pull_comp_as_string is not None:
-            element.set_param('stroke_pull_compensation_mm', pull_comp_as_string)
+        if pull_comp_as_string not in ['0', None]:
+            # pull compensation for zigzags is now a sided property. Which also means, that it is applied to each side
+            # therefore we need to cut it in half
+            try:
+                pull_comp = float(pull_comp_as_string)
+                pull_comp /= 2
+                element.set_param('stroke_pull_compensation_mm', pull_comp)
+            except ValueError:
+                pass
     if element.get_boolean_param('satin_column', False):
         element.set_param('start_at_nearest_point', False)
         element.set_param('end_at_nearest_point', False)


### PR DESCRIPTION
A object can carry both, a fill and a stroke - although this is not recommended, it doesn't seem right when they share the same pull compensation values.
This also makes the pull compensation for the stroke zigzag stitch a sided property, so it can be used the same way as the one for fill and satins.