### PR TITLE
Fix params dialog not updating preview when changing stroke method

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -292,10 +292,10 @@ class ParamsTab(ScrolledPanel):
                 debug.log(f"forcing changed on parent select item: {choice_name}")
                 self.param_changed(choice_name)
 
+        self.apply()
+
         if self.on_change_hook:
             self.on_change_hook(self)
-
-        self.apply()
 
     def load_preset(self, preset):
         preset_data = preset.get(self.name, {})


### PR DESCRIPTION
## Problem
When changing the stroke method (e.g., from Running Stitch to ZigZag Stitch) in the params dialog, the preview would not update until another parameter was changed. It was working fine when we open params dialog without selecting the object.

## Root Cause
In [param_changed()](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/extensions/params.py:270:4-297:37), the `on_change_hook` (which triggers preview update) was called *before* [apply()](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/extensions/params.py:686:4-689:20) (which sets values on SVG nodes), causing the preview to render with stale values.

## Fix
Swapped the order so [apply()](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/extensions/params.py:686:4-689:20) runs first, then `on_change_hook()`.

## Testing
- Selected a stroke object
- Changed Method to ZigZag Stitch
- Verified preview updates immediately with zigzag stitches