### PR TITLE
a few fixes for converting stroke to satin internally

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -520,12 +520,6 @@ class EmbroideryElement(object):
 
         return [self.strip_control_points(subpath) for subpath in path]
 
-    def flatten_subpath(self, subpath):
-        path = [deepcopy(subpath)]
-        bezier.cspsubdiv(path, 0.1)
-
-        return self.strip_control_points(path[0])
-
     @property
     @cache
     def lock_stitches(self):

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1076,45 +1076,6 @@ class SatinColumn(EmbroideryElement):
 
         return SatinColumn(node)
 
-    def merge(self, satin):
-        """Merge this satin with another satin
-
-        This method expects that the provided satin continues on directly after
-        this one, as would be the case, for example, if the two satins were the
-        result of the split() method.
-
-        Returns a new SatinColumn instance that combines the rails and rungs of
-        this satin and the provided satin.  A rung is added at the end of this
-        satin.
-
-        The returned SatinColumn will not be in the SVG document and will have
-        its transforms applied.
-        """
-        rails = self.rails
-        other_rails = satin.rails
-
-        if len(rails) != 2 or len(other_rails) != 2:
-            # weird non-satin things, give up and don't merge
-            return self
-
-        # remove first node of each other rail before merging (avoid duplicated nodes)
-        rails[0].extend(other_rails[0][1:])
-        rails[1].extend(other_rails[1][1:])
-
-        rungs = self.rungs
-        other_rungs = satin.rungs
-
-        # add a rung in between the two satins and extend it just a litte to ensure it is crossing the rails
-        new_rung = shgeo.LineString([other_rails[0][0], other_rails[1][0]])
-        rungs.append(list(shaffinity.scale(new_rung, 1.2, 1.2).coords))
-
-        # add on the other satin's rungs
-        rungs.extend(other_rungs)
-
-        rungs = self._get_filtered_rungs(rails, rungs)
-
-        return self._coordinates_to_satin(line_strings_to_coordinate_lists(rails + rungs))
-
     def _get_filtered_rungs(self, rails, rungs):
         # returns a filtered list of rungs which do intersect the rails exactly twice
         rails = shgeo.MultiLineString(rails)

--- a/lib/elements/utils/stroke_to_satin.py
+++ b/lib/elements/utils/stroke_to_satin.py
@@ -285,6 +285,11 @@ def merge(section, other_section):
     rails, rungs = section
     other_rails, other_rungs = other_section
 
+    if len(other_rails[0]) < 2 or len(other_rails[1]) < 2:
+        # Somehow we got a degenerate rail with only one (or no?) point.
+        # Ignore this one since it has zero length anyway.
+        return section
+
     # remove first node of each other rail before merging (avoid duplicated nodes)
     rails[0].extend(other_rails[0][1:])
     rails[1].extend(other_rails[1][1:])

--- a/lib/elements/utils/stroke_to_satin.py
+++ b/lib/elements/utils/stroke_to_satin.py
@@ -285,10 +285,6 @@ def merge(section, other_section):
     rails, rungs = section
     other_rails, other_rungs = other_section
 
-    if len(rails) != 2 or len(other_rails) != 2:
-        # weird non-satin things, give up and don't merge
-        return section
-
     # remove first node of each other rail before merging (avoid duplicated nodes)
     rails[0].extend(other_rails[0][1:])
     rails[1].extend(other_rails[1][1:])

--- a/lib/elements/utils/stroke_to_satin.py
+++ b/lib/elements/utils/stroke_to_satin.py
@@ -33,7 +33,7 @@ def convert_path_to_satin(path, stroke_width, style_args):
     if sections:
         joined_satin = list(sections)[0]
         for satin in sections[1:]:
-            joined_satin = merge(joined_satin, satin)
+            joined_satin = _merge(joined_satin, satin)
         return joined_satin
     return None
 
@@ -268,19 +268,11 @@ def generate_rungs(path, stroke_width, left_rail, right_rail):
     return rungs
 
 
-def merge(section, other_section):
-    """Merge this satin with another satin
+def _merge(section, other_section):
+    """Merge two satin sections
 
-    This method expects that the provided satin continues on directly after
-    this one, as would be the case, for example, if the two satins were the
-    result of the split() method.
-
-    Returns a new SatinColumn instance that combines the rails and rungs of
-    this satin and the provided satin.  A rung is added at the end of this
-    satin.
-
-    The returned SatinColumn will not be in the SVG document and will have
-    its transforms applied.
+    The two sections are expected to be contiguous; that is, the second one
+    starts where the first one ends.
     """
     rails, rungs = section
     other_rails, other_rungs = other_section


### PR DESCRIPTION
This PR has a few fixes that stem from the awesome #3874:

* remove `EmbroideryElement.flatten_subpath()` since it's no longer used anywhere.
* remove `SatinColumn.merge()` since it's also no longer used
* rename convert stroke_to_satin's `merge()` to `_merge()` to avoid confusion since this one is not designed to work on real SatinColumn instances
* bug fix: apparently for really ridiculous paths, it's possible for one (or both?) rails to have just a single point, and that causes a crash in merge()

I was trying to see if I could find a path that actually fails to convert properly, but all I found was this crash, and I had to try pretty hard to get it!

```
Traceback (most recent call last):
  File "/home/lex/repos/inkstitch/inkstitch.py", line 166, in <module>
    extension.run(args=remaining_args)
  File "/home/lex/.pyenv/versions/3.11.13/lib/python3.11/site-packages/inkex/base.py", line 255, in run
    self.save_raw(self.effect())
                  ^^^^^^^^^^^^^
  File "/home/lex/repos/inkstitch/lib/extensions/stroke_to_satin.py", line 42, in effect
    satin_paths = convert_path_to_satin(path, element.stroke_width, style_args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lex/repos/inkstitch/lib/elements/utils/stroke_to_satin.py", line 36, in convert_path_to_satin
    joined_satin = merge(joined_satin, satin)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lex/repos/inkstitch/lib/elements/utils/stroke_to_satin.py", line 297, in merge
    new_rung = shgeo.LineString([other_rails[0][0], other_rails[1][0]])
                                                    ~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Theoretically, it's still possible that converting to satin internally fails, but I really can't find a path that does that in practice.  I'm really excited that we finally have #255!