### PR TITLE
allow for jumps between eulerian cycles

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -1269,15 +1269,16 @@ class FillStitch(EmbroideryElement):
                 end = final_end
             stitch_lists = cross_stitch(self, shape, start, end)
             for stitch_list in stitch_lists:
-                stitch_group = StitchGroup(
-                    color=self.color,
-                    tags=("cross_stitch"),
-                    stitches=stitch_list,
-                    force_lock_stitches=self.force_lock_stitches,
-                    lock_stitches=self.lock_stitches
-                )
-                previous_stitch_group = stitch_group
-                stitch_groups.append(stitch_group)
+                for cycle in stitch_list:
+                    stitch_group = StitchGroup(
+                        color=self.color,
+                        tags=("cross_stitch"),
+                        stitches=cycle,
+                        force_lock_stitches=self.force_lock_stitches,
+                        lock_stitches=self.lock_stitches
+                    )
+                    previous_stitch_group = stitch_group
+                    stitch_groups.append(stitch_group)
         return stitch_groups
 
     def do_circular_fill(self, shape, starting_point, ending_point):

--- a/lib/stitches/cross_stitch.py
+++ b/lib/stitches/cross_stitch.py
@@ -280,11 +280,12 @@ def _unrotate_coords(x, y):
 def _cycles_to_stitches(eulerian_cycles, max_stitch_length, flip):
     stitches = []
     for cycle in eulerian_cycles:
+        cycle_stitches = []
         if cycle is not None:
             last_point = cycle[0]
             if flip:
                 last_point = _unrotate_coords(*last_point)
-            stitches.append(Stitch(*last_point, tags=["cross_stitch"]))
+            cycle_stitches.append(Stitch(*last_point, tags=["cross_stitch"]))
             for point in cycle[1:]:
                 if flip:
                     point = _unrotate_coords(*point)
@@ -292,6 +293,7 @@ def _cycles_to_stitches(eulerian_cycles, max_stitch_length, flip):
                     continue
                 line = LineString([last_point, point]).segmentize(max_stitch_length)
                 for coord in line.coords:
-                    stitches.append(Stitch(*coord, tags=["cross_stitch"]))
+                    cycle_stitches.append(Stitch(*coord, tags=["cross_stitch"]))
                 last_point = point
+        stitches.append(cycle_stitches)
     return stitches


### PR DESCRIPTION
When the shape is disconnected cross_stitch wise, we should not have all the Eulerian cycles in the same StitchGroup to allow jumps instead of long stitches in between cycles.