### PR TITLE
removed shapely rebuild from macos builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,10 +386,6 @@ jobs:
           # for networkx
           pip install pandas
           pip install pyarrow
-          # remove and build shapely with brew geos version
-          pip uninstall -y shapely
-          pip cache remove shapely
-          pip install -v shapely --no-binary shapely
 
           pip install pyinstaller
 
@@ -455,10 +451,6 @@ jobs:
           # for networkx
           pip install pandas
           pip install pyarrow
-          # remove and build shapely with brew geos version
-          pip uninstall -y shapely
-          pip cache remove shapely
-          pip install -v shapely --no-binary shapely
 
           pip install pyinstaller
 


### PR DESCRIPTION
fixed issue with shapely pip package for macOS, no need to rebuild shapely pip package GEOS library from shapely is updated for Inkstitch needs. 