### PR TITLE
Improved dev docs: inkscape python venv config

### DIFF
--- a/collections/_developers/en/002-002-manual-setup.md
+++ b/collections/_developers/en/002-002-manual-setup.md
@@ -1,7 +1,7 @@
 ---
 title: "Manual Setup for Linux and macOS"
 permalink: /developers/inkstitch/manual-setup/
-last_modified_at: 2025-10-19
+last_modified_at: 2026-02-09
 toc: true
 after_footer_scripts:
   - /assets/js/copy_code.js
@@ -10,7 +10,8 @@ A manual setup will allow you to edit the code while running the extension.
 
 ## How to Install Ink/Stitch Manually
 
-We recommend using `pyenv` with python 3.11.
+The required python version for working with Ink/Stitch is >=3.11.0.
+We recommend using `pyenv` to manage your Python virtual environmentm but any other virtual environment manager should work (ex. `conda`, `uv` etc..)
 
 ### 1. Clone the extension source
 
@@ -49,15 +50,10 @@ cd ~/.config/inkscape/extensions
 ln -s /path/to/inkstitch
 ```
 
-### 5. Run Inkscape.
+### 5. Configure Inkscape Python Environment (Linux only)
 
-Changes to the Python code take effect the next time the extension is run. Changes to the extension description files (`*.inx`) take effect the next time Inkscape is restarted.
-
-## Troubleshoot
-
-### ImportError: No module named shapely
-
-If Ink/Stitch returns `ImportError: No module named shapely`, then it is likely the version of Python used by Inkscape and the version you installed the Python dependencies for above are different.
+By default, Inkscape will use your system's python interpreter. On modern linux distributions, the [PEP668](https://peps.python.org/pep-0668/) standard prevents you from installing python packages directly into the system python interpreter.
+To work around this limitation, we need to tell Inkscape to use the python interpreter we installed in step 2:
 
 * Open the file `preferences.xml`.<br>
   The location can be found under `Edit > Preferences > System > User preferences`
@@ -66,3 +62,10 @@ If Ink/Stitch returns `ImportError: No module named shapely`, then it is likely 
 * Search for the term `<group id="extensions" />` and update to the correct Python interpreter.
 
   **Example:** Use `<group id="extensions" python-interpreter="/usr/local/bin/python3" />` where `/usr/local/bin/python3` is the value returned by `which python3`.
+
+For more information see [Inkscape documentation](https://inkscape.gitlab.io/extensions/documentation/authors/interpreters.html#selecting-a-specific-interpreter-version-via-preferences-file).
+
+### 6. Run Inkscape.
+
+Changes to the Python code take effect the next time the extension is run. Changes to the extension description files (`*.inx`) take effect the next time Inkscape is restarted.
+


### PR DESCRIPTION
Improvements in the dev docs:
- Mention the appropriate python version
- Mention that inkscape needs to use the appropriate venv on linux systems