### PR TITLE
Claudine/chose glyphs size

### DIFF
--- a/lib/extensions/lettering_generate_json.py
+++ b/lib/extensions/lettering_generate_json.py
@@ -42,6 +42,7 @@ class LetteringGenerateJson(InkstitchExtension):
         self.arg_parser.add_argument("-w", "--word-spacing", type=int, default=20, dest="word_spacing")
         self.arg_parser.add_argument("-b", "--letter-spacing", type=int, default=100, dest="letter_spacing")
         self.arg_parser.add_argument("-p", "--font-file", type=str, default="", dest="path")
+        self.arg_parser.add_argument("-e", "--scale", type=float, default="1.0", dest="scale")
 
         for category in FONT_CATEGORIES:
             self.arg_parser.add_argument(f"--{category.id}", type=Boolean, default="false", dest=category.id)

--- a/lib/extensions/lettering_generate_json.py
+++ b/lib/extensions/lettering_generate_json.py
@@ -42,7 +42,6 @@ class LetteringGenerateJson(InkstitchExtension):
         self.arg_parser.add_argument("-w", "--word-spacing", type=int, default=20, dest="word_spacing")
         self.arg_parser.add_argument("-b", "--letter-spacing", type=int, default=100, dest="letter_spacing")
         self.arg_parser.add_argument("-p", "--font-file", type=str, default="", dest="path")
-        self.arg_parser.add_argument("-e", "--scale", type=float, default="1.0", dest="scale")
 
         for category in FONT_CATEGORIES:
             self.arg_parser.add_argument(f"--{category.id}", type=Boolean, default="false", dest=category.id)

--- a/lib/extensions/lettering_svg_font_to_layers.py
+++ b/lib/extensions/lettering_svg_font_to_layers.py
@@ -109,7 +109,6 @@ class LetteringSvgFontToLayers(InkstitchExtension):
                 path = glyph.path
                 return path.bounding_box().height
                 break
-        return errormsg("reference glyph not found")
 
     def set_view_port(self, font, scale_by) -> float:
         """
@@ -200,7 +199,11 @@ class LetteringSvgFontToLayers(InkstitchExtension):
         if font is None:
             return errormsg("There are no svg fonts")
 
-        scale_by = self.options.height * PIXELS_PER_MM / self.reference_size(font, self.options.reference)
+        reference_size = self.reference_size(font, self.options.reference)
+        if reference_size is None:
+            return errormsg("Reference glyph not found in the font")
+
+        scale_by = self.options.height * PIXELS_PER_MM / reference_size
         emsize = self.set_view_port(font, scale_by)
         baseline = self.set_guide_lines(font, scale_by)
 

--- a/lib/extensions/lettering_svg_font_to_layers.py
+++ b/lib/extensions/lettering_svg_font_to_layers.py
@@ -19,7 +19,7 @@
 #
 #
 # Adapted for the inkstitch lettering module to allow glyph annotations for characters
-# in specific positions or settings. Changes: see git history
+# in specific positions or settings, also allows scaling.Changes: see git history
 """Extension for converting svg fonts to layers"""
 
 from inkex import Layer, PathElement, errormsg
@@ -30,9 +30,37 @@ from ..svg import PIXELS_PER_MM
 
 
 class LetteringSvgFontToLayers(InkstitchExtension):
-    """Convert an svg font to layers"""
+    """
+    An Ink/Stitch extension for converting SVG font glyphs into separate layers.
+    This extension processes an SVG font embedded in an SVG document, scaling and converting each glyph into its own layer for
+    further manipulation or embroidery digitization. It provides options to control the number of glyphs processed,
+    the reference character for scaling, and the desired reference height in millimeters.
+    Attributes:
+        None explicitly defined.
+    Methods:
+        add_arguments(pars):
+            Adds command-line arguments for glyph count, reference character, and reference height.
+        scale_hkerning(scale_by):
+        flip_cordinate_system(elem, emsize, baseline, scale_by):
+            Scales and translates the element's path to match the desired coordinate system.
+        reference_size(font, reference):
+        set_view_port(font, scale_by):
+            Sets the SVG viewport size and viewBox based on the scaled em size, return the width (= height) of the viewport
+        set_guide_lines(font, scale_by):
+            Adds guide lines for baseline, ascender, caps, x-height, and descender to the SVG. Return the baseline position
+        convert_glyph_to_layer(glyph, emsize, baseline, scale_by, hide_layer):
+            Converts a single glyph into a new SVG layer, applying scaling and coordinate transformation.
+        effect():
+            Main entry point for the extension. Processes the SVG font, scales glyphs, creates layers, and applies kerning scaling.
 
-    def add_arguments(self, pars):
+    Usage:
+        This extension is intended to be used within the Ink/Stitch environment as a command-line or GUI extension for converting
+        SVG font glyphs into layers suitable for embroidery design.
+    """
+
+    def add_arguments(self, pars) -> None:
+        """ Adds command-line arguments for glyph count, reference character, and reference height.
+        """
         pars.add_argument(
             "--count",
             type=int,
@@ -51,110 +79,92 @@ class LetteringSvgFontToLayers(InkstitchExtension):
             default=20.0,
             help="Reference character height in mm"
         )
-    def scale_kerning(self, scale_by):
-        
+
+    def scale_hkerning(self, scale_by) -> None:
+        """
+         Scales all horizontal kerning (hkern) values in the font by the given factor.
+        """
         font = self.svg.defs.findone("svg:font")
         for hkern in font.findall("svg:hkern"):
-            import sys
             k = hkern.get("k", None)
-         #   print(f"hkern=", "k=",file=sys.stderr)
             if k is not None:
-                k = float(k) * scale_by
+                k = round(float(k) * scale_by, 2)
                 hkern.set(("k"), str(k))
 
-
-    def flip_cordinate_system(self, elem, emsize, baseline,scale_by):
-        """Scale and translate the element's path, returns the path object"""
+    def flip_cordinate_system(self, elem, emsize, baseline, scale_by):
+        """
+        Scale and translate the element's path, returns the path object
+        """
         path = elem.path
         path.scale(scale_by, -scale_by, inplace=True)
         path.translate(0, float(emsize) - float(baseline), inplace=True)
         return path
-    
-    def reference_size(self,font, reference):
-       
+
+    def reference_size(self, font, reference):
+        """
+        Returns the height of the reference glyph used for scaling.
+        """
         for glyph in font.findall("svg:glyph"):
             if glyph.get("glyph-name") == str(reference):
                 path = glyph.path
-                import sys
-               # return errormsg(f" trouve le M et {path = }  {path.bounding_box().height=}")
                 return path.bounding_box().height
                 break
         return errormsg("reference glyph not found")
-              
-            
 
-    def effect(self):
-      
-        # Current code only reads the first svgfont instance
-        font = self.svg.defs.findone("svg:font")
-        if font is None:
-            return errormsg("There are no svg fonts")
-        # setwidth = font.get("horiz-adv-x")
-        size  =self.reference_size(font, self.options.reference)
-        
-        scale_by = self.options.height* PIXELS_PER_MM/ size
+    def set_view_port(self, font, scale_by) -> float:
+        """
+        Sets the SVG viewport size and viewBox based on the scaled em size, return the width (= height) of the viewport
+        """
+        fontface = font.findone("svg:font-face")
+
+        emsize = fontface.get("units-per-em")
+        emsize = round(float(emsize) * scale_by, 2)
+        fontface.set("units-per-em", str(emsize))
+
+        self.svg.set("width", str(emsize))
+        self.svg.set("height", str(emsize))
+        self.svg.set("viewBox", "0 0 " + str(emsize) + " " + str(emsize))
+        return emsize
+
+    def set_guide_lines(self, font, scale_by) -> float:
+        """
+        Adds guide lines for baseline, ascender, caps, x-height, and descender to the SVG. Return the baseline position_
+        """
+
         baseline = font.get("horiz-origin-y")
-        # import sys
-        # print(f"{Msize =}", file=sys.stderr)
+        horiz_adv_x = round(float(font.get("horiz-adv-x", 0)) * scale_by, 2)
+        font.set("horiz-adv-x", str(horiz_adv_x))
+
+        fontface = font.findone("svg:font-face")
         if baseline is None:
             baseline = 0
         else:
             baseline = float(baseline) * scale_by
 
-        
-        fontface = font.findone("svg:font-face")
-        emsize = fontface.get("units-per-em") 
-        emsize = float(emsize) * scale_by
-        self.svg.set("width", str(emsize))
-        self.svg.set("height", str(emsize))
-        self.svg.set("viewBox", "0 0 " + str(emsize) + " " + str(emsize))
-       
         guidebase = (self.svg.viewbox_height) - float(baseline)
 
+        caps = round(float(fontface.get("cap-height", 0)) * scale_by, 2)
+        xheight = round(float(fontface.get("x-height", 0)) * scale_by, 2)
+        ascender = round(float(fontface.get("ascent", 0)) * scale_by, 2)
+        descender = round(float(fontface.get("descent", 0)) * scale_by, 2)
 
-        caps = float(fontface.get("cap-height", 0)) * scale_by  
-        xheight = float(fontface.get("x-height", 0)) * scale_by
-        ascender = float(fontface.get("ascent", 0)) * scale_by
-        descender = float(fontface.get("descent", 0)) * scale_by
-
-        fontface.set("cap-height",str(caps))
+        fontface.set("cap-height", str(caps))
         fontface.set("x-height", str(xheight))
         fontface.set("ascent", str(ascender))
         fontface.set("descent", str(descender))
 
-       
-
-        
         self.svg.namedview.add_guide(guidebase, True, "baseline")
         self.svg.namedview.add_guide(guidebase - ascender, True, "ascender")
         self.svg.namedview.add_guide(guidebase - caps, True, "caps")
         self.svg.namedview.add_guide(guidebase - xheight, True, "xheight")
         self.svg.namedview.add_guide(guidebase - descender, True, "decender")
-      
 
-        
-        count = 0
-        for glyph in font.findall("svg:glyph"):
-            hide_layer = count != 0
-            hax = glyph.get("horiz-adv-x", None)
-            if hax is not None:
-                hax = float(hax) * scale_by
-                glyph.set(("horiz-adv-x"), str(hax))
-            self.convert_glyph_to_layer(glyph, emsize, baseline, scale_by,hide_layer=hide_layer)
-            count += 1
-            if count >= self.options.count:
-                break
-        
-        self.scale_kerning(scale_by)
-        
-                
-
-
-       
-        
-        
+        return baseline
 
     def convert_glyph_to_layer(self, glyph, emsize, baseline, scale_by, hide_layer):
+        """
+        Converts a single glyph into a new SVG layer, applying scaling and coordinate transformation.
+        """
         unicode_char = glyph.get("unicode")
 
         glyph_name = glyph.get("glyph-name").split('.')
@@ -183,6 +193,30 @@ class LetteringSvgFontToLayers(InkstitchExtension):
         # Using curve description in d attribute of svg:glyph
         path = layer.add(PathElement())
         path.path = self.flip_cordinate_system(glyph, emsize, baseline, scale_by)
+
+    def effect(self) -> None:
+        # Current code only reads the first svgfont instance
+        font = self.svg.defs.findone("svg:font")
+        if font is None:
+            return errormsg("There are no svg fonts")
+
+        scale_by = self.options.height * PIXELS_PER_MM / self.reference_size(font, self.options.reference)
+        emsize = self.set_view_port(font, scale_by)
+        baseline = self.set_guide_lines(font, scale_by)
+
+        count = 0
+        for glyph in font.findall("svg:glyph"):
+            hide_layer = count != 0
+            hax = glyph.get("horiz-adv-x", None)
+            if hax is not None:
+                hax = float(hax) * scale_by
+                glyph.set(("horiz-adv-x"), str(hax))
+            self.convert_glyph_to_layer(glyph, emsize, baseline, scale_by, hide_layer=hide_layer)
+            count += 1
+            if count >= self.options.count:
+                break
+
+        self.scale_hkerning(scale_by)
 
 
 if __name__ == "__main__":

--- a/lib/extensions/lettering_svg_font_to_layers.py
+++ b/lib/extensions/lettering_svg_font_to_layers.py
@@ -43,26 +43,23 @@ class LetteringSvgFontToLayers(InkstitchExtension):
             default=1.0,
             help="Scale the font (1 = no scaling)"
         )
-    def create_horizontal_guideline(self, name: str, position):
-        """Create a horizontal guideline with name and position
+    def scale_kerning(self):
+        scale_by = self.options.scale
+        font = self.svg.defs.findone("svg:font")
+        for hkern in font.findall("svg:hkern"):
+            import sys
+            k = hkern.get("k", None)
+         #   print(f"hkern=", "k=",file=sys.stderr)
+            if k is not None:
+                k = float(k) * scale_by
+                hkern.set(("k"), str(k))
 
-        Args:
-            name (str): the name of the guideline
-            position (Union[int, float]): the vertical position of the guideline
-
-        Returns:
-            inkex.BaseElement: the created guideline
-        """
-        return self.svg.namedview.add_guide(
-            self.svg.height - position, True, name
-         #    self.svg.viewbox_height - position, True, name
-        )
 
     def flip_cordinate_system(self, elem, emsize, baseline):
         """Scale and translate the element's path, returns the path object"""
         path = elem.path
         path.scale(self.options.scale, -self.options.scale, inplace=True)
-        path.translate(0, int(emsize) - int(baseline), inplace=True)
+        path.translate(0, float(emsize) - float(baseline), inplace=True)
         return path
 
     def effect(self):
@@ -73,13 +70,14 @@ class LetteringSvgFontToLayers(InkstitchExtension):
             return errormsg("There are no svg fonts")
         # setwidth = font.get("horiz-adv-x")
         baseline = font.get("horiz-origin-y")
+        import sys
+       # print("baseline: ",baseline, file=sys.stderr  )
         if baseline is None:
             baseline = 0
         else:
-            baseline = baseline * scale_by
+            baseline = float(baseline) * scale_by
 
-        guidebase = (self.svg.viewbox_height * scale_by) - baseline
-
+        
         fontface = font.findone("svg:font-face")
 
         emsize = fontface.get("units-per-em") 
@@ -87,12 +85,15 @@ class LetteringSvgFontToLayers(InkstitchExtension):
         self.svg.set("width", str(emsize))
         self.svg.set("height", str(emsize))
         self.svg.set("viewBox", "0 0 " + str(emsize) + " " + str(emsize))
+       
+        guidebase = (self.svg.viewbox_height) - float(baseline)
 
-        # TODO: should we guarantee that <svg:font horiz-adv-x> equals <svg:font-face units-per-em> ?
+
         caps = float(fontface.get("cap-height", 0)) * scale_by  
         xheight = float(fontface.get("x-height", 0)) * scale_by
         ascender = float(fontface.get("ascent", 0)) * scale_by
         descender = float(fontface.get("descent", 0)) * scale_by
+
         fontface.set("cap-height",str(caps))
         fontface.set("x-height", str(xheight))
         fontface.set("ascent", str(ascender))
@@ -100,24 +101,15 @@ class LetteringSvgFontToLayers(InkstitchExtension):
 
        
 
-        baseline = descender
-        # Create guidelines
-        self.create_horizontal_guideline(_("baseline"), baseline)
-        self.create_horizontal_guideline(_("ascender"), baseline + ascender)
-        self.create_horizontal_guideline(_("caps"), baseline + caps)
-        self.create_horizontal_guideline(_("xheight"), baseline + xheight)
-        self.create_horizontal_guideline(_("descender"), baseline - descender)
+        
+        self.svg.namedview.add_guide(guidebase, True, "baseline")
+        self.svg.namedview.add_guide(guidebase - ascender, True, "ascender")
+        self.svg.namedview.add_guide(guidebase - caps, True, "caps")
+        self.svg.namedview.add_guide(guidebase - xheight, True, "xheight")
+        self.svg.namedview.add_guide(guidebase - descender, True, "decender")
       
 
-        namedview = self.svg.namedview
-        namedview.set("inkscape:document-units", "px")
-        namedview.set("inkscape:cx", str(emsize / 2.0))
-        namedview.set("inkscape:cy", str(emsize / 2.0))
-       # self.svg.namedview.add_guide(guidebase, True, "baseline")
-        # self.svg.namedview.add_guide(guidebase - ascender, True, "ascender")
-        # self.svg.namedview.add_guide(guidebase - caps, True, "caps")
-        # self.svg.namedview.add_guide(guidebase - xheight, True, "xheight")
-        # self.svg.namedview.add_guide(guidebase + descender, True, "decender")
+        
         count = 0
         for glyph in font.findall("svg:glyph"):
             hide_layer = count != 0
@@ -129,6 +121,10 @@ class LetteringSvgFontToLayers(InkstitchExtension):
             count += 1
             if count >= self.options.count:
                 break
+        
+        self.scale_kerning()
+        
+                
 
 
        
@@ -157,7 +153,7 @@ class LetteringSvgFontToLayers(InkstitchExtension):
 
         layer = self.svg.add(Layer.new(f"GlyphLayer-{unicode_char}{typographic_feature}"))
 
-        # glyph layers (except the first one) are innitially hidden
+        # glyph layers (except the first one) are initially hidden
         if hide_layer:
             layer.style["display"] = "none"
 

--- a/lib/extensions/lettering_svg_font_to_layers.py
+++ b/lib/extensions/lettering_svg_font_to_layers.py
@@ -34,18 +34,39 @@ class LetteringSvgFontToLayers(InkstitchExtension):
         pars.add_argument(
             "--count",
             type=int,
-            default=30,
-            help="Stop making layers after this number of glyphs.",
+            default=150,
+            help="Stop making layers after this number of glyphs."
+        )
+        pars.add_argument(
+            "--scale",
+            type=float,
+            default=1.0,
+            help="Scale the font (1 = no scaling)"
+        )
+    def create_horizontal_guideline(self, name: str, position):
+        """Create a horizontal guideline with name and position
+
+        Args:
+            name (str): the name of the guideline
+            position (Union[int, float]): the vertical position of the guideline
+
+        Returns:
+            inkex.BaseElement: the created guideline
+        """
+        return self.svg.namedview.add_guide(
+            self.svg.height - position, True, name
+         #    self.svg.viewbox_height - position, True, name
         )
 
     def flip_cordinate_system(self, elem, emsize, baseline):
         """Scale and translate the element's path, returns the path object"""
         path = elem.path
-        path.scale(1, -1, inplace=True)
+        path.scale(self.options.scale, -self.options.scale, inplace=True)
         path.translate(0, int(emsize) - int(baseline), inplace=True)
         return path
 
     def effect(self):
+        scale_by = self.options.scale
         # Current code only reads the first svgfont instance
         font = self.svg.defs.findone("svg:font")
         if font is None:
@@ -54,33 +75,65 @@ class LetteringSvgFontToLayers(InkstitchExtension):
         baseline = font.get("horiz-origin-y")
         if baseline is None:
             baseline = 0
+        else:
+            baseline = baseline * scale_by
 
-        guidebase = self.svg.viewbox_height - baseline
+        guidebase = (self.svg.viewbox_height * scale_by) - baseline
 
         fontface = font.findone("svg:font-face")
 
-        emsize = fontface.get("units-per-em")
+        emsize = fontface.get("units-per-em") 
+        emsize = float(emsize) * scale_by
+        self.svg.set("width", str(emsize))
+        self.svg.set("height", str(emsize))
+        self.svg.set("viewBox", "0 0 " + str(emsize) + " " + str(emsize))
 
         # TODO: should we guarantee that <svg:font horiz-adv-x> equals <svg:font-face units-per-em> ?
-        caps = float(fontface.get("cap-height", 0))
-        xheight = float(fontface.get("x-height", 0))
-        ascender = float(fontface.get("ascent", 0))
-        descender = float(fontface.get("descent", 0))
+        caps = float(fontface.get("cap-height", 0)) * scale_by  
+        xheight = float(fontface.get("x-height", 0)) * scale_by
+        ascender = float(fontface.get("ascent", 0)) * scale_by
+        descender = float(fontface.get("descent", 0)) * scale_by
+        fontface.set("cap-height",str(caps))
+        fontface.set("x-height", str(xheight))
+        fontface.set("ascent", str(ascender))
+        fontface.set("descent", str(descender))
 
-        self.svg.set("width", emsize)
-        self.svg.namedview.add_guide(guidebase, True, "baseline")
-        self.svg.namedview.add_guide(guidebase - ascender, True, "ascender")
-        self.svg.namedview.add_guide(guidebase - caps, True, "caps")
-        self.svg.namedview.add_guide(guidebase - xheight, True, "xheight")
-        self.svg.namedview.add_guide(guidebase + descender, True, "decender")
+       
 
+        baseline = descender
+        # Create guidelines
+        self.create_horizontal_guideline(_("baseline"), baseline)
+        self.create_horizontal_guideline(_("ascender"), baseline + ascender)
+        self.create_horizontal_guideline(_("caps"), baseline + caps)
+        self.create_horizontal_guideline(_("xheight"), baseline + xheight)
+        self.create_horizontal_guideline(_("descender"), baseline - descender)
+      
+
+        namedview = self.svg.namedview
+        namedview.set("inkscape:document-units", "px")
+        namedview.set("inkscape:cx", str(emsize / 2.0))
+        namedview.set("inkscape:cy", str(emsize / 2.0))
+       # self.svg.namedview.add_guide(guidebase, True, "baseline")
+        # self.svg.namedview.add_guide(guidebase - ascender, True, "ascender")
+        # self.svg.namedview.add_guide(guidebase - caps, True, "caps")
+        # self.svg.namedview.add_guide(guidebase - xheight, True, "xheight")
+        # self.svg.namedview.add_guide(guidebase + descender, True, "decender")
         count = 0
         for glyph in font.findall("svg:glyph"):
             hide_layer = count != 0
+            hax = glyph.get("horiz-adv-x", None)
+            if hax is not None:
+                hax = float(hax) * scale_by
+                glyph.set(("horiz-adv-x"), str(hax))
             self.convert_glyph_to_layer(glyph, emsize, baseline, hide_layer=hide_layer)
             count += 1
             if count >= self.options.count:
                 break
+
+
+       
+        
+        
 
     def convert_glyph_to_layer(self, glyph, emsize, baseline, hide_layer):
         unicode_char = glyph.get("unicode")

--- a/lib/extensions/lettering_svg_font_to_layers.py
+++ b/lib/extensions/lettering_svg_font_to_layers.py
@@ -209,7 +209,7 @@ class LetteringSvgFontToLayers(InkstitchExtension):
             hide_layer = count != 0
             hax = glyph.get("horiz-adv-x", None)
             if hax is not None:
-                hax = float(hax) * scale_by
+                hax = round(float(hax) * scale_by, 2)
                 glyph.set(("horiz-adv-x"), str(hax))
             self.convert_glyph_to_layer(glyph, emsize, baseline, scale_by, hide_layer=hide_layer)
             count += 1

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -19,6 +19,7 @@
 
         <param type="string" name="font-name" gui-text="Name" indent="1" />
         <param type="string" name="font-description" gui-text="Description" indent="1" />
+        
         <param name="default_variant" type="optiongroup" appearance="combo" gui-text="Default variant" indent="1">
              <option value="0" translatable="no">→</option>
              <option value="1" translatable="no">←</option>

--- a/templates/lettering_svg_font_to_layers.xml
+++ b/templates/lettering_svg_font_to_layers.xml
@@ -3,7 +3,8 @@
   <name>Convert SVG Font to Glyph Layers</name>
   <id>org.{{ id_inkstitch }}.lettering_svg_font_to_layers</id>
   <param name="extension" type="string" gui-hidden="true">lettering_svg_font_to_layers</param>
-  <param name="count" type="int" min="1" max="65535" gui-text="Stop after">100</param>
+  <param name="count" type="int" min="1" max="65535" gui-text="Stop after">150</param>
+  <param name="scale" type="float" min="0.01" max="100" gui-text="Scale">1.00</param>
 
   <effect needs-live-preview="false">
     <object-type>all</object-type>

--- a/templates/lettering_svg_font_to_layers.xml
+++ b/templates/lettering_svg_font_to_layers.xml
@@ -4,7 +4,8 @@
   <id>org.{{ id_inkstitch }}.lettering_svg_font_to_layers</id>
   <param name="extension" type="string" gui-hidden="true">lettering_svg_font_to_layers</param>
   <param name="count" type="int" min="1" max="65535" gui-text="Stop after">150</param>
-  <param name="scale" type="float" min="0.01" max="100" gui-text="Scale">1.00</param>
+  <param name="reference" type="string"  gui-text="Use this  character to define size">M</param>
+  <param name="height" type="float" min="1" max="1000" gui-text="Height of reference character (mm)">20</param>
 
   <effect needs-live-preview="false">
     <object-type>all</object-type>


### PR DESCRIPTION
This modifies the Font Management > Convert svg font to glyph layers to allow the user to specify a target height for a chosen letter. For instance, one can choose to have M 25 mm tall. 
This avoids resizing the font in fontforge, as fontforge is not good at that and often yields deformed glyphs