### PR TITLE
Add zigzag angle parameter for spoke/radial stitch effects

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -285,6 +285,26 @@ class Stroke(EmbroideryElement):
 
     @property
     @param(
+        "zigzag_angle",
+        _("Zig-zag angle"),
+        tooltip=_(
+            "Rotate zig-zag direction by this angle (degrees). "
+            "Creates spoke/radial effects on curves."
+        ),
+        unit="°",
+        type="float",
+        default=0,
+        select_items=[("stroke_method", "zigzag_stitch")],
+        sort_index=7,
+    )
+    @cache
+    def zigzag_angle(self):
+        """Return the zigzag angle in degrees, clamped to -89 to 89."""
+        angle = self.get_float_param("zigzag_angle", 0)
+        return max(-89, min(89, angle))
+
+    @property
+    @param(
         "line_count",
         _("Number of lines"),
         tooltip=_("Number of lines from start to finish"),
@@ -727,7 +747,7 @@ class Stroke(EmbroideryElement):
         else:
             return self.unclipped_shape.centroid
 
-    def simple_satin(self, path, zigzag_spacing, stroke_width, pull_compensation):
+    def simple_satin(self, path, zigzag_spacing, stroke_width, pull_compensation, zigzag_angle=0):
         """Generate zig-zag along the path at the specified spacing and width.
 
         Applies zigzag to a single pass first, then handles repeats manually.
@@ -754,6 +774,7 @@ class Stroke(EmbroideryElement):
             zigzag_spacing,
             stroke_width,
             pull_compensation,
+            zigzag_angle,
         )
 
         # For closed paths (circles), ensure the last stitch connects to the first
@@ -901,6 +922,7 @@ class Stroke(EmbroideryElement):
                         self.zigzag_spacing,
                         self.stroke_width,
                         self.pull_compensation,
+                        self.zigzag_angle,
                     )
                     # bean stitch
                     if any(self.bean_stitch_repeats):

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -166,6 +166,7 @@ inkstitch_attribs = [
     'zigzag_underlay_max_stitch_length_mm',
     'e_stitch',
     'stroke_pull_compensation_mm',
+    'zigzag_angle',
     'pull_compensation_mm',
     'pull_compensation_percent',
     'stroke_first',


### PR DESCRIPTION
## Summary
Adds a new [zigzag_angle](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/elements/stroke.py:285:4-303:39) parameter to the zigzag stroke stitch method that rotates the stitch direction, creating spoke/radial effects on curved paths.

## Changes
- **New parameter:** `Zig-zag angle` (degrees) - rotates zigzag direction from perpendicular
- Angle range limited to ±89° 
- Uses averaged tangent direction at each point for smoother transitions

## Files Modified
- [lib/elements/stroke.py](cci:7://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/elements/stroke.py:0:0-0:0) - Added [zigzag_angle](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/elements/stroke.py:285:4-303:39) property
- [lib/stitches/running_stitch.py](cci:7://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/stitches/running_stitch.py:0:0-0:0) - Updated [zigzag_stitch()](cci:1://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/stitches/running_stitch.py:458:0-569:23) to rotate direction by angle
- [lib/svg/tags.py](cci:7://file:///c:/Users/Fahad/AppData/Roaming/inkscape/extensions/inkstitch/lib/svg/tags.py:0:0-0:0) - Registered new attribute

## Usage
- Set angle to 0° for normal perpendicular zigzag
- Set angle to 30-60° for tilted/radial spoke effects on curves

## Known Limitations
Sharp corners may still render asymmetrically - this is a pre-existing issue with zigzag stitch calculation that will be addressed in a future PRs may be.