### PR TITLE
macOS intel fixed misconfiguration now build intel version on macos15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,7 +353,7 @@ jobs:
           name: inkstitch-windows64
           path: signed-artifacts
   macx86:
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6
         with:
@@ -418,7 +418,7 @@ jobs:
           name: inkstitch-mac-x86
           path: artifacts
   macarm64:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
macOS arm set to macos14 and fix issue of macOS intel version not building