### PR TITLE
Params: set tooltips on inputs

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -505,6 +505,8 @@ class ParamsTab(ScrolledPanel):
                 input = wx.TextCtrl(self, wx.ID_ANY, value=str(value))
                 input.Bind(wx.EVT_TEXT, self.changed)
 
+            input.SetToolTip(param.tooltip)
+
             self.param_name_to_input[param.name] = input
 
             if param.type == 'random_seed':


### PR DESCRIPTION
Tooltips were only shown on hovering the labels, not the input fiels. People usually miss to see them.
I hope this helps a little (until sew stack is available).