### PR TITLE
Update sys.exit(0) calls to account for changes in Inkscape handling extensions

### DIFF
--- a/lib/extensions/auto_satin.py
+++ b/lib/extensions/auto_satin.py
@@ -34,7 +34,8 @@ class AutoSatin(CommandsExtension):
             this_command = satin.get_command(command_type)
             if command is not None and this_command:
                 inkex.errormsg(_("Please ensure that at most one start and end command is attached to the selected satin columns."))
-                sys.exit(0)
+                self.skip_output()
+                return None
             elif this_command:
                 command = this_command
 

--- a/lib/extensions/base.py
+++ b/lib/extensions/base.py
@@ -22,10 +22,31 @@ class InkstitchExtension(inkex.EffectExtension):
     # only be available in development installations.
     DEVELOPMENT_ONLY = False
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._skip_output = False
+
     def load(self, *args, **kwargs):
         document = super().load(*args, **kwargs)
         update_inkstitch_document(document)
         return document
+
+    def write_file(self, filename):
+        """Override write_file to skip output if _skip_output is set.
+        
+        This provides a safe way to prevent SVG output without calling sys.exit(),
+        which can cause Inkscape to crash during document cleanup.
+        """
+        if not self._skip_output:
+            super().write_file(filename)
+
+    def skip_output(self):
+        """Mark that the extension output should not be written to the SVG file.
+        
+        This is a safe alternative to sys.exit(0) that allows Inkscape to properly
+        clean up the document without crashing.
+        """
+        self._skip_output = True
 
     @classmethod
     def name(cls):

--- a/lib/extensions/batch_lettering.py
+++ b/lib/extensions/batch_lettering.py
@@ -88,7 +88,7 @@ class BatchLettering(InkstitchExtension):
         self.generate_output_files(texts, file_formats)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()
 
     def setup_trim(self):
         self.trim = 0

--- a/lib/extensions/lettering.py
+++ b/lib/extensions/lettering.py
@@ -83,4 +83,4 @@ class Lettering(CommandsExtension):
         if self.cancelled:
             # This prevents the superclass from outputting the SVG, because we
             # may have modified the DOM.
-            sys.exit(0)
+            self.skip_output()

--- a/lib/extensions/output.py
+++ b/lib/extensions/output.py
@@ -49,7 +49,8 @@ class Output(InkstitchExtension):
 
     def effect(self):
         if not self.get_elements():
-            sys.exit(0)
+            self.skip_output()
+            return
 
         self.metadata = self.get_inkstitch_metadata()
         collapse_len = self.metadata['collapse_len_mm']
@@ -81,4 +82,4 @@ class Output(InkstitchExtension):
         os.remove(temp_file.name)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()

--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -700,7 +700,6 @@ class SettingsPanel(wx.Panel):
         self.simulator.stop()
         wx.CallAfter(self.GetTopLevelParent().cancel)
         # Do not apply changes
-        sys.exit(0)
 
     def __do_layout(self):
         # begin wxGlade: MyFrame.__do_layout
@@ -883,6 +882,6 @@ class Params(InkstitchExtension):
             if self.cancelled:
                 # This prevents the superclass from outputting the SVG, because we
                 # may have modified the DOM.
-                sys.exit(0)
+                self.skip_output()
         except NoValidObjects:
             self.no_elements_error()

--- a/lib/extensions/png_realistic.py
+++ b/lib/extensions/png_realistic.py
@@ -35,4 +35,4 @@ class PngRealistic(InkstitchExtension):
         write_png_output(self.svg, layer, self.options.dpi)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()

--- a/lib/extensions/png_simple.py
+++ b/lib/extensions/png_simple.py
@@ -42,7 +42,7 @@ class PngSimple(InkstitchExtension):
         write_png_output(self.svg, layer, self.options.dpi)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()
 
 
 def write_png_output(svg, layer, dpi):

--- a/lib/extensions/satin_multicolor.py
+++ b/lib/extensions/satin_multicolor.py
@@ -57,4 +57,4 @@ class SatinMulticolor(InkstitchExtension):
         if self.cancelled:
             # This prevents the superclass from outputting the SVG, because we
             # may have modified the DOM.
-            sys.exit(0)
+            self.skip_output()

--- a/lib/extensions/select_elements.py
+++ b/lib/extensions/select_elements.py
@@ -102,7 +102,8 @@ class SelectElements(InkstitchExtension):
             errormsg(_("Could not detect python path. "
                        "Please insert python path manually as described in the help tab "
                        "of the select elements dialog."))
-            sys.exit(0)
+            self.skip_output()
+            return None, None
 
         return py_path, file_path
 

--- a/lib/extensions/sew_stack_editor.py
+++ b/lib/extensions/sew_stack_editor.py
@@ -563,4 +563,4 @@ class SewStackEditor(InkstitchExtension):
         if self.cancelled:
             # This prevents the superclass from outputting the SVG, because we
             # may have modified the DOM.
-            sys.exit(0)
+            self.skip_output()

--- a/lib/extensions/tartan.py
+++ b/lib/extensions/tartan.py
@@ -89,4 +89,4 @@ class Tartan(InkstitchExtension):
         if self.cancelled:
             # This prevents the superclass from outputting the SVG, because we
             # may have modified the DOM.
-            sys.exit(0)
+            self.skip_output()

--- a/lib/extensions/thread_list.py
+++ b/lib/extensions/thread_list.py
@@ -33,7 +33,7 @@ class ThreadList(InkstitchExtension):
         sys.stdout.write(thread_list)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()
 
 
 def get_threadlist(stitch_plan, design_name):

--- a/lib/extensions/zip.py
+++ b/lib/extensions/zip.py
@@ -99,7 +99,7 @@ class Zip(InkstitchExtension):
         os.rmdir(path)
 
         # don't let inkex output the SVG!
-        sys.exit(0)
+        self.skip_output()
 
     def _get_file_name(self):
         if self.options.custom_file_name:


### PR DESCRIPTION
The Ink/Stitch extension crashes in current Inkscape. I filed the crash here:
[inkscape/inbox#13148
](https://gitlab.com/inkscape/inbox/-/issues/13148)

I used the stack crawl + Claude to figure out that "Inkscape" has a new way that extensions should use instead of "sys.exit(0)" when they are done with their work. I asked Claude to make that edit to Ink/Stitch. This is the result. It compiles. I do not know if it works. Someone with more experience building the extension will need to test it. 

[EDIT] After testing, found that the sys.exit(0) issue goes back much further than 1.4.3. 