### PR TITLE
auto_satin: do not try to add a trim to a deleted element

### DIFF
--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -630,9 +630,12 @@ def add_trims(elements, trim_indices):
     trim_indices = set(trim_indices)
     new_elements = []
     just_trimmed = False
+    just_removed = False
+
     for i, element in enumerate(elements):
         if just_trimmed and isinstance(element, Stroke):
             element.node.delete()
+            just_removed = True
             continue
 
         if i in trim_indices:
@@ -642,9 +645,10 @@ def add_trims(elements, trim_indices):
             just_trimmed = False
 
         new_elements.append(element)
+        just_removed = False
 
     # trim at the end, too
-    if i not in trim_indices:
+    if i not in trim_indices and not just_removed:
         add_commands(element, ["trim"])
 
     return new_elements


### PR DESCRIPTION
When they run auto_satin on a selection of supposed to be satins (but running stitches in reality), we can expect a lot of trim commands (when enabled). Follow up strokes will be removed and the last one possibly as well. When trim commands is enabled, it will always try to add a trim on the last element - which then has been removed. Which will lead to an error on trim insertion.

The original error message points to an other issue earlier in the process, but inkex has improved.

Fixes #1647