### PR TITLE
Fix meander clamp (2)

### DIFF
--- a/lib/stitches/meander_fill.py
+++ b/lib/stitches/meander_fill.py
@@ -185,7 +185,9 @@ def post_process(points, shape, original_shape, fill):
         stitches = even_running_stitch(smoothed_points, fill.running_stitch_length, fill.running_stitch_tolerance)
 
     if fill.clip:
-        stitches = clamp_path_to_polygon(stitches, original_shape)
+        # the stitch path may have self intersections
+        # therefore we don't want clamp polygon to check for the distance to the start point of a segment
+        stitches = clamp_path_to_polygon(stitches, original_shape, False)
 
     if fill.bean_stitch_repeats:
         stitches = bean_stitch(stitches, fill.bean_stitch_repeats)

--- a/lib/utils/clamp_path.py
+++ b/lib/utils/clamp_path.py
@@ -88,7 +88,7 @@ def clamp_fully_external_path(path, polygon):
     return adjust_line_end(shorter, start)
 
 
-def clamp_path_to_polygon(path, polygon):
+def clamp_path_to_polygon(path, polygon, check_distance=True):
     """Constrain a path to a Polygon.
 
     The path is expected to have at least some part inside the Polygon.
@@ -131,7 +131,10 @@ def clamp_path_to_polygon(path, polygon):
             # The second part of this or condition checks whether part of the
             # path was removed by difference() above, because it coincided
             # with part of the shape border.
-            if not was_inside and last_point_inside is not None:
+            if last_point_inside is not None and (
+                not was_inside or
+                (check_distance and last_point_inside.distance(start) > 0.01)
+            ):
                 # We traveled outside or on the border of the shape for
                 # a while.  In either case, we need to add a path along the
                 # border between the exiting and entering points.


### PR DESCRIPTION
Fixes newly introduced issues in #3941

We really only want to remove the distance check for meander fill for other fill methods we actually do need it. 
Meander fill has no edge run feature, but may have self intersecting paths which is causing the issues described in #3902 