### PR TITLE
Skip clamping when buffering the polygon returns GEOSException

### DIFF
--- a/lib/utils/clamp_path.py
+++ b/lib/utils/clamp_path.py
@@ -1,8 +1,8 @@
+from shapely.errors import GEOSException
 from shapely.geometry import LineString, MultiPolygon
 from shapely.geometry import Point as ShapelyPoint
 from shapely.ops import nearest_points
 from shapely.prepared import prep
-from shapely.errors import GEOSException
 
 from .geometry import (Point, ensure_geometry_collection,
                        ensure_multi_line_string)


### PR DESCRIPTION
Buffering the polygon seems to fail when coordinate values are very high (shape is way off from the canvas).
However, the output results seem to be better, when we do not try to continue clamping, so we can just skip it as well.

I might be wrong, but I think this is enough effort for fixing this kind of a setup...
Fixes #4219