### PR TITLE
Fix: Prevent crash on empty geometry and command symbols being embroi…

### DIFF
--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -727,7 +727,7 @@ class EmbroideryElement(object):
             else:
                 try:
                     next_stitch = nearest_points(next_element.first_stitch, self.shape)[1]
-                except (ValueError, AttributeError):
+                except (ValueError, AttributeError, TypeError):
                     pass
         return next_stitch
 

--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -714,7 +714,13 @@ class Stroke(EmbroideryElement):
 
     @property
     def first_stitch(self):
-        return shgeo.Point(self.as_multi_line_string().geoms[0].coords[0])
+        multi_line = self.as_multi_line_string()
+        if multi_line.is_empty or len(multi_line.geoms) == 0:
+            return None
+        first_geom = multi_line.geoms[0]
+        if first_geom.is_empty or len(first_geom.coords) == 0:
+            return None
+        return shgeo.Point(first_geom.coords[0])
 
     def _get_clipped_path(self, paths):
         if self.clip_shape is None:

--- a/lib/elements/utils/nodes.py
+++ b/lib/elements/utils/nodes.py
@@ -13,7 +13,7 @@ from ...debug.debug import sew_stack_enabled
 from ...marker import has_marker
 from ...svg import PIXELS_PER_MM
 from ...svg.tags import (CONNECTOR_TYPE, EMBROIDERABLE_TAGS,
-                         INKSCAPE_GROUPMODE, NOT_EMBROIDERABLE_TAGS,
+                         INKSCAPE_GROUPMODE, INKSCAPE_LABEL, NOT_EMBROIDERABLE_TAGS,
                          SVG_CLIPPATH_TAG, SVG_DEFS_TAG, SVG_GROUP_TAG,
                          SVG_IMAGE_TAG, SVG_MASK_TAG, SVG_TEXT_TAG)
 from ..clone import Clone, is_clone
@@ -112,6 +112,12 @@ def iterate_nodes(node: BaseElement,  # noqa: C901
 
         # command connectors with a fill color set, will glitch into the elements list
         if is_command(node) or node.get(CONNECTOR_TYPE):
+            return []
+
+        # command groups contain command symbols that should not be embroidered
+        # These are groups with labels like "Ink/Stitch Command: ..."
+        node_label = node.get(INKSCAPE_LABEL, "")
+        if node_label.startswith("Ink/Stitch Command"):
             return []
 
         if not selected:


### PR DESCRIPTION
# Fix: Prevent crash on empty geometry and command symbols being embroidered

Fixes #4154

## Changes

### 1. Fix IndexError on empty geometry
When a stroke element has empty geometry (e.g., after clipping), accessing `geoms[0]` crashed with `IndexError: index out of range`.

**Files modified:**
- [lib/elements/stroke.py](cci:7://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/elements/stroke.py:0:0-0:0): [first_stitch](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/elements/fill_stitch.py:941:4-946:19) property now returns `None` safely for empty geometry
- [lib/elements/element.py](cci:7://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/elements/element.py:0:0-0:0): Added `TypeError` to exception handling in [next_stitch](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/elements/element.py:717:4-731:26) to handle `None` values

### 2. Fix command symbols being embroidered
DST files imported into Ink/Stitch have command symbols (scissors, etc.) inlined as groups instead of `<use>` elements. These were being treated as regular embroiderable paths.