### PR TITLE
fix: set trims=True for pyembroidery.write

### DIFF
--- a/lib/output.py
+++ b/lib/output.py
@@ -87,6 +87,9 @@ def write_embroidery_file(file_path, stitch_plan, svg, settings={}):
         # This forces a jump at the start of the design and after each trim,
         # even if we're close enough not to need one.
         "full_jump": True,
+
+        # defaults to False in pyembroidery (see https://github.com/EmbroidePy/pyembroidery/issues/188)
+        "trims": True,
     })
 
     if not file_path.endswith(('.col', '.edr', '.inf')):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,53 @@
+from inkex.tester import TestCase
+from inkex import SvgDocumentElement, Rectangle
+from inkex.tester.svg import svg
+
+from lib.svg.tags import INKSTITCH_ATTRIBS
+from lib import output
+from lib.stitch_plan.stitch_plan import StitchPlan, stitch_groups_to_stitch_plan
+from lib.elements.utils import node_to_elements
+
+
+class OutputTest(TestCase):
+    def _get_output(self, svg: SvgDocumentElement, format: str) -> bytes:
+        # TODO: support SVGs with more than one element
+        # (turn InkstitchExtension.elements_to_stitch_groups into a function so we can use it here?)
+        assert len(svg) == 1
+        [element] = node_to_elements(svg[0])
+        stitch_groups = element.embroider(None)
+        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups)
+        path = self.temp_file(suffix=f".{format}")
+        output.write_embroidery_file(path, stitch_plan, svg)
+        with open(path, "rb") as f:
+            return f.read()
+
+    def test_jef_output_does_not_change(self):
+        root: SvgDocumentElement = svg()
+        rect = root.add(
+            Rectangle(
+                attrib={
+                    "width": "10",
+                    "height": "10",
+                }
+            )
+        )
+        output1 = self._get_output(root, "jef")
+        output2 = self._get_output(root, "jef")
+        assert output1 == output2
+
+    def test_jef_output_includes_trims(self):
+        root: SvgDocumentElement = svg()
+        rect = root.add(
+            Rectangle(
+                attrib={
+                    "width": "10",
+                    "height": "10",
+                }
+            )
+        )
+        output1 = self._get_output(root, "jef")
+
+        rect.attrib[INKSTITCH_ATTRIBS["trim_after"]] = "true"
+
+        output2 = self._get_output(root, "jef")
+        assert output1 != output2


### PR DESCRIPTION
While the trims default was changed in pyembroidery back in 2019 with c4242f0f940c86766c0c27f65b5a09641b0af4bd that change only made it into the used Ink/Stitch fork of pyembroidery in 2022 with 28534cf1a8d692687d9f40c3be622e0945b5a2ee.

So trims have been broken in Ink/Stitch since v2.2.0.

Fixes #2813.