### PR TITLE
Fill to satin: skip when there is no combinable rung

### DIFF
--- a/lib/extensions/fill_to_satin.py
+++ b/lib/extensions/fill_to_satin.py
@@ -260,8 +260,6 @@ class FillElementToSatin:
     def _combined_segments_to_satin_geoms(self, combined_rails, combined_rungs, satin_segments):
         combined_satins = []
         for i, segments in combined_rails.items():
-            if not combined_rungs[i]:
-                continue
             segment_geoms = []
             for segment_index in set(segments):
                 segment_geoms.extend(list(satin_segments[segment_index].geoms))
@@ -275,7 +273,8 @@ class FillElementToSatin:
 
             # adjust rail direction and starting points
             satin_rails = [self._adjust_rail_direction(satin_rails)]
-            satin_rails = [self._adjust_closed_path_starting_point(satin_rails, self.rungs[combined_rungs[i][0]])]
+            if combined_rungs[i]:
+                satin_rails = [self._adjust_closed_path_starting_point(satin_rails, self.rungs[combined_rungs[i][0]])]
 
             segment_geoms = []
             for rung_index in set(combined_rungs[i]):


### PR DESCRIPTION
<img width="428" height="647" alt="Fill to satin problem" src="https://github.com/user-attachments/assets/a2ee8099-7aa6-4db5-bc75-294002590e42" />

With a setup like this (the second rung not intersecting the fill twice and the last one not bridged), the last segment is somehow cut off from the rest of the to be build satin. With the current implementation we would receive an error message. Let's at least ignore the bottom part as we don't know how to connect it. Users can undo and inspect the area.