### PR TITLE
Jump to stroke: use min jump stitch length...

### DIFF
--- a/templates/jump_to_stroke.xml
+++ b/templates/jump_to_stroke.xml
@@ -16,9 +16,9 @@
     <param name="tab" type="notebook">
       <page name="options" gui-text="Options">
         <param name="minimum-jump-length" type="float" precision="2" min="0" max="100"
-               gui-text="Convert jumps longer than (mm)">3.0</param>
+               gui-text="Convert jumps longer than (mm)" gui-description="A value of 0 defaults to the actual minimum jump stitch length.">0</param>
         <param name="maximum-jump-length" type="float" precision="2" min="0" max="10000"
-               gui-text="Convert jumps shorter than (mm)">0</param>
+               gui-text="Convert jumps shorter than (mm)" gui-description="A value of 0 means no size limit.">0</param>
         <param name="connect" type="optiongroup" appearance="combo" gui-text="Connect">
             <option value="all">all</option>
             <option value="layer">in same layer</option>


### PR DESCRIPTION
... when users sets convert jumps longer than to zero.

Additionally remove dasharray setting. It's not necessary anymore and makes it harder to see the actual start and end points of the line.