### PR TITLE
Add rungs at nodes for on-the-fly-satins

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -621,7 +621,7 @@ class SatinColumn(EmbroideryElement):
         paths = [path for path in self.paths if len(path) > 1]
         if len(paths) == 1:
             style_args = get_join_style_args(self)
-            new_satin = convert_path_to_satin(paths[0], self.stroke_width, style_args)
+            new_satin = convert_path_to_satin(paths[0], self.stroke_width, style_args, rungs_at_nodes=True)
             if new_satin:
                 rails, rungs = new_satin
                 paths = list(rails) + list(rungs)


### PR DESCRIPTION
This enables the user to have a little more control over the outcome of the "stroke-satins" by adding or removing nodes from the original path.