### PR TITLE
Fill to satin: do not error out for fills without rungs

### DIFF
--- a/lib/extensions/fill_to_satin.py
+++ b/lib/extensions/fill_to_satin.py
@@ -171,7 +171,7 @@ class FillElementToSatin:
         self._generate_line_sections()
         self._define_relations(bridges)
 
-        if len(self.line_sections) == 2 and self.line_sections[0].distance(self.line_sections[1]) > 0:
+        if len(self.line_sections) == 2 and self.line_sections[0].distance(self.line_sections[1]) > 0 and len(self.rungs):
             # there is only one segment, add it directly
             rails = [MultiLineString([self.line_sections[0], self.line_sections[1]])]
             rungs = [ensure_multi_line_string(self.rungs[0])]


### PR DESCRIPTION
When multiple fills are selected, but only one of them has rungs, Ink/Stitch throws an error message for fill to satin conversion ... and shouldn't.