### PR TITLE
CI: Moved checks out of build into test, pinned versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,21 +58,11 @@ jobs:
 
           python -m pip install pyinstaller
 
-          python -m pip install flake8
-
           echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
       - name: Tests
         shell: bash
         run: |
           pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
-      - name: Style check
-        run: bash -x bin/style-check
       - shell: bash
         run: |
           make dist
@@ -137,12 +127,6 @@ jobs:
         shell: bash
         run: |
           pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
       - shell: bash
         run: |
           make dist
@@ -286,12 +270,6 @@ jobs:
         shell: bash
         run: |
           pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
       - shell: bash
         run: |
           make dist
@@ -398,12 +376,6 @@ jobs:
         shell: bash
         run: |
           pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
       - shell: bash
         run: |
           make dist
@@ -463,12 +435,6 @@ jobs:
         shell: bash
         run: |
           pytest
-      - name: Mypy Type Checking
-        shell: bash
-        run: |
-          python -m pip install mypy
-          python -m mypy --output json | python .github/mypy-github-formatter
-        continue-on-error: true
       - shell: bash
         run: |
           make dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch: {}
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -37,8 +37,6 @@ jobs:
           python -m pip install PyGObject==3.50.0
           python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.2-cp311-cp311-linux_x86_64.whl
           python -m pip install -r requirements.txt
-          python -m pip install mypy
-          python -m pip install flake8
 
       - name: Run tests
         run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,16 +30,22 @@ diskcache
 flask-cors
 pywinutils ; sys_platform == 'win32'
 pywin32 ; sys_platform == 'win32'
-types-pywin32; sys_platform == 'win32'
 
-# Test dependencies.
+# Dev dependencies
 # It should be okay to include these here because this list isn't the one used for bundling dependencies.
 # Instead Pyinstaller finds what dependencies the project needs based on what inkstitch.py imports
+
+# Checkers: Versions pinned to stop an update to them introducing check failures
+mypy==1.19.1
+flake8==7.3.0
+
+# Test dependencies
 pytest
 
-# Misc dev dependencies
+# Types
 types-wxpython
 types-appdirs
 types-shapely
 types-networkx
 types-lxml
+types-pywin32


### PR DESCRIPTION
As discussed in previous PR, moved the checks to just the Test workflow. Also, pinned the versions of mypy and flake8 to prevent spontaneous new style violations when their versions update.