### PR TITLE
Fix untyped decorator errors (and downstream type errors)

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -339,6 +339,9 @@ def ensure_symbol(svg, command) -> None:
     defs = svg.defs
     if defs.find(path) is None:
         symbol = deepcopy(symbol_defs().find(path))
+        if symbol is None:
+            # We should, essentially, never get here.
+            raise ValueError(f"Unable to find {command} in Ink/Stitch symbols!")
         symbol.transform = 'scale(0.25)'
         symbol.style['opacity'] = 0.7
         defs.append(symbol)

--- a/lib/debug/debug.py
+++ b/lib/debug/debug.py
@@ -7,6 +7,7 @@ import atexit  # to save svg file on exit
 import time    # to measure time of code block, use time.monotonic() instead of time.time()
 import traceback
 from datetime import datetime
+from typing import TypeVar, Callable, Any, cast
 
 from contextlib import contextmanager  # to measure time of with block
 from pathlib import Path  # to work with paths as objects
@@ -22,6 +23,9 @@ from ..utils.paths import get_ini
 
 import logging
 logger = logging.getLogger("inkstitch.debug")   # create module logger with name 'inkstitch.debug'
+
+# See https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
+F = TypeVar('F', bound=Callable[..., Any])
 
 # to log messages if previous debug logger is not enabled
 logger_inkstich = logging.getLogger("inkstitch")   # create module logger with name 'inkstitch'
@@ -163,7 +167,7 @@ class Debug(object):
         logger.info(msg)
 
     # decorator to measure time of function
-    def time(self, func):
+    def time(self, func: F) -> F:
         def decorated(*args, **kwargs):
             if self.enabled:
                 self.raw_log("entering %s()", func.__name__)
@@ -177,7 +181,7 @@ class Debug(object):
 
             return result
 
-        return decorated
+        return cast(F, decorated)
 
     @check_enabled
     @unwrap_arguments

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -940,7 +940,7 @@ class FillStitch(EmbroideryElement):
 
     @property
     def first_stitch(self):
-        # Serves as a reverence point for the end point of the previous element
+        # Serves as a reference point for the end point of the previous element
         if self.get_command('starting_point'):
             return shgeo.Point(*self.get_command('starting_point').target_point)
         return None

--- a/lib/extensions/cut_satin.py
+++ b/lib/extensions/cut_satin.py
@@ -30,7 +30,7 @@ class CutSatin(InkstitchExtension):
                 self.index = parent.index(satin.node)
                 self.label_index = 0
 
-                commands = satin.get_command("satin_cut_point", True)
+                commands = satin.get_commands("satin_cut_point")
 
                 if commands is None:
                     # L10N will have the satin's id prepended, like this:

--- a/lib/utils/cache.py
+++ b/lib/utils/cache.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import pickle
 import sqlite3
+from typing import TypeVar, Callable, Any, cast
 
 import diskcache  # type: ignore[import-untyped]
 
@@ -15,10 +16,13 @@ from lib.utils.settings import global_settings
 from .paths import get_user_dir
 from functools import lru_cache
 
+# See https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
+F = TypeVar('F', bound=Callable[..., Any])
+
 
 # simplify use of lru_cache decorator
-def cache(*args, **kwargs):
-    return lru_cache(maxsize=None)(*args, **kwargs)
+def cache(func: F) -> F:
+    return cast(F, lru_cache(maxsize=None)(func))
 
 
 __stitch_plan_cache = None

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -9,7 +9,8 @@ from itertools import groupby
 
 import numpy
 from shapely.geometry import (GeometryCollection, LinearRing, LineString,
-                              MultiLineString, MultiPoint, MultiPolygon)
+                              MultiLineString, MultiPoint, MultiPolygon, Polygon)
+from shapely.geometry.base import BaseGeometry
 from shapely.geometry import Point as ShapelyPoint
 
 
@@ -138,16 +139,16 @@ def ensure_geometry_collection(thing):
     return GeometryCollection([thing])
 
 
-def ensure_multi_polygon(thing, min_size=0):
+def ensure_multi_polygon(thing: BaseGeometry, min_size=0) -> MultiPolygon:
     """Given a shapely geometry, return a MultiPolygon"""
     multi_polygon = MultiPolygon()
     if thing.is_empty:
         return multi_polygon
-    if thing.geom_type == "MultiPolygon":
+    if isinstance(thing, MultiPolygon):
         multi_polygon = thing
-    elif thing.geom_type == "Polygon":
+    elif isinstance(thing, Polygon):
         multi_polygon = MultiPolygon([thing])
-    elif thing.geom_type == "GeometryCollection":
+    elif isinstance(thing, GeometryCollection):
         multipolygon = []
         for shape in thing.geoms:
             if shape.geom_type == "MultiPolygon":

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -521,7 +521,12 @@ class CloneElementTest(TestCase):
             self.assertEqual(len(elements), element_count())
             cmd_orig = original.get_command("ending_point")
             cmd_clone = elements[0].get_command("ending_point")
+            self.assertIsNotNone(cmd_orig)
             self.assertIsNotNone(cmd_clone)
+            # Typechecker doesn't understand assertIsNotNone, need these asserts to narrow
+            # the type to non-None. See https://github.com/python/mypy/issues/4063
+            assert cmd_orig is not None
+            assert cmd_clone is not None
             self.assertAlmostEqual(cmd_orig.target_point[0]+10, cmd_clone.target_point[0], 4)
             self.assertAlmostEqual(cmd_orig.target_point[1]+10, cmd_clone.target_point[1], 4)
 
@@ -548,7 +553,12 @@ class CloneElementTest(TestCase):
             self.assertEqual(len(elements), element_count())
             cmd_orig = original.get_command("ending_point")
             cmd_clone = elements[0].get_command("ending_point")
+            self.assertIsNotNone(cmd_orig)
             self.assertIsNotNone(cmd_clone)
+            # Typechecker doesn't understand assertIsNotNone, need these asserts to narrow
+            # the type to non-None. See https://github.com/python/mypy/issues/4063
+            assert cmd_orig is not None
+            assert cmd_clone is not None
             self.assertAlmostEqual(cmd_orig.target_point[0]+10, cmd_clone.target_point[0], 4)
             self.assertAlmostEqual(cmd_orig.target_point[1]+10, cmd_clone.target_point[1], 4)
 


### PR DESCRIPTION
- Added types to untyped decorators (see https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators). If/when we move to Python 3.12 as the minimum version, we can ditch the `TypeVar` uses in favor of the better generic syntax .
- Fixed a bunch of downstream type errors exposed by fixing the type errors.
- Fixed a couple of other misc type errors that I'm surprised never cropped up before in the tests.
- Fixed a typo.

Tested "split satin", tartan fill, and a couple of misc. other tests embroidering some basic shapes and files and did not see any regressions.