### PR TITLE
Cut satin: allow multiple cut position commands

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -514,11 +514,14 @@ class EmbroideryElement(object):
         return len(self.get_commands(command)) > 0
 
     @cache
-    def get_command(self, command: str) -> Optional[Command]:
+    def get_command(self, command: str, multiple: bool = False) -> Optional[Command]:
         commands = self.get_commands(command)
 
         if commands:
-            return commands[0]
+            if multiple:
+                return commands
+            else:
+                return commands[0]
         else:
             return None
 

--- a/lib/extensions/cut_satin.py
+++ b/lib/extensions/cut_satin.py
@@ -4,6 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import inkex
+from shapely.geometry import Point
 
 from ..elements import SatinColumn
 from ..i18n import _
@@ -22,30 +23,55 @@ class CutSatin(InkstitchExtension):
 
         for satin in self.elements:
             if isinstance(satin, SatinColumn):
-                command = satin.get_command("satin_cut_point")
+                old_satin = satin
+                self.split = False
+                transform = get_correction_transform(satin.node)
+                parent = satin.node.getparent()
+                self.index = parent.index(satin.node)
+                self.label_index = 0
 
-                if command is None:
+                commands = satin.get_command("satin_cut_point", True)
+
+                if commands is None:
                     # L10N will have the satin's id prepended, like this:
                     # path12345: error: this satin column does not ...
                     satin.fatal(_('this satin column does not have a "satin column cut point" command attached to it. '
                                   'Please use the "Attach commands" extension and attach the "Satin Column cut point" command first.'))
 
-                split_point = command.target_point
-                command_group = command.use.getparent()
-                if command_group is not None and command_group.get('id').startswith('command_group'):
-                    command_group.delete()
-                else:
-                    command.use.delete()
-                    command.connector.delete()
+                commands.sort(key=lambda command: satin.center_line.project(Point(command.target_point)), reverse=True)
 
-                new_satins = satin.split(split_point)
-                if None in new_satins:
-                    continue
-                transform = get_correction_transform(satin.node)
-                parent = satin.node.getparent()
-                index = parent.index(satin.node)
-                satin.node.delete()
-                for new_satin in new_satins:
-                    new_satin.node.set('transform', transform)
-                    parent.insert(index, new_satin.node)
-                    index += 1
+                satins = [None, None]
+                for command in commands:
+                    satins = self.split_satin(satin, command)
+                    if None in satins:
+                        continue
+                    self.insert_satin(satins[1], parent, transform)
+                    satin = satins[0]
+                if satins[0] is not None:
+                    self.insert_satin(satins[0], parent, transform)
+                if self.split:
+                    old_satin.node.delete()
+
+    def insert_satin(self, satin, parent, transform):
+        if satin is None:
+            return
+        node = satin.node
+        label = node.label or satin.node.get_id()
+        node.set('transform', transform)
+        parent.insert(self.index, node)
+        node.set('inkscape:label', f'{label} {self.label_index}')
+        node.apply_transform()
+        self.label_index += 1
+        self.split = True
+
+    def split_satin(self, satin, command):
+        split_point = command.target_point
+        command_group = command.use.getparent()
+        if command_group is not None and command_group.get('id').startswith('command_group'):
+            command_group.delete()
+        else:
+            command.use.delete()
+            command.connector.delete()
+
+        new_satins = satin.split(split_point)
+        return new_satins


### PR DESCRIPTION
It's a bit annoying when we have to add one command, then cut, add an other command, then cut, etc.
Nicer if we can add all cut commands and then cut the satin at once.