### PR TITLE
Object commands: add position option

### DIFF
--- a/lib/extensions/commands.py
+++ b/lib/extensions/commands.py
@@ -15,3 +15,4 @@ class CommandsExtension(InkstitchExtension):
         InkstitchExtension.__init__(self, *args, **kwargs)
         for command in self.COMMANDS:
             self.arg_parser.add_argument("--%s" % command, type=Boolean)
+        self.arg_parser.add_argument("--command_position", type=str, dest="command_position", default="random")

--- a/lib/extensions/object_commands.py
+++ b/lib/extensions/object_commands.py
@@ -4,10 +4,13 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from inkex import errormsg
+from shapely.geometry import Point
+from shapely.ops import nearest_points
 
 from ..commands import OBJECT_COMMANDS, add_commands
 from ..elements import Clone
 from ..i18n import _
+from ..utils.geometry import ensure_multi_polygon
 from .commands import CommandsExtension
 
 
@@ -46,5 +49,32 @@ class ObjectCommands(CommandsExtension):
 
         for element in self.elements:
             if element.node not in seen_nodes and element.shape and not isinstance(element, Clone):
-                add_commands(element, commands)
+                position = self._get_position(element)
+                add_commands(element, commands, pos=position)
                 seen_nodes.add(element.node)
+
+    def _get_position(self, element):
+        command_position = self.options.command_position
+        position = None
+        if command_position != "random":
+            outline, bounds = self._get_element_outline_and_bounds(element)
+
+        if command_position == "top_left":
+            position = nearest_points(outline, Point(bounds[0], bounds[1]))[0]
+        elif command_position == "top_right":
+            position = nearest_points(outline, Point(bounds[2], bounds[1]))[0]
+        elif command_position == "bottom_left":
+            position = nearest_points(outline, Point(bounds[0], bounds[3]))[0]
+        elif command_position == "bottom_right":
+            position = nearest_points(outline, Point(bounds[2], bounds[3]))[0]
+        return position
+
+    def _get_element_outline_and_bounds(self, element):
+        if element.name == "Stroke":
+            shape = element.as_multi_line_string()
+        else:
+            shape = element.shape
+        shape = ensure_multi_polygon(shape.buffer(0.001)).geoms[-1]
+        outline = shape.exterior
+        bounds = outline.bounds
+        return outline, bounds

--- a/templates/object_commands.xml
+++ b/templates/object_commands.xml
@@ -5,6 +5,13 @@
     {%- for command, description in object_commands -%}
     <param name="{{ command }}" type="boolean" gui-text="{{ description }}">false</param>
     {% endfor %}
+    <param name="command_position" type="optiongroup" appearance="combo" gui-text="Command position">
+       <option value="random" default="true">Random</option>
+       <option value="top_left">Top left</option>
+       <option value="top_right">Top right</option>
+       <option value="bottom_left">Bottom left</option>
+       <option value="bottom_right">Bottom right</option>
+</param>
     <param name="extension" type="string" gui-hidden="true">object_commands</param>
     <effect>
         <object-type>all</object-type>


### PR DESCRIPTION
Object commands: option to define a general position. The command will attach to the nearest point of the specified bounding box corner.

Useful for a cross stitch font in development... feature request.