### PR TITLE
Prevent possbile RecursionError for relative lock stitches

### DIFF
--- a/lib/stitch_plan/lock_stitch.py
+++ b/lib/stitch_plan/lock_stitch.py
@@ -98,7 +98,9 @@ class RelativeLock(LockStitchDefinition):
         return lock_stitches
 
     def get_direction_and_length(self, stitches, i=1):
-        if len(stitches) < i+1:
+        if len(stitches) < i+1 or i > 15:
+            # we exceeded the stitch length of the path or tried 15 times already
+            # we don't want to try any longer and return a default value
             return Stitch(1, 0), 0.5
 
         to_previous = stitches[i] - stitches[0]


### PR DESCRIPTION
This is supposed to fix #3690

Without a file hard to verify, but that was a possible sinkhole for recursions.