### PR TITLE
Fix package build with Nix package manager

### DIFF
--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from . import cache as cache_module  # Slight hack to allow cache to be imported for monkeypatching
 from .cache import cache
 from .dotdict import DotDict
 from .geometry import *

--- a/lib/utils/paths.py
+++ b/lib/utils/paths.py
@@ -41,12 +41,12 @@ def get_resource_dir(name):
         return realpath(os.path.join(dirname(realpath(__file__)), '..', '..', name))
 
 
-def get_user_dir(name=None):
+def get_user_dir(name=None, create=True):
     try:
         path = platformdirs.user_config_dir('inkstitch')
     except ImportError:
         path = os.path.expanduser('~/.inkstitch')
-    if not os.path.exists(path):
+    if create and not os.path.exists(path):
         os.makedirs(path)
 
     if name is not None:

--- a/lib/utils/settings.py
+++ b/lib/utils/settings.py
@@ -45,7 +45,11 @@ DEFAULT_SETTINGS = {
 class GlobalSettings(MutableMapping):
     def __init__(self):
         super().__init__()
-        self.__settings_file = os.path.join(get_user_dir(), "settings.json")
+        # We set create=False here because this code is executed on module load
+        # and via imports also runs on generate-inx-files, which with the Nix
+        # package manager is executed with a non-writable home directory.
+        user_dir = get_user_dir(create=False)
+        self.__settings_file = os.path.join(user_dir, "settings.json")
         self.__settings = {}
 
         for name, value in DEFAULT_METADATA.items():

--- a/lib/utils/settings.py
+++ b/lib/utils/settings.py
@@ -49,40 +49,40 @@ class GlobalSettings(MutableMapping):
         # and via imports also runs on generate-inx-files, which with the Nix
         # package manager is executed with a non-writable home directory.
         user_dir = get_user_dir(create=False)
-        self.__settings_file = os.path.join(user_dir, "settings.json")
-        self.__settings = {}
+        self._settings_file = os.path.join(user_dir, "settings.json")
+        self._settings = {}
 
         for name, value in DEFAULT_METADATA.items():
-            self.__settings[f"default_{name}"] = value
+            self._settings[f"default_{name}"] = value
 
-        self.__settings.update(DEFAULT_SETTINGS)
+        self._settings.update(DEFAULT_SETTINGS)
 
         try:
-            with open(self.__settings_file, 'r') as settings_file:
-                self.__settings.update(json.load(settings_file))
+            with open(self._settings_file, 'r') as settings_file:
+                self._settings.update(json.load(settings_file))
         except (OSError, json.JSONDecodeError, ValueError):
             pass
 
     def __setitem__(self, item, value):
-        self.__settings[item] = value
+        self._settings[item] = value
 
-        with open(self.__settings_file, 'w') as settings_file:
-            json.dump(self.__settings, settings_file)
+        with open(self._settings_file, 'w') as settings_file:
+            json.dump(self._settings, settings_file)
 
     def __getitem__(self, item):
-        return self.__settings[item]
+        return self._settings[item]
 
     def __delitem__(self, item):
-        del self.__settings[item]
+        del self._settings[item]
 
     def __iter__(self):
-        return iter(self.__settings)
+        return iter(self._settings)
 
     def __len__(self):
-        return len(self.__settings)
+        return len(self._settings)
 
     def __json__(self):
-        return self.__settings
+        return self._settings
 
 
 global_settings = GlobalSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+import lib.utils.settings
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_cache():
+    # We disable the cache because Nix executes our tests with a non-writable HOME directory.
+    lib.utils.settings.global_settings._settings['cache_size'] = 0

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -9,7 +9,6 @@ from inkex.tester.svg import svg
 from lib.commands import add_commands
 from lib.elements import Clone, EmbroideryElement, FillStitch
 from lib.svg.tags import INKSCAPE_LABEL, INKSTITCH_ATTRIBS, SVG_RECT_TAG
-from lib.utils import cache_module
 
 from .utils import element_count
 
@@ -22,16 +21,6 @@ def element_fill_angle(element: EmbroideryElement) -> Optional[float]:
 
 
 class CloneElementTest(TestCase):
-    # Monkey-patch the cahce to forcibly disable it: We may need to refactor this out for tests.
-    def setUp(self) -> None:
-        from pytest import MonkeyPatch
-        self.monkeypatch = MonkeyPatch()
-        self.monkeypatch.setattr(cache_module, "is_cache_disabled", lambda: True)
-
-    def tearDown(self) -> None:
-        self.monkeypatch.undo()
-        return super().tearDown()
-
     def assertAngleAlmostEqual(self, a, b) -> None:
         # Take the mod 180 of the returned angles, because e.g. -130deg and 50deg produce fills along the same angle.
         # We have to use a precision of 4 decimal digits because of the precision of the matrices as they are stored in the svg trees


### PR DESCRIPTION
f672d713351ade5dbd8f593bf4b329fb19ad8168 changed `get_user_dir` to create the directory if it does not exist. Since the function is called on `GlobalSettings` initialization this broke `generate-inx-files` with Nix because Nix builds packages with a non-writable home directory. And for the same reason the tests that are executed during the Nix build also broke. This PR fixes both.

Please merge these two commits *without* squashing to preserve their commit messages.