### PR TITLE
Lettering: enable ltr, rtl, ttb, btt file names for font variants ...

### DIFF
--- a/lib/extensions/lettering_generate_json.py
+++ b/lib/extensions/lettering_generate_json.py
@@ -24,7 +24,7 @@ class LetteringGenerateJson(InkstitchExtension):
 
         self.arg_parser.add_argument("-n", "--font-name", type=str, default="Font", dest="font_name")
         self.arg_parser.add_argument("-d", "--font-description", type=str, default="Description", dest="font_description")
-        self.arg_parser.add_argument("-v", "--default_variant", type=int, default=0, dest="default_variant")
+        self.arg_parser.add_argument("-v", "--default_variant", type=int, default="ltr", dest="default_variant")
         self.arg_parser.add_argument("-x", "--text_direction", type=str, default="ltr", dest="text_direction")
         self.arg_parser.add_argument("-s", "--auto-satin", type=Boolean, default="true", dest="auto_satin")
         self.arg_parser.add_argument("-r", "--reversible", type=Boolean, default="true", dest="reversible")
@@ -88,20 +88,10 @@ class LetteringGenerateJson(InkstitchExtension):
         combine_at_sort_indices = self.options.combine_at_sort_indices.split(',')
         combine_at_sort_indices = set([index.strip() for index in combine_at_sort_indices if index.strip()])
 
-        # The inx gui doesn't seem to be able to remember the arrow values,
-        # therefore we used numbers which we need to convert now
-        default_variant = "→"
-        if self.options.default_variant == 1:
-            default_variant = "←"
-        elif self.options.default_variant == 2:
-            default_variant = "↓"
-        elif self.options.default_variant == 3:
-            default_variant = "↑"
-
         # collect data
         data = {'name': self.options.font_name,
                 'description': self.options.font_description,
-                'default_variant': default_variant,
+                'default_variant': self.options.default_variant,
                 'text_direction': self.options.text_direction,
                 'keywords': keywords,
                 'leading': leading,

--- a/lib/gui/edit_json/main_panel.py
+++ b/lib/gui/edit_json/main_panel.py
@@ -178,13 +178,13 @@ class LetteringEditJsonPanel(wx.Panel):
 
     def on_default_variant_change(self, event=None):
         selection = self.settings_panel.font_info.default_variant.GetSelection()
-        value = '→'
+        value = 'ltr'
         if selection == 1:
-            value = '←'
+            value = 'rtl'
         elif selection == 2:
-            value = '↓'
+            value = 'ttb'
         elif selection == 3:
-            value = '↑'
+            value = 'btt'
         self.font_meta['default_variant'] = value
         self.update_preview()
 
@@ -331,7 +331,7 @@ class LetteringEditJsonPanel(wx.Panel):
         # update ctrl
         self.settings_panel.font_info.name.ChangeValue(self.font.name)
         self.settings_panel.font_info.description.ChangeValue(self.font.metadata['description'])
-        selection = ['→', '←', '↓', '↑'].index(self.font.json_default_variant)
+        selection = [_('ltr'), _('rtl'), _('ttb'), _('btt')].index(self.font.json_default_variant)
         self.settings_panel.font_info.default_variant.SetSelection(selection)
         selection = ['ltr', 'rtl'].index(self.font.text_direction)
         self.settings_panel.font_info.text_direction.SetSelection(selection)

--- a/templates/lettering_generate_json.xml
+++ b/templates/lettering_generate_json.xml
@@ -20,11 +20,12 @@
         <param type="string" name="font-name" gui-text="Name" indent="1" />
         <param type="string" name="font-description" gui-text="Description" indent="1" />
         
-        <param name="default_variant" type="optiongroup" appearance="combo" gui-text="Default variant" indent="1">
-             <option value="0" translatable="no">→</option>
-             <option value="1" translatable="no">←</option>
-             <option value="2" translatable="no">↓</option>
-             <option value="3" translatable="no">↑</option>
+        <param name="default_variant" type="optiongroup" appearance="combo" gui-text="Default variant"
+               gui-description="Default embroidery direction" indent="1">
+             <option value="ltr" translatable="no">Left to right</option>
+             <option value="rtl" translatable="no">Right to left</option>
+             <option value="ttb" translatable="no">Top to bottom</option>
+             <option value="btt" translatable="no">Bottom to top</option>
         </param>
         <param name="text_direction" type="optiongroup" appearance="combo" gui-text="Text direction" indent="1">
              <option value="ltr">Left to right</option>


### PR DESCRIPTION
... instead of the arrow.

Legacy font files with arrow names will still work normaly.