### PR TITLE
Satin: skip contour underlay if there are no pairs

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1353,6 +1353,9 @@ class SatinColumn(EmbroideryElement):
             self.contour_underlay_stitch_tolerance,
             -self.contour_underlay_inset_px, -self.contour_underlay_inset_percent/100)
 
+        if not pairs:
+            return []
+
         first_side = running_stitch.even_running_stitch(
             [points[0] for points in pairs],
             self.contour_underlay_stitch_length,


### PR DESCRIPTION
Fixes #3910

What we see there is a satin setup which fails to recognize the correct rails (one rail has 3 intersection and is identified correctly, the other has two intersections and is taken for a rung, while the rung with one intersection is detected as the rail). I guess, this is just unlucky and we will end up with a message about a bad satin setup. When contour underlay is enabled we received the traceback message instead.

This simply returns an empty list when there are no pairs to form the contour underlay with. This way the user ends up with the bad satin message again (same as when contour underlay is disabled).