### PR TITLE
Satin: first_stitch method fails on invalid path...

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -835,8 +835,8 @@ class SatinColumn(EmbroideryElement):
                 point = (0, 0)
             yield NotStitchableError(point)
 
-            if not self.to_stitch_groups():
-                yield NotStitchableError(self.line_string_rails[0].representative_point())
+        elif not self.to_stitch_groups() and self.line_string_rails:
+            yield NotStitchableError(self.line_string_rails[0].representative_point())
 
     def _center_walk_is_odd(self):
         return self.center_walk_underlay and self.center_walk_underlay_repeats % 2 == 1


### PR DESCRIPTION
... and prevents a more helpful error message.