### PR TITLE
Stroke: ignore invalid shapes in first_stitch

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -714,7 +714,11 @@ class Stroke(EmbroideryElement):
 
     @property
     def first_stitch(self):
-        return shgeo.Point(self.as_multi_line_string().geoms[0].coords[0])
+        try:
+            return shgeo.Point(self.as_multi_line_string().geoms[0].coords[0])
+        except IndexError:
+            # shape is invalid or completely clipped
+            return None
 
     def _get_clipped_path(self, paths):
         if self.clip_shape is None:


### PR DESCRIPTION
Completely clipped strokes fail with an IndexError in first_stitch method.
We can simply return None as the first stitch value, when the path is empty.
The only impact is the end position of the previous element.

Fixes #4154