### PR TITLE
Create directory if it can be created without raising an error

### DIFF
--- a/lib/utils/paths.py
+++ b/lib/utils/paths.py
@@ -43,11 +43,9 @@ def get_resource_dir(name):
 
 def get_user_dir(name=None, create=True):
     try:
-        path = platformdirs.user_config_dir('inkstitch')
+        path = platformdirs.user_config_dir(appname='inkstitch', ensure_exists=create)
     except ImportError:
         path = os.path.expanduser('~/.inkstitch')
-    if create and not os.path.exists(path):
-        os.makedirs(path)
 
     if name is not None:
         path = os.path.join(path, name)


### PR DESCRIPTION
See https://platformdirs.readthedocs.io/en/latest/api.html

This will mean that a new installation will not create an error dialog if the path can be created if it did not exist.