### PR TITLE
Fixed "Whether" -> "Wether" typo

### DIFF
--- a/collections/_docs/en/004-003-edit.md
+++ b/collections/_docs/en/004-003-edit.md
@@ -123,5 +123,5 @@ This extension applies transformations (rotate, flip) while also adjusting fill 
 This extension unlinks clones (optionally recursive) and applies fill angle transformations.
 
 * Run `Extensions > Ink/Stitch > Edit > Unlink Clone ...`
-* Choose wether to unlink recursively or not
+* Choose whether to unlink recursively or not
 * Click on Apply

--- a/collections/_docs/en/004-005-lettering.md
+++ b/collections/_docs/en/004-005-lettering.md
@@ -128,9 +128,9 @@ Batch lettering allows to easily create multiple text files.
 
 * **Font name:** The name of the font you wish to use. Have a look at the [font library](/fonts/font-library/) to find a list of available fonts
 * **Scale (%):** Scale value to resize a font. The value will be clamped to the available scale range of the specific font.
-* **Color sort:** Wether multicolor fonts should be color sorted or not
-* **Add trims:** Wether trims should be added or not (never, after each line, word or letter)
-* **Use command symbols:** Wether the trims should be added as command symbols or as a param option (only relevant for svg output)
+* **Color sort:** Whether multicolor fonts should be color sorted or not
+* **Add trims:** Whether trims should be added or not (never, after each line, word or letter)
+* **Use command symbols:** Whether the trims should be added as command symbols or as a param option (only relevant for svg output)
 * **Align Multiline Text:** Define how multiline text should be aligned
 * **Lettering along path: text position:** The text position on the `batch lettering` path
 * **File formats:** Enter a comma separated list of [file formats](/docs/file-formats/#writing)

--- a/collections/_docs/en/004-009-fill-tools.md
+++ b/collections/_docs/en/004-009-fill-tools.md
@@ -68,7 +68,7 @@ Helper method to generate a fill area underneath of all selected elements, optio
 
 ### Settings
 
-* Keep holes: Wether or not the shape should contain holes
+* Keep holes: Whether or not the shape should contain holes
 * Offset: The offset (mm) around the selection
 * Method (round, mitre, bevel): Influences how edges will look like
 * Mitre limit:  Influences how edges will look like

--- a/collections/_docs/en/004-010-satin-tools.md
+++ b/collections/_docs/en/004-010-satin-tools.md
@@ -149,7 +149,7 @@ If you want to understand how this extension works internally, [read this](/tuto
 * Pull compensation (mm): Makes the satin columns wider and will overlap the color sections to avoid gaps
 * Random seed: Change the value to change the appearance of randomized params
 
-* Keep original satin: wether the original satin should be deleted or not
+* Keep original satin: whether the original satin should be deleted or not
 * Adjust underlay per color: applies only when the original satin column has underlays
   * If checked, the underlays will be applied to each color separately, excluding the multicolor sections
   * If unchecked, only the first color will use an underlay, covering the whole area
@@ -218,7 +218,7 @@ Instead of drawing first the two rails and then several rungs, this tool allows 
 * Draw you shape with your prefered pattern style.
 * Select the shape and run `Extensions > Ink/Stitch > Tools: Satin > Zigzag Line to Satin`
   * Select your path style (pattern)
-  * Chose wether the resulting path should be smoothed out or straight lines
+  * Chose whether the resulting path should be smoothed out or straight lines
   * Chose if rungs should be inserted or not. The resulting path will always have the same amount of nodes on both rails.
 
 ### Pattern styles

--- a/collections/_docs/en/004-011-stroke-tools.md
+++ b/collections/_docs/en/004-011-stroke-tools.md
@@ -35,7 +35,7 @@ This works best on evenly spaced satin columns.
 
 1. Select the satin column(s) you want to convert into a running stitch
 2. Run `Extensions > Ink/Stitch > Tools: Stroke > Convert satin to stroke...`
-3. Choose wether you want to keep selected satin column(s) or if you want to replace them
+3. Choose whether you want to keep selected satin column(s) or if you want to replace them
 4. Click apply
 
 
@@ -127,7 +127,7 @@ The main difference to `Autoroute Running Stitch` is that it ensures that paths 
   Sets the [bean stitch number of repeats](/docs/stitches/bean-stitch/) for the top layer stitches (not on underpaths).
 
 * Combine elements: Combine consecutive elements of the same type
-* Keep original paths: wether to delete the original elements or not
+* Keep original paths: whether to delete the original elements or not
 
 ### Start- and end position
 

--- a/collections/_docs/en/004-012-thread-color.md
+++ b/collections/_docs/en/004-012-thread-color.md
@@ -94,7 +94,7 @@ It could also be helpful, if you are wanting to test different color settings. Y
 
 * Run `Extensions > Ink/Stitch > Thread Color Management > Apply Threadlist`
 * Choose a file with the thread color information
-* Define wether the color infomration file has been generated with Ink/Stitch or otherwise.
+* Define whether the color infomration file has been generated with Ink/Stitch or otherwise.
 
   If otherwise: Select the Ink/Stitch color palette to match colors to.
 * Click on Apply

--- a/collections/_tutorial/en/font_creation.md
+++ b/collections/_tutorial/en/font_creation.md
@@ -148,7 +148,7 @@ Ink/Stitch offers a tool for you to create the json file with the correct kernin
    * **AutoRoute Satin**:
       * enabled: Ink/Stitch will generate a reasonable routing for satin columns in your font when used in the lettering tool. [More information about AutoRoute Satin](/docs/satin-tools/#auto-route-satin-columns)
       * disabled: Ink/Stitch will use the glyphs as is. Disable this option, if you took care for the routing in your font by yourself.
-   * **Reversible**: wether your font can be stitched forwards and backwards or only forwards
+   * **Reversible**: whether your font can be stitched forwards and backwards or only forwards
    * **Force letter case**:
       * No: Choose this option if your font contains upper and lower case letters (default).
       * Upper: Choose this option if your font only contains upper case letters.


### PR DESCRIPTION
"Whether" is the correct spelling unless we're talking about castrated rams.