### PR TITLE
Lettering: do not warn about fonts without jsons

### DIFF
--- a/lib/gui/lettering/main_panel.py
+++ b/lib/gui/lettering/main_panel.py
@@ -115,7 +115,7 @@ class LetteringPanel(wx.Panel):
     @property
     @cache
     def font_list(self):
-        return get_font_list()
+        return get_font_list(False)
 
     def update_font_list(self):
         self.fonts = {}

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -79,20 +79,22 @@ class Font(object):
       variants -- A dict of FontVariants, with keys in FontVariant.VARIANT_TYPES.
     """
 
-    def __init__(self, font_path):
+    def __init__(self, font_path, show_font_path_warning):
         self.path = font_path
         self.metadata = {}
         self.license = None
         self.variants = {}
 
-        self._load_metadata()
+        self._load_metadata(show_font_path_warning)
         self._load_license()
 
-    def _load_metadata(self):
+    def _load_metadata(self, show_font_path_warning=True):
         try:
             with open(os.path.join(self.path, "font.json"), encoding="utf-8-sig") as metadata_file:
                 self.metadata = json.load(metadata_file)
         except IOError:
+            if not show_font_path_warning:
+                return
             path = os.path.join(self.path, "font.json")
             msg = _("JSON file missing. Expected a JSON file at the following location:")
             msg += f"\n{path}\n\n"
@@ -100,6 +102,8 @@ class Font(object):
             msg += '\n\n'
             inkex.errormsg(msg)
         except json.decoder.JSONDecodeError as exception:
+            if not show_font_path_warning:
+                return
             path = os.path.join(self.path, "font.json")
             msg = _("Corrupt JSON file")
             msg += f" ({exception}):\n{path}\n\n"

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -79,7 +79,7 @@ class Font(object):
       variants -- A dict of FontVariants, with keys in FontVariant.VARIANT_TYPES.
     """
 
-    def __init__(self, font_path, show_font_path_warning):
+    def __init__(self, font_path, show_font_path_warning=True):
         self.path = font_path
         self.metadata = {}
         self.license = None

--- a/lib/lettering/utils.py
+++ b/lib/lettering/utils.py
@@ -10,7 +10,7 @@ from ..lettering import Font
 from ..utils import get_bundled_dir, get_user_dir
 
 
-def get_font_list():
+def get_font_list(show_font_path_warning=True):
     font_paths = get_font_paths()
 
     fonts = []
@@ -21,7 +21,7 @@ def get_font_list():
             continue
 
         for font_dir in font_dirs:
-            font = _get_font_from_path(font_path, font_dir)
+            font = _get_font_from_path(font_path, font_dir, show_font_path_warning)
             if not font or font.marked_custom_font_name == "" or font.marked_custom_font_id == "":
                 continue
             fonts.append(font)
@@ -66,7 +66,7 @@ def get_font_by_name(font_name):
     return None
 
 
-def _get_font_from_path(font_path, font_dir):
+def _get_font_from_path(font_path, font_dir, show_font_path_warning=True):
     if not os.path.isdir(os.path.join(font_path, font_dir)) or font_dir.startswith('.'):
         return
-    return Font(os.path.join(font_path, font_dir))
+    return Font(os.path.join(font_path, font_dir), show_font_path_warning)


### PR DESCRIPTION
The warnings will still be seen when using tools from font management extensions. But they shouldn't disrupt the lettering tool usage.

Fixes #3761