### PR TITLE
Fix Bluenesia name

### DIFF
--- a/fonts/bluenesia_satin/font.json
+++ b/fonts/bluenesia_satin/font.json
@@ -1,5 +1,5 @@
 {
-    "name": "Bluenesia 72",
+    "name": "Bluenesia Satin",
     "description": "A Syafrizal a.k.a. Khurasan jawn. 3.5mm satin at 100%, splits at higher sizes.",
     "keywords": [
         "sans_serif",


### PR DESCRIPTION
Despite the fact that I apparently spelled it "Bluesia" in the commit, this actually changes the display name "Bluenesia-72" to "Bluenesia-Satin" so it matches its preview image. (The satin version is based on the TTF at 72-point, and should appear that way at 100%, so I name fonts that way during digitization.) 