### PR TITLE
Revert "add icc color workaround (#3687)" and use 1.4.x inkex

### DIFF
--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -5,7 +5,7 @@
 
 import colorsys
 
-from inkex import Color, ColorCMS
+from inkex import Color
 from pyembroidery.EmbThread import EmbThread
 
 
@@ -33,12 +33,7 @@ class ThreadColor(object):
             self.rgb = (color.get_red(), color.get_green(), color.get_blue())
             return
         elif isinstance(color, str):
-            # This will catch icc colors which cannot be parsed as rgb colors directly
-            if isinstance(Color(color), ColorCMS):
-                # The icc color has a hex color prepended.
-                # The easiest way to receive a color value is therefore to just use the hex color from the front.
-                color = color.split()[0]
-            self.rgb = tuple(Color(color).to('rgb').get_values(False))
+            self.rgb = tuple(Color(color).to('rgb'))
         elif isinstance(color, (list, tuple)):
             self.rgb = tuple(color)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@
 # but the .gitignore file should be updated to ignore the build directory.
 ./pyembroidery
 
-# get up to date inkex version (March 1, 2024)
-inkex @ git+https://gitlab.com/inkscape/extensions.git@1792934a09046fdef8aab20d05aad9c47f825bf5
+# For macOS and Windows our installer bundles the version specified here
+# but some Linux distros package Ink/Stitch as depending on the inkex that's bundled with Inkscape.
+# So at least for releases we should use a tagged version here such as EXTENSIONS_AT_INKSCAPE_$version.
+inkex @ git+https://gitlab.com/inkscape/extensions.git@EXTENSIONS_AT_INKSCAPE_1.4.1
 
 # for linux user it may be tricky to install wxPython from sources
 # prebuilt packages: https://wxpython.org/pages/downloads/index.html

--- a/tests/test_threads_color.py
+++ b/tests/test_threads_color.py
@@ -1,0 +1,16 @@
+from lib.threads.color import ThreadColor
+
+
+def test_init_color_from_string_rgb():
+    color = ThreadColor("rgb(170, 187, 204)")
+    assert color.rgb == (170, 187, 204)
+
+
+def test_init_color_from_string_hex():
+    color = ThreadColor("#AABBCC")
+    assert color.rgb == (170, 187, 204)
+
+
+def test_init_color_from_string_hex_icc():
+    color = ThreadColor("#AABBCC icc-color(Some-Profile, 0.1, 0.2, 0.3, 0.4)")
+    assert color.rgb == (170, 187, 204)


### PR DESCRIPTION
This commit reverts 4cfb02c370e2f09d59658f652c4b15bd41d46d6e which did not fix anything as far as I can tell.

The inkex.Color constructor has been doing the same split logic since 2018 and the used ColorCMS class isn't available in the inkex that's bundled with Inkscape which breaks packaging for Linux distros such as NixOS.

To prevent such breakages from being introduce accidentally in the future the pinned inkex version is changed to the git tagged version EXTENSIONS_AT_INKSCAPE_1.4.1.

Fixes #3824.