### PR TITLE
Handle empty sequences in bounding_box calculations

### DIFF
--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -167,6 +167,9 @@ class ColorBlock(object):
 
     @property
     def bounding_box(self):
+        if not self.stitches:
+            # Return zero-size bounding box at origin if no stitches
+            return (0, 0, 0, 0)
         minx = min(stitch.x for stitch in self)
         miny = min(stitch.y for stitch in self)
         maxx = max(stitch.x for stitch in self)

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -188,7 +188,10 @@ class StitchPlan(object):
 
     @property
     def bounding_box(self):
-        color_block_bounding_boxes = [cb.bounding_box for cb in self]
+        color_block_bounding_boxes = [cb.bounding_box for cb in self if len(cb) > 0]
+        if not color_block_bounding_boxes:
+            # Return zero-size bounding box at origin if no stitches
+            return (0, 0, 0, 0)
         minx = min(bb[0] for bb in color_block_bounding_boxes)
         miny = min(bb[1] for bb in color_block_bounding_boxes)
         maxx = max(bb[2] for bb in color_block_bounding_boxes)


### PR DESCRIPTION
# Fix ValueError when opening empty/malformed embroidery files

Fixes #4039

## Problem
Opening certain DST files causes `ValueError: min() arg is an empty sequence` crash in the stitch plan generation.

## Solution
Added defensive checks in [bounding_box](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitch_plan/stitch_plan.py:188:4-199:37) properties to handle empty stitch data gracefully, returning [(0, 0, 0, 0)](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitches/running_stitch.py:20:0-22:30) when no stitches are present.

## Changes
- [lib/stitch_plan/stitch_plan.py](cci:7://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitch_plan/stitch_plan.py:0:0-0:0) - Skip empty color blocks in [bounding_box](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitch_plan/stitch_plan.py:188:4-199:37), return zeros if all empty
- [lib/stitch_plan/color_block.py](cci:7://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitch_plan/color_block.py:0:0-0:0) - Handle empty stitches in [bounding_box](cci:1://file:///media/fahad090np/Drive/Work/OpenSource/InkStitch/inkstitch/lib/stitch_plan/stitch_plan.py:188:4-199:37)