### PR TITLE
Ensure start and end point for ripple lines

### DIFF
--- a/lib/stitches/ripple_stitch.py
+++ b/lib/stitches/ripple_stitch.py
@@ -106,6 +106,11 @@ def _get_staggered_stitches(stroke, lines, skip_start):
         else:
             # uses the guided fill alforithm to stagger rows of stitches
             points = list(apply_stitches(LineString(line), stitch_length, stroke.staggers, 0.5, i, tolerance).coords)
+
+            # simplifying the path in apply_stitches could have removed the start or end point
+            # we can simply add it again, the minimum stitch length value will take care to remove possible duplicates
+            points = [line[0]] + points + [line[-1]]
+
             stitched_line = [InkstitchPoint(*point) for point in points]
             if should_reverse and stroke.flip_copies:
                 stitched_line.reverse()


### PR DESCRIPTION
Start and end points in a line may have an impact on how a design is rendered in ripple.

![ripple-ends](https://github.com/user-attachments/assets/6cf4be01-2337-4b15-9b0f-f2b8dcb3ecc3)
