### PR TITLE
Claudine/unable element info copy

### DIFF
--- a/lib/extensions/element_info.py
+++ b/lib/extensions/element_info.py
@@ -37,8 +37,6 @@ class ElementInfo(InkstitchExtension):
             text_export, previous_stitch_group = self._element_info(element, previous_stitch_group, next_element)
             self.export_txt += text_export
         self._general_info()
-        import sys
-        print(self.export_txt, file= sys.stderr)
         app = ElementInfoApp(self.list_items, self.export_txt)
         app.MainLoop()
 

--- a/lib/extensions/element_info.py
+++ b/lib/extensions/element_info.py
@@ -26,9 +26,9 @@ class ElementInfo(InkstitchExtension):
         self.metadata = self.get_inkstitch_metadata()
         self.list_items = []
         self.max_stitch_lengths = []
-        self.min_stitch_lengths = []  
-        self.export_txt =  f"element_id \t type \t method  \t dimensions  \t stitches number \t jumps number \t max_stitch_length \t min_stitch_length \n"
-       
+        self.min_stitch_lengths = []
+        self.export_txt = "element_id \t type \t method  \t dimensions  \t stitches \t jumps  \t max_stitch_length \t min_stitch_length \n"
+
         next_elements = [None]
         if len(self.elements) > 1:
             next_elements = self.elements[1:] + next_elements
@@ -40,7 +40,6 @@ class ElementInfo(InkstitchExtension):
         app = ElementInfoApp(self.list_items, self.export_txt)
         app.MainLoop()
 
-
     def _element_info(self, element, previous_stitch_group, next_element):
         stitch_groups = element.embroider(previous_stitch_group, next_element)
         stitch_plan = stitch_groups_to_stitch_plan(
@@ -50,7 +49,7 @@ class ElementInfo(InkstitchExtension):
         )
         label = element.node.label
         element_id = element.node.get_id()
-        
+
         self.list_items.append(ListItem(
             name=f"{label} ({element_id})",
             value=stitch_groups[0].color,
@@ -63,7 +62,7 @@ class ElementInfo(InkstitchExtension):
         ))
         if isinstance(element, FillStitch):
             fill_method = next((method.name for method in element._fill_methods if method.id == element.fill_method), "")
-            method=fill_method
+            method = fill_method
             self.list_items.append(ListItem(
                 name=_("Fill Method"),
                 value=fill_method
@@ -71,7 +70,7 @@ class ElementInfo(InkstitchExtension):
 
         if isinstance(element, SatinColumn):
             satin_method = next((method.name for method in element._satin_methods if method.id == element.satin_method), "")
-            method=satin_method
+            method = satin_method
             self.list_items.append(ListItem(
                 name=_("Satin Method"),
                 value=satin_method
@@ -79,14 +78,14 @@ class ElementInfo(InkstitchExtension):
 
         if isinstance(element, Stroke):
             stroke_method = next((method.name for method in element._stroke_methods if method.id == element.stroke_method), "")
-            method=stroke_method
+            method = stroke_method
             self.list_items.append(ListItem(
                 name=_("Stroke Method"),
                 value=stroke_method
             ))
-        dimensions="{:.2f} x {:.2f}".format(stitch_plan.dimensions_mm[0], stitch_plan.dimensions_mm[1])
+        dimensions = "{:.2f} x {:.2f}".format(stitch_plan.dimensions_mm[0], stitch_plan.dimensions_mm[1])
         self.list_items.append(ListItem(
-            name=_("Dimensions (mm)"),  
+            name=_("Dimensions (mm)"),
             value=dimensions
         ))
 
@@ -126,7 +125,7 @@ class ElementInfo(InkstitchExtension):
         if len(stitch_groups) > 1:
             stitches_per_group = f" ({', '.join([str(len(group.stitches)) for group in stitch_groups])})"
 
-        nb_stitches=str(stitch_plan.num_stitches - stitch_plan.num_jumps) + stitches_per_group
+        nb_stitches = str(stitch_plan.num_stitches - stitch_plan.num_jumps) + stitches_per_group
         self.list_items.append(ListItem(
             name=_("Stitches"),
             value=nb_stitches
@@ -135,17 +134,17 @@ class ElementInfo(InkstitchExtension):
             name=_("Small stitches (removed)"),
             value=str(removed_stitches)
         ))
-        nb_jumps=str(stitch_plan.num_jumps - 1)
+        nb_jumps = str(stitch_plan.num_jumps - 1)
         self.list_items.append(ListItem(
             name=_("Jumps"),
             value=nb_jumps
         ))
-        max_stitch_length="{:.2f}".format(max(stitch_lengths))
+        max_stitch_length = "{:.2f}".format(max(stitch_lengths))
         self.list_items.append(ListItem(
             name=_("Max stitch length"),
             value=max_stitch_length
         ))
-        min_stitch_length="{:.2f}".format(min(stitch_lengths))
+        min_stitch_length = "{:.2f}".format(min(stitch_lengths))
         self.list_items.append(ListItem(
             name=_("Min stitch length"),
             value=min_stitch_length

--- a/lib/extensions/element_info.py
+++ b/lib/extensions/element_info.py
@@ -119,7 +119,7 @@ class ElementInfo(InkstitchExtension):
                 name=_("Small stitches (removed)"),
                 value=str(removed_stitches)
             ))
-            return stitch_groups[0]
+            return ("", stitch_groups[0])
 
         stitches_per_group = ""
         if len(stitch_groups) > 1:

--- a/lib/extensions/element_info.py
+++ b/lib/extensions/element_info.py
@@ -27,7 +27,7 @@ class ElementInfo(InkstitchExtension):
         self.list_items = []
         self.max_stitch_lengths = []
         self.min_stitch_lengths = []
-        self.export_txt = "element_id \t type \t method  \t dimensions  \t stitches \t jumps  \t max_stitch_length \t min_stitch_length \n"
+        self.export_txt = "element_id\ttype\tmethod\tdimensions\tstitches\tjumps\tmax_stitch_length\tmin_stitch_length\n"
 
         next_elements = [None]
         if len(self.elements) > 1:

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -13,6 +13,7 @@ class ElementInfoFrame(wx.Frame):
 
     def __init__(self, *args, **kwargs):
         self.list_items = kwargs.pop("list_items")
+        self.export_txt = kwargs.pop("export_txt")
         self.index = 0
         wx.Frame.__init__(self, None, wx.ID_ANY, _("Element Info"), *args, **kwargs)
 
@@ -85,7 +86,7 @@ class ElementInfoFrame(wx.Frame):
 
     def on_copy(self, event):
         if wx.TheClipboard.Open():
-            text =self.export_text
+            text =self.export_txt
             data_object = wx.TextDataObject(text)
             wx.TheClipboard.SetData(data_object)
             
@@ -108,13 +109,13 @@ class ElementInfoFrame(wx.Frame):
 
 
 class ElementInfoApp(wx.App):
-    def __init__(self, list_items, export_text):
+    def __init__(self, list_items, export_txt):
         self.list_items = list_items
-        self.export_text = export_text
+        self.export_txt = export_txt
         super().__init__()
 
     def OnInit(self):
-        self.frame = ElementInfoFrame(list_items=self.list_items)
+        self.frame = ElementInfoFrame(list_items=self.list_items, export_txt=self.export_txt)
         self.SetTopWindow(self.frame)
         self.frame.Show()
         return True

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -28,7 +28,14 @@ class ElementInfoFrame(wx.Frame):
         self.notebook.AddPage(self.info, _("Info"))
 
         info_sizer = wx.BoxSizer(wx.VERTICAL)
-
+        #self.parent = parent
+        #self.txt_input = wx.TextCtrl(self)
+       
+       # cmd_copy.Bind(wx.EVT_BUTTON, parent.on_copy)
+       # sizer = wx.BoxSizer(wx.VERTICAL)
+        #sizer.Add(self.txt_input)
+       # info_sizer.Add(cmd_copy,1,wx.ALL| wx.EXPAND, 10)
+        
         self.info_list = wx.ListCtrl(self.info, wx.ID_ANY, style=wx.BORDER_SUNKEN | wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES)
         self.info_list.AppendColumn(_("Name"), format=wx.LIST_FORMAT_LEFT)
         self.info_list.AppendColumn(_("Value"), format=wx.LIST_FORMAT_LEFT)
@@ -64,6 +71,10 @@ class ElementInfoFrame(wx.Frame):
         )
         help_sizer.Add(self.website_link, 0, wx.ALL, 8)
 
+        cmd_copy = wx.Button(self.help, wx.ID_COPY)
+        cmd_copy.Bind(wx.EVT_BUTTON, self.on_copy)
+        help_sizer.Add(cmd_copy, 0, wx.ALL, 8)
+    
         self.help.SetSizer(help_sizer)
         self.info.SetSizer(info_sizer)
         self.main_panel.SetSizer(notebook_sizer)
@@ -71,6 +82,13 @@ class ElementInfoFrame(wx.Frame):
         self.SetSizeHints(notebook_sizer.CalcMin())
 
         self.Layout()
+
+    def on_copy(self, event):
+        if wx.TheClipboard.Open():
+            text =self.export_text
+            data_object = wx.TextDataObject(text)
+            wx.TheClipboard.SetData(data_object)
+            
 
     def _fill_info_list(self):
         for item in self.list_items:
@@ -90,8 +108,9 @@ class ElementInfoFrame(wx.Frame):
 
 
 class ElementInfoApp(wx.App):
-    def __init__(self, list_items):
+    def __init__(self, list_items, export_text):
         self.list_items = list_items
+        self.export_text = export_text
         super().__init__()
 
     def OnInit(self):

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -65,13 +65,13 @@ class ElementInfoFrame(wx.Frame):
         )
         help_sizer.Add(self.website_link, 0, wx.ALL, 8)
 
-        copyright_text = wx.StaticText(
+        copy_info_text = wx.StaticText(
             self.help,
             wx.ID_ANY,
-            _("Clip on Copy to copy the information in the Clipboard"),
+            _("Click on Copy to copy the information in the Clipboard"),
             style=wx.ALIGN_LEFT
         )
-        help_sizer.Add(copyright_text, 0, wx.ALL, 8)
+        help_sizer.Add(copy_info_text, 0, wx.ALL, 8)
 
         cmd_copy = wx.Button(self.help, wx.ID_COPY)
         cmd_copy.Bind(wx.EVT_BUTTON, self.on_copy)

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -29,7 +29,7 @@ class ElementInfoFrame(wx.Frame):
         self.notebook.AddPage(self.info, _("Info"))
 
         info_sizer = wx.BoxSizer(wx.VERTICAL)
-        
+
         self.info_list = wx.ListCtrl(self.info, wx.ID_ANY, style=wx.BORDER_SUNKEN | wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES)
         self.info_list.AppendColumn(_("Name"), format=wx.LIST_FORMAT_LEFT)
         self.info_list.AppendColumn(_("Value"), format=wx.LIST_FORMAT_LEFT)
@@ -72,11 +72,11 @@ class ElementInfoFrame(wx.Frame):
             style=wx.ALIGN_LEFT
         )
         help_sizer.Add(copyright_text, 0, wx.ALL, 8)
-        
+
         cmd_copy = wx.Button(self.help, wx.ID_COPY)
         cmd_copy.Bind(wx.EVT_BUTTON, self.on_copy)
         help_sizer.Add(cmd_copy, 0, wx.ALL, 8)
-    
+
         self.help.SetSizer(help_sizer)
         self.info.SetSizer(info_sizer)
         self.main_panel.SetSizer(notebook_sizer)
@@ -87,10 +87,9 @@ class ElementInfoFrame(wx.Frame):
 
     def on_copy(self, event):
         if wx.TheClipboard.Open():
-            text =self.export_txt
+            text = self.export_txt
             data_object = wx.TextDataObject(text)
             wx.TheClipboard.SetData(data_object)
-            
 
     def _fill_info_list(self):
         for item in self.list_items:

--- a/lib/gui/element_info.py
+++ b/lib/gui/element_info.py
@@ -29,13 +29,6 @@ class ElementInfoFrame(wx.Frame):
         self.notebook.AddPage(self.info, _("Info"))
 
         info_sizer = wx.BoxSizer(wx.VERTICAL)
-        #self.parent = parent
-        #self.txt_input = wx.TextCtrl(self)
-       
-       # cmd_copy.Bind(wx.EVT_BUTTON, parent.on_copy)
-       # sizer = wx.BoxSizer(wx.VERTICAL)
-        #sizer.Add(self.txt_input)
-       # info_sizer.Add(cmd_copy,1,wx.ALL| wx.EXPAND, 10)
         
         self.info_list = wx.ListCtrl(self.info, wx.ID_ANY, style=wx.BORDER_SUNKEN | wx.LC_HRULES | wx.LC_REPORT | wx.LC_VRULES)
         self.info_list.AppendColumn(_("Name"), format=wx.LIST_FORMAT_LEFT)
@@ -72,6 +65,14 @@ class ElementInfoFrame(wx.Frame):
         )
         help_sizer.Add(self.website_link, 0, wx.ALL, 8)
 
+        copyright_text = wx.StaticText(
+            self.help,
+            wx.ID_ANY,
+            _("Clip on Copy to copy the information in the Clipboard"),
+            style=wx.ALIGN_LEFT
+        )
+        help_sizer.Add(copyright_text, 0, wx.ALL, 8)
+        
         cmd_copy = wx.Button(self.help, wx.ID_COPY)
         cmd_copy.Bind(wx.EVT_BUTTON, self.on_copy)
         help_sizer.Add(cmd_copy, 0, wx.ALL, 8)


### PR DESCRIPTION
When working on a satin font, one of the final steps it to check if some satin columns are too wide.
Using element info on the whole font file allows to know what is the maximum stitch length. However, finding which satin columns are too wide  is not easy as there are plenty of elements involved and the info is not searchable or sortable.

I added a copy button on the help tab that copies the details of element info into the clipboard,so that it is easy to paste the result in an excel or like  file and find whatever satins are too wide.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/26153b1e-f834-44fc-892a-a6fb07f6581c" />

