### PR TITLE
Claudine/more help to add lock stitches in fonts

### DIFF
--- a/lib/extensions/lettering_force_lock_stitches.py
+++ b/lib/extensions/lettering_force_lock_stitches.py
@@ -29,6 +29,7 @@ class LetteringForceLockStitches(InkstitchExtension):
         self.arg_parser.add_argument("-i", "--min_distance", type=float, default=1, dest="min_distance")
         self.arg_parser.add_argument("-l", "--last_element", type=inkex.Boolean, dest="last_element")
         self.arg_parser.add_argument("-g", "--last_group_element", type=inkex.Boolean, dest="last_group_element")
+
     def effect(self):
         if self.options.max_distance < self.options.min_distance:
             inkex.errormssg(_("The maximum value is smaller than the minimum value."))

--- a/lib/extensions/lettering_force_lock_stitches.py
+++ b/lib/extensions/lettering_force_lock_stitches.py
@@ -28,7 +28,7 @@ class LetteringForceLockStitches(InkstitchExtension):
         self.arg_parser.add_argument("-a", "--max_distance", type=float, default=3, dest="max_distance")
         self.arg_parser.add_argument("-i", "--min_distance", type=float, default=1, dest="min_distance")
         self.arg_parser.add_argument("-l", "--last_element", type=inkex.Boolean, dest="last_element")
-
+        self.arg_parser.add_argument("-g", "--last_group_element", type=inkex.Boolean, dest="last_group_element")
     def effect(self):
         if self.options.max_distance < self.options.min_distance:
             inkex.errormssg(_("The maximum value is smaller than the minimum value."))
@@ -43,7 +43,9 @@ class LetteringForceLockStitches(InkstitchExtension):
             # Set glyph layers to be visible. We don't want them to be ignored by self.elements
             self._update_layer_visibility('inline')
         for layer in glyph_layers:
-            if uses_glyph_layers and self.options.last_element:
+            if uses_glyph_layers and self.options.last_group_element:
+                self._set_force_attribute_on_last_group_elements(layer)
+            elif uses_glyph_layers and self.options.last_element:
                 self._set_force_attribute_on_last_elements(layer)
             if self.options.distance:
                 self._set_force_attribute_by_distance(layer)
@@ -51,6 +53,11 @@ class LetteringForceLockStitches(InkstitchExtension):
         if uses_glyph_layers:
             # unhide glyph layers
             self._update_layer_visibility('none')
+
+    def _set_force_attribute_on_last_group_elements(self, layer):
+        group_nodes = list(layer.iterdescendants("g"))
+        for group in group_nodes:
+            self._set_force_attribute_on_last_elements(group)
 
     def _set_force_attribute_on_last_elements(self, layer):
         # find the last path that does not carry a marker or belongs to a visual command and add a trim there

--- a/lib/extensions/lettering_force_lock_stitches.py
+++ b/lib/extensions/lettering_force_lock_stitches.py
@@ -10,7 +10,7 @@ from ..elements.utils import iterate_nodes, nodes_to_elements
 from ..i18n import _
 from ..marker import has_marker
 from ..svg import PIXELS_PER_MM
-from ..svg.tags import EMBROIDERABLE_TAGS
+from ..svg.tags import EMBROIDERABLE_TAGS, SVG_GROUP_TAG
 from .base import InkstitchExtension
 
 
@@ -45,7 +45,7 @@ class LetteringForceLockStitches(InkstitchExtension):
         for layer in glyph_layers:
             if uses_glyph_layers and self.options.last_group_element:
                 self._set_force_attribute_on_last_group_elements(layer)
-            elif uses_glyph_layers and self.options.last_element:
+            if uses_glyph_layers and self.options.last_element:
                 self._set_force_attribute_on_last_elements(layer)
             if self.options.distance:
                 self._set_force_attribute_by_distance(layer)
@@ -55,7 +55,7 @@ class LetteringForceLockStitches(InkstitchExtension):
             self._update_layer_visibility('none')
 
     def _set_force_attribute_on_last_group_elements(self, layer):
-        group_nodes = list(layer.iterdescendants("g"))
+        group_nodes = list(layer.iterdescendants(SVG_GROUP_TAG))
         for group in group_nodes:
             self._set_force_attribute_on_last_elements(group)
 

--- a/templates/lettering_force_lock_stitches.xml
+++ b/templates/lettering_force_lock_stitches.xml
@@ -18,7 +18,7 @@
             <separator />
             <spacer />
             <param name="last_element" type="boolean" gui-text="Add forced lock stitches to the last element of each glyph">false</param>
-            <param name="last_element_group" type="boolean" gui-text="Add forced lock stitches to the last element of each group">false</param>
+            <param name="last_group_element" type="boolean" gui-text="Add forced lock stitches to the last element of each group">false</param>
         </page>
         <page name="info" gui-text="Help">
             <label >

--- a/templates/lettering_force_lock_stitches.xml
+++ b/templates/lettering_force_lock_stitches.xml
@@ -18,6 +18,7 @@
             <separator />
             <spacer />
             <param name="last_element" type="boolean" gui-text="Add forced lock stitches to the last element of each glyph">false</param>
+            <param name="last_element_group" type="boolean" gui-text="Add forced lock stitches to the last element of each group">false</param>
         </page>
         <page name="info" gui-text="Help">
             <label >


### PR DESCRIPTION
This is useful when you want to make sure that there is a tie  not only at the end of each letter, but also for a letter with a diacritic, you want to also have a tie at the end of the diacritic  (for large letters). It is easy to group all the pieces in the accent, and then at the very end you can add lock stitch at the last element of each group. 
This only works if you don't use group inside letters for something else, but for basic satin letters, it works well.