### PR TITLE
fix crash with tiny satin

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -611,6 +611,10 @@ class SatinColumn(EmbroideryElement):
             self.pull_compensation_percent/100,
             True,
         )
+        if len(pairs) == 1:
+            # we need at least two points for line string creation
+            # if there is only one, we simply duplicate it to prevent an error
+            pairs.append(pairs[0])
         rail1 = [point[0] for point in pairs]
         rail2 = [point[1] for point in pairs]
         return shgeo.MultiLineString((rail1, rail2))

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1149,6 +1149,10 @@ class SatinColumn(EmbroideryElement):
 
         points = [points[0] for points in pairs]
         stitches = running_stitch.even_running_stitch(points, self.running_stitch_length, self.running_stitch_tolerance)
+
+        if len(stitches) == 1:
+            stitches.append(stitches[0])
+
         return stitches
 
     def _stitch_distance(self, pos0, pos1, previous_pos0, previous_pos1):

--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -12,6 +12,9 @@
             <param name="rm_stroke" type="boolean" gui-text="Remove Small strokes"
                    gui-description="Removes small strokes shorter than defined by threshold.">true</param>
             <param name="stroke_threshold" type="int" gui-text="Stroke threshold (px)" min="2" max="800">5</param>
+            <param name="rm_satin" type="boolean" gui-text="Remove Small satins"
+                   gui-description="Removes small satin columns shorter than defined by threshold.">true</param>
+            <param name="satin_threshold" type="int" gui-text="Satin threshold (px)" min="2" max="800">5</param>
             <param name="rm_groups" type="boolean" gui-text="Remove empty layers and groups">true</param>
             <spacer />
             <separator />


### PR DESCRIPTION
fixes #3933 

With a super-tiny satin, `_get_center_line_stitches()` can return a single-point path, which makes `LineString()` mad.  This PR works around that by just duplicating the single point.  I also added an option to the cleanup extension to clean up super-tiny satins.