### PR TITLE
Empty-d-object: define a default color (black)

### DIFF
--- a/lib/elements/empty_d_object.py
+++ b/lib/elements/empty_d_object.py
@@ -31,5 +31,11 @@ class EmptyDObject(EmbroideryElement):
     def first_stitch(self):
         return None
 
+    @property
+    def color(self):
+        # We are not able to sitch this element, but some method calling the element may require a color definition.
+        # So let's simply define a black color
+        return 'black'
+
     def to_stitch_groups(self, last_stitch_group, next_element=None):
         return []


### PR DESCRIPTION
Although we are never going to stitch an object like this, methods (such as apply color palette) require a color definition.