### PR TITLE
make it easier for user to understand

### DIFF
--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -151,10 +151,10 @@ class JumpToStroke(InkstitchExtension):
 
         # do not add a running stitch if the distance is smaller than min_jump setting
         line = DirectedLineSegment((start.x, start.y), (end.x, end.y))
-        if line.length < self.options.min_jump * PIXELS_PER_MM:
+        if line.length <= self.options.min_jump * PIXELS_PER_MM:
             return
         # do not add a running stitch if the distance is longer than max_jump setting
-        if self.options.max_jump > 0 and line.length > self.options.max_jump * PIXELS_PER_MM:
+        if self.options.max_jump > 0 and line.length >= self.options.max_jump * PIXELS_PER_MM:
             return
 
         path = Path([(start.x, start.y), (end.x, end.y)])

--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -16,9 +16,9 @@
     <param name="tab" type="notebook">
       <page name="options" gui-text="Options">
         <param name="minimum-jump-length" type="float" precision="2" min="0" max="100"
-               gui-text="Convert jumps not shorter than (mm)">3.0</param>
+               gui-text="Convert jumps longer than (mm)">3.0</param>
         <param name="maximum-jump-length" type="float" precision="2" min="0" max="10000"
-               gui-text="Convert jumps not longer than (mm)">0</param>
+               gui-text="Convert jumps shorter than (mm)">0</param>
         <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
             <option value="all">all</option>
             <option value="layer">in same layer</option>


### PR DESCRIPTION
replace "not shorter" by "longer" and "not longer" by "shorter" in the template of jump to stroke, change the code accordingly.

I had a discussion with users of the US based Facebook group, as they were complaining that they could not understand jumps to strokes options.

It seems that the problem is that understanding a negation is harder.

This branch simply replaces "not longer" by shorter and "not shorter" by longer to help users understand the options, and change the code accordingly (switching from "<" to "≤")
