### PR TITLE
preset-related fixes

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -271,8 +271,6 @@ class ParamsTab(ScrolledPanel):
     def load_preset(self, preset):
         preset_data = preset.get(self.name, {})
 
-        # print(self.param_inputs, '\n\n', preset_data.items(), file=sys.stderr)
-
         for name, value in preset_data.items():
             if name in self.param_inputs:
                 if name in self.dict_of_choices and self.dict_of_choices[name]['param'].type == 'combo':
@@ -286,8 +284,14 @@ class ParamsTab(ScrolledPanel):
                         value = not value
                     input.SetValue(value)
                 self.changed_inputs.add(self.param_inputs[name])
+                self.enable_change_indicator(name)
 
         self.update_toggle_state()
+        self.update_enable_widgets()
+        self.update_choice_widgets()
+        self.settings_grid.Layout()
+        self.Fit()
+        self.Layout()
 
     def save_preset(self, storage):
         storage[self.name] = self.get_values()

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -60,6 +60,7 @@ class ParamsTab(ScrolledPanel):
         self.dict_of_choices = {}
         self.paired_tab = None
         self.disable_notify_pair = False
+        self.on_change_hook = None
 
         toggles = [param for param in self.params if param.type == 'toggle']
 

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -506,10 +506,14 @@ class ParamsTab(ScrolledPanel):
         indicator.SetToolTip(
             _('Click to force this parameter to be saved when you click "Apply and Quit"'))
         indicator.Bind(
-            wx.EVT_BUTTON, lambda event: self.enable_change_indicator(param))
+            wx.EVT_BUTTON, lambda event: self.on_change_indicator_clicked(param))
 
         self.param_change_indicators[param] = indicator
         return indicator
+
+    def on_change_indicator_clicked(self, param):
+        self.changed_inputs.add(self.param_inputs[param])
+        self.enable_change_indicator(param)
 
     def enable_change_indicator(self, param):
         self.param_change_indicators[param].SetBitmapLabel(self.pencil_icon)

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -251,7 +251,8 @@ class ParamsTab(ScrolledPanel):
     def apply(self):
         values = self.get_values()
         for node in self.nodes:
-            if "satin_column" in values.keys() and values["satin_column"] is True and node.stroke_width < 0.3 * PIXELS_PER_MM:
+            if ("satin_column" in values.keys() and values["satin_column"] is True and
+                    len(node.paths) == 1 and node.stroke_width < 0.3 * PIXELS_PER_MM):
                 # when we apply satin columns, strokes (running stitches) are not rendered in the simulator
                 # and we also don't want to set any of the chosen values to these elements as this may lead to unexpected rendering results
                 continue

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -216,15 +216,16 @@ class ParamsTab(ScrolledPanel):
 
         for name, input in self.param_inputs.items():
             if input in self.changed_inputs and input != self.toggle_checkbox:
-                # there are two types of combo boxes:
-                # 1. multiple values for the same param on selected elements - 2. param type
-                # multiple values will be handled with the GetValue() method
-                if name in self.dict_of_choices and self.dict_of_choices[name]['param'].type == 'combo':
-                    values[name] = input.GetClientData(input.GetSelection()).id
-                elif isinstance(input, wx.Choice):
-                    values[name] = input.GetSelection()
-                else:
-                    values[name] = input.GetValue()
+                if input.IsEnabled() and input.IsShown():
+                    # there are two types of combo boxes:
+                    # 1. multiple values for the same param on selected elements - 2. param type
+                    # multiple values will be handled with the GetValue() method
+                    if name in self.dict_of_choices and self.dict_of_choices[name]['param'].type == 'combo':
+                        values[name] = input.GetClientData(input.GetSelection()).id
+                    elif isinstance(input, wx.Choice):
+                        values[name] = input.GetSelection()
+                    else:
+                        values[name] = input.GetValue()
 
         return values
 

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -701,7 +701,6 @@ class SettingsPanel(wx.Panel):
 
     def use_last(self, event):
         self.presets_panel.load_preset("__LAST__")
-        self.apply(event)
 
     def close(self):
         self.simulator.stop()

--- a/lib/gui/presets.py
+++ b/lib/gui/presets.py
@@ -102,9 +102,12 @@ class PresetsPanel(wx.Panel):
             json.dump(presets, presets_file)
 
     def update_preset_list(self):
+        current_preset = self.preset_chooser.GetValue().strip()
         preset_names = list(self._load_presets().keys())
         preset_names = [preset for preset in preset_names if not self.is_hidden(preset)]
         self.preset_chooser.SetItems(sorted(preset_names))
+        if current_preset in preset_names:
+            self.preset_chooser.SetValue(current_preset)
 
     def is_hidden(self, preset_name):
         return self.HIDDEN_PRESET_RE.match(preset_name)
@@ -140,6 +143,11 @@ class PresetsPanel(wx.Panel):
             return
 
         self.store_preset(preset_name, self.parent.get_preset_data())
+
+        if overwrite:
+            info_dialog(self, _('Preset "%s" updated.') % preset_name)
+        else:
+            info_dialog(self, _('Preset "%s" added.') % preset_name)
 
         event.Skip()
 
@@ -177,5 +185,7 @@ class PresetsPanel(wx.Panel):
 
         self.update_preset_list()
         self.preset_chooser.SetValue("")
+
+        info_dialog(self, _('Preset "%s" deleted.') % preset_name)
 
         event.Skip()


### PR DESCRIPTION
# Make clicking the pencil icon work properly

The pencil icon was originally added in #301, and my explanation for what it does is there.

Clicking the pencil icon _should_ tell Ink/Stitch that you want that setting to be written to all relevant selected objects, even though you haven't actually changed the value.  It should also cause that setting to be included if you save a preset.  That was inadvertently broken in #1918.  This PR should fix that and make clicking the pencil icon work again.

fixes #3888

# Update choice-based params when loading presets

When loading a preset that affects a dropdown, the UI is now updated to reflect the dependent params.  For example, if loading a preset changes the fill method to Meander, then the meander-related params like Meander Pattern are now properly shown.

# Set choice dropdowns as changed when dependent params are changed

I fixed a bug that could show up in several ways.  Here's an example of the bug:

1. Create a filled shape.
2. Set its Fill Method to Meander.
3. Click Apply.
4. Reopen Params.
5. Change the Meander Pattern to something different.
6. Save a preset.
7. Click Apply.
8. Create a new filled shape.
9. Select the new shape and open Params.
10. Load the preset you created earlier.

Loading the preset will have no effect.  This is because the preset _only_ contains params you actually changed.  It doesn't contain the Fill Method param, so loading the preset won't enable Meander on any element that didn't already have it set.

This is probably also the cause of #3904.  Behind the scenes, "use last settings" just loads a hidden preset named `__LAST__` which is automatically saved any time you click "Apply" in Params.   This bug will make it look like "Use last settings" had no effect.

This bug can also have other weird effects.  For example, select one object that has a fill method of Meander and a second that has a fill method of Auto-fill, and run Params.  It seems like you have a 50% chance of the Fill Method showing up as set to Meander in Params.  If it does and you change params like the Meander Pattern, only the Meander shape will be affected, but not the one that was set to Auto-fill.

I think that if the user changes a sub-param like Meander Pattern and creates a preset, they _intend_ the preset to enable Meander _and_ set the Meander Pattern.  This PR automatically enables the pencil icon on Fill Method if you change Meander Pattern, and similar for all other dependent params.  This means the Fill Method will be applied to all selected fill elements, and the Fill Method will also be saved into any presets (including the hidden Use Last Settings preset).

fixes #3904

# Don't save invisible params to presets

This PR fixes a weird behavior that you could get by doing the following:

1. Create a fill shape.
2. Set its Fill Method to Meander.
3. Click Apply.
4. Reopen Params.
5. Set its Meander Pattern to something different.
6. Set its Fill Method to Auto-fill.
7. Save a preset.

The saved preset will contain the Meander Pattern param you changed, even though that param is no longer relevant or even visible now that you've set the Fill Method to Auto-fill.  This could show up in weird ways like unexpectedly changing the Meander Pattern on an object when you load that preset.  This isn't a _huge_ deal since the Fill Method will also be part of the preset, so it would only become obvious that the Meander Pattern was changed if they set the Fill Method back to Meander.  Still, it's weird behavior

We shouldn't save invisible params to presets (including the hidden Use Last Settings preset), and this PR ensures that we don't.

# Don't immediately apply when clicking Use Last Settings

This was always a weird UI choice, and I've regretted making it in the past.  Now, when you click "Use Last Settings", the previous settings are loaded, and you see things change and the pencil icons appear.

# Make adding, updating, and deleting presets clearer

When adding a preset, previously the preset chooser was reset to be blank and nothing else happened.  Now, the new preset remains selected, and a dialog pops up telling you that your new preset has been added.  When overwriting or deleting presets, dialogs are also shown.