### PR TITLE
Do not save empty embroidery file

### DIFF
--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -49,7 +49,7 @@ class Output(InkstitchExtension):
 
     def effect(self):
         if not self.get_elements():
-            return
+            sys.exit(0)
 
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']


### PR DESCRIPTION
As mentioned in https://github.com/inkstitch/inkstitch/issues/4088 Ink/Stitch will warn about no embroiderable elements, but still saves to a file. We do not want to create empty embroidery files...