### PR TITLE
Smoothing and clamping

### DIFF
--- a/lib/utils/clamp_path.py
+++ b/lib/utils/clamp_path.py
@@ -106,16 +106,16 @@ def clamp_path_to_polygon(path, polygon):
     except FloatingPointError:
         return path
 
-    if len(split_path.geoms) == 1:
+    # contains() checks can fail without the buffer.
+    buffered_polygon = prep(polygon.buffer(1e-9))
+
+    if len(split_path.geoms) == 1 and buffered_polygon.contains(split_path.geoms[0]):
         # The path never intersects with the polygon, so it's entirely inside.
         return path
 
     # Add the start and end points to avoid losing part of the path if the
     # start or end coincides with the polygon boundary
     split_path = [ShapelyPoint(start), *split_path.geoms, ShapelyPoint(end)]
-
-    # contains() checks can fail without the buffer.
-    buffered_polygon = prep(polygon.buffer(1e-9))
 
     last_point_inside = None
     was_inside = False

--- a/lib/utils/smoothing.py
+++ b/lib/utils/smoothing.py
@@ -57,4 +57,8 @@ def smooth_path(path, smoothness=1.0, iterations=5):
         r[-1] = ll[-1]
         points = ll * 0.75 + r * 0.25
 
-    return [Point(*coord) for coord in points]
+    # we want to keep the old start and end points
+    start = [Point(* path[0])]
+    end = [Point(* path[-1])]
+
+    return start + [Point(*coord) for coord in points] + end


### PR DESCRIPTION
Smoothing may lead to a path completely outside of the shape. And clamp didn't recognize it, because it thought it was entirely within the shape.