### PR TITLE
Cross stitch helper visual

### DIFF
--- a/lib/elements/image.py
+++ b/lib/elements/image.py
@@ -62,7 +62,10 @@ class ImageObject(EmbroideryElement):
         # biggest path.
         paths = self.paths
         paths.sort(key=lambda point_list: Polygon(point_list).area, reverse=True)
-        shape = MultiPolygon([(paths[0], paths[1:])])
+        if len(paths) > 1:
+            shape = MultiPolygon([(paths[0], paths[1:])])
+        else:
+            shape = MultiPolygon([paths])
         return shape
 
     def center(self):

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -33,7 +33,7 @@ class CrossStitchHelper(InkstitchExtension):
             'set_params': True,
             'cross_method': 'simple_cross',
             'pixelize': False,
-            'pixelize_combined': True,
+            'remove_overlaps': True,
             'coverage': 50,
             'grid_offset': '0',
             'align_with_canvas': True,
@@ -86,10 +86,11 @@ class CrossStitchHelper(InkstitchExtension):
         self.settings = settings
 
         # Pixelate and parametrize elements
-        if self.settings['pixelize_combined']:
+        if self.settings['remove_overlaps']:
             # first convert images to fills, then process everything at once
             fills = self._prepare_fills(elements, palette)
-            self.pixelize_combined(fills)
+            if fills:
+                self.pixelize_combined(fills)
         else:
             self._process_elements(elements, palette)
 

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from inkex import Color, Grid, Group, Path
+from inkex import Color, Grid, Group, Path, errormsg
 from inkex.units import convert_unit
 
 from ..elements import FillStitch
@@ -43,6 +43,7 @@ class CrossStitchHelper(InkstitchExtension):
             'remove_grids': False,
             'color_method': 0,
             'convert_bitmap': False,
+            'pixel_by_pixel': False,
             'bitmap_num_colors': 5,
             'bitmap_quantize_method': 1,
             'bitmap_rgb_colors': '',
@@ -69,6 +70,11 @@ class CrossStitchHelper(InkstitchExtension):
         for element in self.elements:
             if element.name in ["Image", "FillStitch"]:
                 elements.append(element)
+
+        # No elements selected, exit with an error message
+        if not elements:
+            errormsg(_("Please select at least one element with a fill color or one image."))
+            return
 
         # When elements have been combined, we need to define a place in the layering order for our new group
         # Let's take the top most element from selection

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -6,6 +6,7 @@
 from inkex import Color, Grid, Group, Path
 from inkex.units import convert_unit
 
+from ..elements import FillStitch
 from ..gui.cross_stitch_helper import CrossStitchHelperApp
 from ..i18n import _
 from ..svg import get_correction_transform
@@ -63,54 +64,73 @@ class CrossStitchHelper(InkstitchExtension):
             # nothing was selected, keep it this way
             self.elements = []
 
-        # collect image and fill elements
-        images = []
-        fills = []
+        # Fillter to only handle image and fill elements
+        elements = []
         for element in self.elements:
-            if element.name == "Image":
-                images.append(element)
-            elif element.name == "FillStitch":
-                fills.append(element)
+            if element.name in ["Image", "FillStitch"]:
+                elements.append(element)
+
+        # Images may have been converted to fills which are not in the document
+        # therefore we define a fallback element node, so we can use it to find a got spot to include the new elements
+        self.fallback_element = None
+        if elements:
+            self.fallback_element = elements[-1]
 
         palette = self._get_stroke_palette()
 
-        app = CrossStitchHelperApp(settings=settings, fills=fills, images=images, palette=palette)
+        app = CrossStitchHelperApp(settings=settings, elements=elements, palette=palette)
         app.MainLoop()
 
         if not settings['applied']:
             return
         self.settings = settings
 
-        # process elements
-        self._process_images(images, palette)
-        self._process_fills(fills)
+        # Pixelate and parametrize elements
+        if self.settings['pixelize_combined']:
+            # first convert images to fills, then process everything at once
+            fills = self._prepare_fills(elements, palette)
+            self.pixelize_combined(fills)
+        else:
+            self._process_elements(elements, palette)
 
         # add grid
         if settings['set_grid']:
             self.setup_page_grid()
 
-    def _process_images(self, images, palette):
-        if not self.settings['convert_bitmap']:
-            return
-        for image in images:
-            self.process_image(image, palette)
-
-    def _process_fills(self, fills):
-        if not fills:
-            return
-
-        if self.settings['pixelize']:
-            if self.settings['pixelize_combined']:
-                self.pixelize_combined(fills)
+    def _prepare_fills(self, elements, palette):
+        fills = []
+        for element in elements:
+            if element.name == "FillStitch":
+                if self.settings['pixelize']:
+                    fills.append(element)
+                elif self.settings['set_params']:
+                    # when pixelize is disabled, set params on each fill element
+                    self.set_element_cross_stitch_params(element.node)
             else:
-                for fill in fills:
-                    self.pixelize_single(fill)
-        elif self.settings['set_params']:
-            # Pixelize may split up elements
-            # we handle param settings in pixelize when enabled
-            # when pixelize is disabled, set params on each fill element
-            for fill in fills:
-                self.set_element_cross_stitch_params(fill.node)
+                if not self.settings['convert_bitmap']:
+                    continue
+                bitmap_convert = BitmapToCrossStitch(self.svg, element, self.settings, palette)
+                if bitmap_convert.original_image is None:
+                    continue
+                nodes = bitmap_convert.svg_nodes(False)
+                for color_group in nodes:
+                    for el in color_group:
+                        fills.append(FillStitch(el))
+                # element.node.delete()
+        return fills
+
+    def _process_elements(self, elements, palette):
+        for element in elements:
+            if element.name == "FillStitch":
+                if self.settings['pixelize']:
+                    self.pixelize_single(element)
+                elif self.settings['set_params']:
+                    # when pixelize is disabled, set params on each fill element
+                    self.set_element_cross_stitch_params(element.node)
+            else:
+                if not self.settings['convert_bitmap']:
+                    continue
+                self._process_image(element, palette)
 
     def _get_stroke_palette(self):
         palette = []
@@ -121,7 +141,7 @@ class CrossStitchHelper(InkstitchExtension):
                     palette.extend(color.to_rgb())
         return palette
 
-    def process_image(self, element, palette):
+    def _process_image(self, element, palette):
         parent = element.node.getparent()
         index = parent.index(element.node)
         bitmap_convert = BitmapToCrossStitch(self.svg, element, self.settings, palette)
@@ -130,6 +150,7 @@ class CrossStitchHelper(InkstitchExtension):
         elements = bitmap_convert.svg_nodes()
         if elements:
             main_group = Group()
+            main_group.label = element.node.label or element.node.get_id()
             for color in elements:
                 if self.settings['set_params']:
                     for path in color:
@@ -166,15 +187,25 @@ class CrossStitchHelper(InkstitchExtension):
                 self.set_element_cross_stitch_params(path_element)
             path_element.set('id', self.svg.get_unique_id('cross_stitch_'))
 
+        node = fills[-1].node
         parent = fills[-1].node.getparent()
-        index = parent.index(fills[-1].node)
+        if fills[-1].node.getroottree().getroot().TAG == "g":
+            # use the fallback node when we hit an image
+            node = self.fallback_element.node
+            parent = node.getparent()
+            transform = get_correction_transform(node)
+            cross_stitch_group.transform = transform
+            index = parent.index(node) + 1
+        else:
+            index = parent.index(node)
         parent.insert(index, cross_stitch_group)
 
         for fill in fills:
             node = fill.node
             parent = node.getparent()
             fill.node.delete()
-            self._remove_empty_group(parent)
+            if parent:
+                self._remove_empty_group(parent)
 
     def _remove_empty_group(self, group):
         parent = group.getparent()

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2025 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from inkex import Color, Grid, Group, Path, errormsg
+from inkex import Color, Grid, Group, Path
 from inkex.units import convert_unit
 
 from ..elements import FillStitch
@@ -71,15 +71,6 @@ class CrossStitchHelper(InkstitchExtension):
             if element.name in ["Image", "FillStitch"]:
                 elements.append(element)
 
-        # No elements selected, exit with an error message
-        if not elements:
-            errormsg(_("Please select at least one element with a fill color or one image."))
-            return
-
-        # When elements have been combined, we need to define a place in the layering order for our new group
-        # Let's take the top most element from selection
-        self.insert_position_element = self.svg.selection.rendering_order()[-1]
-
         palette = self._get_stroke_palette()
 
         app = CrossStitchHelperApp(settings=settings, elements=elements, palette=palette)
@@ -89,6 +80,15 @@ class CrossStitchHelper(InkstitchExtension):
             return
         self.settings = settings
 
+        # add grid
+        if settings['set_grid']:
+            self.setup_page_grid()
+
+        # the following operations will need selected elements
+        # if we cannot find any, return early
+        if not elements:
+            return
+
         # Pixelate and parametrize elements
         if self.settings['remove_overlaps']:
             # first convert images to fills, then process everything at once
@@ -97,10 +97,6 @@ class CrossStitchHelper(InkstitchExtension):
                 self.pixelize_combined(fills)
         else:
             self._process_elements(elements, palette)
-
-        # add grid
-        if settings['set_grid']:
-            self.setup_page_grid()
 
     def _prepare_fills(self, elements, palette):
         fills = []
@@ -191,7 +187,8 @@ class CrossStitchHelper(InkstitchExtension):
                 self.set_element_cross_stitch_params(path_element)
             path_element.set('id', self.svg.get_unique_id('cross_stitch_'))
 
-        node = self.insert_position_element
+        # Let's take the top most element from selection and insert everything here
+        node = self.svg.selection.rendering_order()[-1]
         parent = node.getparent()
         transform = get_correction_transform(node)
         cross_stitch_group.transform = transform
@@ -199,7 +196,6 @@ class CrossStitchHelper(InkstitchExtension):
         parent.insert(index, cross_stitch_group)
 
         for fill in fills:
-            node = fill.node
             parent = node.getparent()
             fill.node.delete()
             if parent is not None:

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -70,11 +70,9 @@ class CrossStitchHelper(InkstitchExtension):
             if element.name in ["Image", "FillStitch"]:
                 elements.append(element)
 
-        # Images may have been converted to fills which are not in the document
-        # therefore we define a fallback element node, so we can use it to find a got spot to include the new elements
-        self.fallback_element = None
-        if elements:
-            self.fallback_element = elements[-1]
+        # When elements have been combined, we need to define a place in the layering order for our new group
+        # Let's take the top most element from selection
+        self.insert_position_element = self.svg.selection.rendering_order()[-1]
 
         palette = self._get_stroke_palette()
 
@@ -117,7 +115,6 @@ class CrossStitchHelper(InkstitchExtension):
                 for color_group in nodes:
                     for el in color_group:
                         fills.append(FillStitch(el))
-                # element.node.delete()
         return fills
 
     def _process_elements(self, elements, palette):
@@ -188,31 +185,25 @@ class CrossStitchHelper(InkstitchExtension):
                 self.set_element_cross_stitch_params(path_element)
             path_element.set('id', self.svg.get_unique_id('cross_stitch_'))
 
-        node = fills[-1].node
-        parent = fills[-1].node.getparent()
-        if fills[-1].node.getroottree().getroot().TAG == "g":
-            # use the fallback node when we hit an image
-            node = self.fallback_element.node
-            parent = node.getparent()
-            transform = get_correction_transform(node)
-            cross_stitch_group.transform = transform
-            index = parent.index(node) + 1
-        else:
-            index = parent.index(node)
+        node = self.insert_position_element
+        parent = node.getparent()
+        transform = get_correction_transform(node)
+        cross_stitch_group.transform = transform
+        index = parent.index(node) + 1
         parent.insert(index, cross_stitch_group)
 
         for fill in fills:
             node = fill.node
             parent = node.getparent()
             fill.node.delete()
-            if parent:
+            if parent is not None:
                 self._remove_empty_group(parent)
 
     def _remove_empty_group(self, group):
         parent = group.getparent()
         if len(group) == 0:
             group.delete()
-        if parent and len(parent) == 0:
+        if parent is not None and len(parent) == 0:
             self._remove_empty_group(parent)
 
     def pixelize_single(self, element):

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -138,7 +138,7 @@ class CrossStitchHelper(InkstitchExtension):
             if element.name == "Stroke":
                 color = element.stroke_color
                 if color:
-                    palette.extend(color.to_rgb())
+                    palette.extend(color.to('rgb'))
         return palette
 
     def _process_image(self, element, palette):

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -3,17 +3,14 @@
 # Copyright (c) 2025 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from collections import defaultdict
-
-from inkex import Color, Grid, Group, Path, PathElement
+from inkex import Color, Grid, Group, Path
 from inkex.units import convert_unit
-from shapely import make_valid, unary_union
 
 from ..gui.cross_stitch_helper import CrossStitchHelperApp
 from ..i18n import _
-from ..stitches.utils.cross_stitch import CrossGeometries
-from ..svg import PIXELS_PER_MM, get_correction_transform
-from ..utils.geometry import ensure_multi_polygon
+from ..svg import get_correction_transform
+from ..svg.tags import SVG_PATH_TAG
+from ..utils.pixelate import pixelate_element, pixelate_multiple
 from .base import InkstitchExtension
 from .utils.bitmap_to_cross_stitch import BitmapToCrossStitch
 
@@ -54,7 +51,8 @@ class CrossStitchHelper(InkstitchExtension):
             'bitmap_contrast': 1,
             'bitmap_transparency_threshold': 50,
             'bitmap_background_color': (0, 0, 0),
-            'bitmap_remove_background': 0
+            'bitmap_remove_background': 0,
+            'bitmap_display_svg_image': False
         }
 
         # True will not show the no elements warning
@@ -65,19 +63,6 @@ class CrossStitchHelper(InkstitchExtension):
             # nothing was selected, keep it this way
             self.elements = []
 
-        # When there is an image within the element list, send it to the App (for preview generation)
-        # Send only the first one
-        image = self._get_image()
-
-        palette = self._get_stroke_palette()
-
-        app = CrossStitchHelperApp(settings=settings, image=image, palette=palette)
-        app.MainLoop()
-
-        if not settings['applied']:
-            return
-        self.settings = settings
-
         # collect image and fill elements
         images = []
         fills = []
@@ -86,6 +71,15 @@ class CrossStitchHelper(InkstitchExtension):
                 images.append(element)
             elif element.name == "FillStitch":
                 fills.append(element)
+
+        palette = self._get_stroke_palette()
+
+        app = CrossStitchHelperApp(settings=settings, fills=fills, images=images, palette=palette)
+        app.MainLoop()
+
+        if not settings['applied']:
+            return
+        self.settings = settings
 
         # process elements
         self._process_images(images, palette)
@@ -127,14 +121,6 @@ class CrossStitchHelper(InkstitchExtension):
                     palette.extend(color.to_rgb())
         return palette
 
-    def _get_image(self):
-        image = None
-        for element in self.elements:
-            if element.name == "Image":
-                image = element
-                break
-        return image
-
     def process_image(self, element, palette):
         parent = element.node.getparent()
         index = parent.index(element.node)
@@ -170,38 +156,15 @@ class CrossStitchHelper(InkstitchExtension):
         element.set('inkstitch:canvas_grid_origin', self.settings['align_with_canvas'])
 
     def pixelize_combined(self, fills):
-        colored_boxes = self._get_colored_boxes(fills)
-        if not colored_boxes:
-            return
-
         cross_stitch_group = Group()
         cross_stitch_group.label = _("Cross stitch group")
 
-        for color, boxes in colored_boxes.items():
-            color_group = Group()
-            color_group.label = color
-            # setup the path
-            outline = self._prepare_outline(boxes)
-            for polygon in outline.geoms:
-                path = Path(list(polygon.exterior.coords))
-                for interior in polygon.interiors:
-                    interior_path = Path(list(interior.coords))
-                    interior_path.close()
-                    path += interior_path
-                path.close()
+        cross_stitch_group = pixelate_multiple(cross_stitch_group, fills, self.settings)
 
-                path_element = PathElement()
-                path_element.set('d', str(path))
-                path_element.set('id', self.svg.get_unique_id('cross_stitch_'))
-                path_element.transform = get_correction_transform(fills[-1].node)
-                path_element.style['fill'] = color_group.label
-                if self.settings['set_params']:
-                    self.set_element_cross_stitch_params(path_element)
-                color_group.append(path_element)
-            if len(color_group) > 1:
-                cross_stitch_group.append(color_group)
-            else:
-                cross_stitch_group.append(color_group[0])
+        for path_element in cross_stitch_group.iterdescendants(SVG_PATH_TAG):
+            if self.settings['set_params']:
+                self.set_element_cross_stitch_params(path_element)
+            path_element.set('id', self.svg.get_unique_id('cross_stitch_'))
 
         parent = fills[-1].node.getparent()
         index = parent.index(fills[-1].node)
@@ -233,7 +196,7 @@ class CrossStitchHelper(InkstitchExtension):
         else:
             new_path = node.duplicate()
 
-        pixelated_outline = self.pixelize_element(element)
+        pixelated_outline = pixelate_element(element, self.settings)
         for polygon in pixelated_outline.geoms:
             path = Path(list(polygon.exterior.coords))
             for interior in polygon.interiors:
@@ -250,20 +213,6 @@ class CrossStitchHelper(InkstitchExtension):
                 self.set_element_cross_stitch_params(new_element)
         new_path.delete()
         node.delete()
-
-    def pixelize_element(self, element):
-        geometries = CrossGeometries(
-            element.shrink_or_grow_shape(element.shape, 0.1),
-            (self.settings['box_x'] * PIXELS_PER_MM, self.settings['box_y'] * PIXELS_PER_MM),
-            self.settings['coverage'],
-            'simple_cross',
-            self._get_grid_offset(),
-            4,
-            self.settings['align_with_canvas']
-        )
-
-        outline = self._prepare_outline(geometries.boxes)
-        return outline
 
     def setup_page_grid(self):
         namedview = self.svg.namedview
@@ -302,74 +251,3 @@ class CrossStitchHelper(InkstitchExtension):
             "visible": "true",
         })
         namedview.append(grid)
-
-    def _get_grid_offset(self):
-        grid_offset = self.settings['grid_offset'].split(' ')
-        try:
-            grid_offset = self.settings['grid_offset'].split(' ')
-            if len(grid_offset) == 1:
-                offset = float(grid_offset[0]) * PIXELS_PER_MM
-                return (offset, offset)
-            elif len(grid_offset) == 2:
-                return (float(grid_offset[0]) * PIXELS_PER_MM, float(grid_offset[1] * PIXELS_PER_MM))
-        except ValueError:
-            pass
-        return (0, 0)  # Fallback
-
-    def _get_colored_boxes(self, fills):
-        fill_areas = []
-        fill_areas_by_color = defaultdict(list)
-        for fill in reversed(fills):
-            # subtract areas already filled with a color
-            area = unary_union(fill_areas)
-            adapted_shape = fill.shape.difference(area)
-            if not adapted_shape.is_empty:
-                color = Color(fill.fill_color).to('named')
-                fill_areas_by_color[color].append(fill.shape.difference(area))
-            # add a little expand value to connect otherwise unconnected
-            fill_areas.append(fill.shrink_or_grow_shape(fill.shape, 0.1))
-
-        # combine all selected fill shape areas to generate all squares at once
-        full_area = ensure_multi_polygon(unary_union(fill_areas))
-        # get squares
-        grid_offset = self._get_grid_offset()
-        geometries = CrossGeometries(
-            full_area,
-            (self.settings['box_x'] * PIXELS_PER_MM, self.settings['box_y'] * PIXELS_PER_MM),
-            self.settings['coverage'],
-            'simple_cross',
-            grid_offset,
-            4,
-            self.settings['align_with_canvas']
-        )
-
-        color_shape_dict = {}
-        for color, shapes in fill_areas_by_color.items():
-            color_shape_dict[color] = make_valid(unary_union(shapes))
-
-        colored_boxes = defaultdict(list)
-        for box in geometries.boxes:
-            current_color = None
-            highest_overlap = 0
-            for color, shape in color_shape_dict.items():
-                overlap = box.intersection(shape).area
-                if overlap > highest_overlap:
-                    current_color = color
-                    highest_overlap = overlap
-            if current_color is not None:
-                colored_boxes[current_color].append(box)
-        return colored_boxes
-
-    def _prepare_outline(self, boxes):
-        outline = unary_union(boxes)
-        # add a small buffer to connect otherwise unconnected elements
-        outline = outline.buffer(0.001)
-        # the buffer has added some unwanted nodes at corners
-        # remove them with simplify
-        outline = outline.simplify(0.1)
-        outline = make_valid(outline)
-        # simplify has removed nodes at grid intersections.
-        # the user chose to have some additional nodes (to pull the shape out, let's add some nodes back in
-        if self.settings['nodes']:
-            outline = outline.segmentize(self.settings['box_x'] * PIXELS_PER_MM + 0.002)
-        return ensure_multi_polygon(outline)

--- a/lib/extensions/cross_stitch_helper.py
+++ b/lib/extensions/cross_stitch_helper.py
@@ -196,17 +196,14 @@ class CrossStitchHelper(InkstitchExtension):
         parent.insert(index, cross_stitch_group)
 
         for fill in fills:
-            parent = node.getparent()
-            fill.node.delete()
-            if parent is not None:
-                self._remove_empty_group(parent)
+            self._remove_empty(fill.node)
 
-    def _remove_empty_group(self, group):
-        parent = group.getparent()
-        if len(group) == 0:
-            group.delete()
+    def _remove_empty(self, group_or_element):
+        parent = group_or_element.getparent()
+        if group_or_element.TAG != 'g' or len(group_or_element) == 0:
+            group_or_element.delete()
         if parent is not None and len(parent) == 0:
-            self._remove_empty_group(parent)
+            self._remove_empty(parent)
 
     def pixelize_single(self, element):
         node = element.node

--- a/lib/extensions/generate_palette.py
+++ b/lib/extensions/generate_palette.py
@@ -68,7 +68,7 @@ class GeneratePalette(InkstitchExtension):
             if 'fill' not in element.style.keys() or not isinstance(element, inkex.TextElement):
                 continue
 
-            color = inkex.Color(element.style['fill']).to_rgb()
+            color = inkex.Color(element.style['fill']).to('rgb')
             color_name = element.get_text().split(' ')
             if len(color_name) > 1 and color_name[-1].isdigit():
                 number = color_name[-1]

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -214,7 +214,7 @@ class BitmapToCrossStitch(object):
         # get the clip shape and move it to canvas origin
         clip = self.bitmap.clip_shape
         if not clip:
-            return self._crop_transparent_borders(image)
+            return image
         minx, miny, maxx, maxy = self.bitmap.original_shape.bounds
         clip = translate(clip, -minx, -miny)
 
@@ -232,7 +232,7 @@ class BitmapToCrossStitch(object):
         # apply mask
         image.putalpha(mask)
 
-        return self._crop_transparent_borders(image)
+        return image
 
     def combine_images(self, image1, image2, offset):
         minx, miny, maxx, maxy = self.bitmap.original_shape.bounds

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -31,8 +31,7 @@ class BitmapToCrossStitch(object):
     '''
     def __init__(self, svg, bitmap, settings, palette=None):
         '''Prepare the bitmap image:
-            * self.original_image       None or original pillow image (rgba), should not be altered by other methods in this class
-            * self.reduced_image        Same as original image, but will be altered by methods within this class (color reduction, background removal)
+            * self.original_image   None or original pillow image (rgba), should not be altered by other methods in this class
 
            Parameters:
            * svg:       the svg document
@@ -48,7 +47,7 @@ class BitmapToCrossStitch(object):
         self.settings = settings
         self.palette = palette
         self.original_image = None
-        self.reduced_image = None
+        self.recolored_image = None
 
         image = self._get_image_byte_string(bitmap.node)
         if image is None:
@@ -66,12 +65,8 @@ class BitmapToCrossStitch(object):
 
         # ensure rgba mode
         self.original_image = self.original_image.convert("RGBA")
-
         # apply transform
         self.original_image = self.apply_transform(self.original_image)
-
-        # apply color corrections
-        self.apply_color_corrections()
 
     def _get_image_byte_string(self, image):
         '''Gets the image byte strig, base64
@@ -133,7 +128,7 @@ class BitmapToCrossStitch(object):
         # Apply the perspective transformation
         return image.transform((width, height), Image.PERSPECTIVE, transform_data, Image.NEAREST)
 
-    def apply_color_corrections(self):
+    def apply_color_corrections(self, image):
         """ Applies color settings
             - color balance
             - brightness
@@ -141,29 +136,29 @@ class BitmapToCrossStitch(object):
             - transparency threshold
             - reduce number of colors by either a given number or palette
         """
-        if self.original_image is None:
+        if image is None:
             return
 
-        self.reduced_image = self.original_image.copy()
+        recolored_image = image.copy()
 
         # Get initial alpha mask and apply to avoid falsifying colors of only partly transparent pixels
         transparency_threshold = self.settings['bitmap_transparency_threshold'] * 255 // 100
-        self.alpha_mask = self.reduced_image.getchannel("A")
+        self.alpha_mask = recolored_image.getchannel("A")
         self.alpha_mask = self._ensure_black_and_white_mask(self.alpha_mask, transparency_threshold)
-        self.reduced_image.putalpha(self.alpha_mask)
+        recolored_image.putalpha(self.alpha_mask)
 
-        saturation_enhancer = ImageEnhance.Color(self.reduced_image)
-        self.reduced_image = saturation_enhancer.enhance(self.settings['bitmap_saturation'])
+        saturation_enhancer = ImageEnhance.Color(recolored_image)
+        recolored_image = saturation_enhancer.enhance(self.settings['bitmap_saturation'])
 
-        brightness_enhancer = ImageEnhance.Brightness(self.reduced_image)
-        self.reduced_image = brightness_enhancer.enhance(self.settings['bitmap_brightness'])
+        brightness_enhancer = ImageEnhance.Brightness(recolored_image)
+        recolored_image = brightness_enhancer.enhance(self.settings['bitmap_brightness'])
 
-        contrast_enhancer = ImageEnhance.Brightness(self.reduced_image)
-        self.reduced_image = contrast_enhancer.enhance(self.settings['bitmap_contrast'])
+        contrast_enhancer = ImageEnhance.Brightness(recolored_image)
+        recolored_image = contrast_enhancer.enhance(self.settings['bitmap_contrast'])
 
         # Some quantize methods will only work with rgb mode images. Means, we need to fill transparent image parts with a color.
         # To do this, we fill up the transparent pixels with white color as it doesn't
-        self.reduced_image = self._convert_to_rgb(self.reduced_image)
+        recolored_image = self._convert_to_rgb(recolored_image)
 
         color_palette = self._get_color_palette()
         if not color_palette:
@@ -171,29 +166,31 @@ class BitmapToCrossStitch(object):
             num_colors = self.settings['bitmap_num_colors']
             if num_colors == 0:
                 num_colors = 1
-            self.reduced_image = self.reduced_image.quantize(num_colors, method=self.settings['bitmap_quantize_method'], kmeans=5)
+            recolored_image = recolored_image.quantize(num_colors, method=self.settings['bitmap_quantize_method'], kmeans=5)
         else:
             palette_image = Image.new("P", (1, 1))
             palette_image.putpalette(color_palette)
-            self.reduced_image = self.reduced_image.quantize(palette=palette_image, dither=Image.NONE)
+            recolored_image = recolored_image.quantize(palette=palette_image, dither=Image.NONE)
 
         # return to rgba mode and apply initial alpha mask
-        self.reduced_image = self.reduced_image.convert('RGBA')
-        self.reduced_image.putalpha(self.alpha_mask)
+        recolored_image = recolored_image.convert('RGBA')
+        recolored_image.putalpha(self.alpha_mask)
 
         # set background to alpha (optional)
         background_color = None
         if self.settings['bitmap_remove_background'] == 1:
             background_color = self._nearest_color(self.settings['bitmap_background_color'])
         elif self.settings['bitmap_remove_background'] == 2:
-            background_color = self._get_main_color(self.reduced_image)
+            background_color = self._get_main_color(recolored_image)
 
         if background_color is not None:
-            background = Image.new("RGBA", self.reduced_image.size, background_color)
-            background_mask = ImageChops.difference(self.reduced_image, background).convert("L")
+            background = Image.new("RGBA", recolored_image.size, background_color)
+            background_mask = ImageChops.difference(recolored_image, background).convert("L")
             self.alpha_mask = ImageChops.multiply(self.alpha_mask, background_mask)
             self.alpha_mask = self._ensure_black_and_white_mask(self.alpha_mask)
-            self.reduced_image.putalpha(self.alpha_mask)
+            recolored_image.putalpha(self.alpha_mask)
+
+        return recolored_image
 
     def _ensure_black_and_white_mask(self, mask, threshold=0):
         ''' Removes grayscale areas from the alpha mask using a threshold value
@@ -238,6 +235,13 @@ class BitmapToCrossStitch(object):
 
         return self._crop_transparent_borders(image)
 
+    def combine_images(self, image1, image2, offset):
+        minx, miny, maxx, maxy = self.bitmap.original_shape.bounds
+        offset_x = minx - offset[0]
+        offset_y = miny - offset[1]
+        image1.paste(image2, (int(offset_x), int(offset_y)), image2)
+        return image1
+
     def _crop_transparent_borders(self, image):
         ''' Crop transparent borders
             (only for use in cross stitch helper)
@@ -248,14 +252,14 @@ class BitmapToCrossStitch(object):
         return image
 
     def _nearest_color(self, target_color):
-        ''' Returns the nearest existing color in self.reduced_image to the target color
+        ''' Returns the nearest existing color in self.recolored_image to the target color
         '''
         def distance(p):
             r, g, b, a = p
             return (r - target_color[0])**2 + (g - target_color[1])**2 + (b - target_color[2])**2 + (255)
 
         # Find the nearest RGBA color
-        img = self.reduced_image.convert("RGBA")
+        img = self.recolored_image.convert("RGBA")
         colors = img.getcolors()
         # Filter transparent areas
         colors = [color for count, color in colors if color[3] > 0]
@@ -316,15 +320,13 @@ class BitmapToCrossStitch(object):
                 pass
         return offset_value
 
-    def svg_nodes(self):
-        '''Converts the bitmap into path elements by respecting the given cross stitch settings
-           Returns:
-            * elements: a list of path elements grouped by color (svg groups)
-        '''
-        if self.reduced_image is None:
+    def _get_color_boxes(self):
+        # ensure rgba mode
+        # apply color corrections
+        recolored_image = self.apply_color_corrections(self.original_image)
+        if recolored_image is None:
             return
 
-        elements = []
         color_boxes = defaultdict(list)
         width = self.settings['box_x'] * PIXELS_PER_MM
         height = self.settings['box_y'] * PIXELS_PER_MM
@@ -342,13 +344,23 @@ class BitmapToCrossStitch(object):
 
             # Find and apply the dominant color for each grid cell
             crop_box = (minx - offset_x, miny - offset_y, maxx - offset_x, maxy - offset_y)
-            main_color = self._get_main_color(self.reduced_image.crop(crop_box))
+            main_color = self._get_main_color(recolored_image.crop(crop_box))
             if main_color[3] < 255:
                 # skip transparent areas
                 continue
-            else:
-                color = main_color[:3]
             color_boxes[main_color[:3]].append(box)
+        return color_boxes
+
+    def svg_nodes(self):
+        '''Converts the bitmap into path elements by respecting the given cross stitch settings
+           Returns:
+            * elements: a list of path elements grouped by color (svg groups)
+        '''
+        elements = []
+        width = self.settings['box_x'] * PIXELS_PER_MM
+        color_boxes = self._get_color_boxes()
+        if not color_boxes:
+            return
 
         for color, boxes in color_boxes.items():
             color_group = Group()

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -422,7 +422,9 @@ class BitmapToCrossStitch(object):
 
                 new_element = PathElement()
                 new_element.set('d', str(path))
-                new_element.set('style', f"fill:rgb{color}")
+                # We could just insert the color as f"fill:rgb({color})"
+                # but inkex (computed_style) seems to have a problem with reading some rgb colors, so let's use the named version for now
+                new_element.set('style', f"fill:{Color(color).to('named')}")
                 if apply_transform:
                     new_element.transform = get_correction_transform(self.bitmap.node)
                 color_group.append(new_element)

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -345,6 +345,7 @@ class BitmapToCrossStitch(object):
             for x in range(w):
                 pixel = pixels[x, y]
                 if pixel[3] < 255:
+                    pos_x += 1
                     continue
                 box = translate(square, pos_x * width + minx, pos_y * height + miny)
                 color_boxes[pixel[:3]].append(box)

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -351,7 +351,7 @@ class BitmapToCrossStitch(object):
             color_boxes[main_color[:3]].append(box)
         return color_boxes
 
-    def svg_nodes(self):
+    def svg_nodes(self, apply_transform=True):
         '''Converts the bitmap into path elements by respecting the given cross stitch settings
            Returns:
             * elements: a list of path elements grouped by color (svg groups)
@@ -386,8 +386,9 @@ class BitmapToCrossStitch(object):
 
                 new_element = PathElement()
                 new_element.set('d', str(path))
-                new_element.set('style', f'fill:rgb{color}')
-                new_element.transform = get_correction_transform(self.bitmap.node)
+                new_element.set('style', f"fill:rgb{color}")
+                if apply_transform:
+                    new_element.transform = get_correction_transform(self.bitmap.node)
                 color_group.append(new_element)
             elements.append(color_group)
         elements.sort(key=lambda group: len(group), reverse=True)

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -18,6 +18,7 @@ from inkex import Path, PathElement
 from PIL import Image, ImageChops, ImageDraw, ImageEnhance
 from shapely import make_valid, unary_union
 from shapely.affinity import translate
+from shapely.geometry import Polygon
 
 from ...stitches.utils.cross_stitch import CrossGeometries
 from ...svg import PIXELS_PER_MM, get_correction_transform
@@ -319,6 +320,38 @@ class BitmapToCrossStitch(object):
                 pass
         return offset_value
 
+    def _get_color_boxes_from_pixels(self):
+        # scales image up, each pixel represents one cros stitch box
+        recolored_image = self.apply_color_corrections(self.original_image)
+        recolored_image = self._crop_transparent_borders(recolored_image)
+        if recolored_image is None:
+            return
+
+        color_boxes = defaultdict(list)
+        width = self.settings['box_x'] * PIXELS_PER_MM
+        height = self.settings['box_y'] * PIXELS_PER_MM
+
+        if recolored_image is None:
+            return
+
+        square = Polygon([(0, 0), (width, 0), (width, height), (0, width)])
+        minx, miny, maxx, maxy = self.bitmap.shape.bounds
+        pos_x = 0
+        pos_y = 0
+        w, h = recolored_image.size
+        pixels = recolored_image.load()
+        for y in range(h):
+            pos_x = 0
+            for x in range(w):
+                pixel = pixels[x, y]
+                if pixel[3] < 255:
+                    continue
+                box = translate(square, pos_x * width + minx, pos_y * height + miny)
+                color_boxes[pixel[:3]].append(box)
+                pos_x += 1
+            pos_y += 1
+        return color_boxes
+
     def _get_color_boxes(self):
         # ensure rgba mode
         # apply color corrections
@@ -357,7 +390,10 @@ class BitmapToCrossStitch(object):
         '''
         elements = []
         width = self.settings['box_x'] * PIXELS_PER_MM
-        color_boxes = self._get_color_boxes()
+        if self.settings['pixel_by_pixel']:
+            color_boxes = self._get_color_boxes_from_pixels()
+        else:
+            color_boxes = self._get_color_boxes()
         if not color_boxes:
             return
 

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -47,7 +47,6 @@ class BitmapToCrossStitch(object):
         self.settings = settings
         self.palette = palette
         self.original_image = None
-        self.recolored_image = None
 
         image = self._get_image_byte_string(bitmap.node)
         if image is None:
@@ -179,7 +178,7 @@ class BitmapToCrossStitch(object):
         # set background to alpha (optional)
         background_color = None
         if self.settings['bitmap_remove_background'] == 1:
-            background_color = self._nearest_color(self.settings['bitmap_background_color'])
+            background_color = self._nearest_color(recolored_image, self.settings['bitmap_background_color'])
         elif self.settings['bitmap_remove_background'] == 2:
             background_color = self._get_main_color(recolored_image)
 
@@ -251,15 +250,15 @@ class BitmapToCrossStitch(object):
             return image.crop(bbox)
         return image
 
-    def _nearest_color(self, target_color):
-        ''' Returns the nearest existing color in self.recolored_image to the target color
+    def _nearest_color(self, image, target_color):
+        ''' Returns the nearest existing color in image to the target color
         '''
         def distance(p):
             r, g, b, a = p
             return (r - target_color[0])**2 + (g - target_color[1])**2 + (b - target_color[2])**2 + (255)
 
         # Find the nearest RGBA color
-        img = self.recolored_image.convert("RGBA")
+        img = image.convert("RGBA")
         colors = img.getcolors()
         # Filter transparent areas
         colors = [color for count, color in colors if color[3] > 0]

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -61,12 +61,15 @@ class BitmapToCrossStitch(object):
             return
 
         with Image.open(image) as img:
-            self.original_image = img.resize((width, height))
+            if self.settings['pixel_by_pixel']:
+                self.original_image = img.resize((width, height))
+            else:
+                self.original_image = img.resize((width, height))
 
-        # ensure rgba mode
-        self.original_image = self.original_image.convert("RGBA")
-        # apply transform
-        self.original_image = self.apply_transform(self.original_image)
+            # ensure rgba mode
+            self.original_image = self.original_image.convert("RGBA")
+            # apply transform
+            self.original_image = self.apply_transform(self.original_image)
 
     def _get_image_byte_string(self, image):
         '''Gets the image byte strig, base64

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -397,7 +397,7 @@ class BitmapToCrossStitch(object):
         else:
             color_boxes = self._get_color_boxes()
         if not color_boxes:
-            return
+            return elements
 
         for color, boxes in color_boxes.items():
             color_group = Group()

--- a/lib/extensions/utils/bitmap_to_cross_stitch.py
+++ b/lib/extensions/utils/bitmap_to_cross_stitch.py
@@ -61,15 +61,12 @@ class BitmapToCrossStitch(object):
             return
 
         with Image.open(image) as img:
-            if self.settings['pixel_by_pixel']:
-                self.original_image = img.resize((width, height))
-            else:
-                self.original_image = img.resize((width, height))
+            self.original_image = img.resize((width, height))
 
-            # ensure rgba mode
-            self.original_image = self.original_image.convert("RGBA")
-            # apply transform
-            self.original_image = self.apply_transform(self.original_image)
+        # ensure rgba mode
+        self.original_image = self.original_image.convert("RGBA")
+        # apply transform
+        self.original_image = self.apply_transform(self.original_image)
 
     def _get_image_byte_string(self, image):
         '''Gets the image byte strig, base64
@@ -210,7 +207,7 @@ class BitmapToCrossStitch(object):
         return image.convert("RGB")
 
     def apply_clip(self, image):
-        ''' clips the image (used in cross stitch helper gui)
+        ''' clips the image
         '''
         # ensure rgba mode
         image = image.convert("RGBA")
@@ -326,6 +323,7 @@ class BitmapToCrossStitch(object):
     def _get_color_boxes_from_pixels(self):
         # scales image up, each pixel represents one cros stitch box
         recolored_image = self.apply_color_corrections(self.original_image)
+        recolored_image = self.apply_clip(recolored_image)
         recolored_image = self._crop_transparent_borders(recolored_image)
         if recolored_image is None:
             return

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -1,10 +1,20 @@
+# Authors: see git history
+#
+# Copyright (c) 2026 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+import threading
 from math import sqrt
 
 import wx
+import wx.svg
+from inkex import Group, Path, PathElement
+from PIL import Image
 
 from ..elements.fill_stitch import FillStitch
 from ..extensions.utils.bitmap_to_cross_stitch import BitmapToCrossStitch
 from ..i18n import _
+from ..utils.pixelate import pixelate_element, pixelate_multiple
 from ..utils.settings import global_settings
 
 
@@ -12,12 +22,18 @@ class CrossStitchHelperFrame(wx.Frame):
     def __init__(self, *args, **kwargs):
         self.settings = kwargs.pop("settings")
         self.default_settings = self.settings.copy()
-        self.image = kwargs.pop("image")
+        self.images = kwargs.pop("images")
+        self.fills = kwargs.pop("fills")
         self.palette = kwargs.pop("palette")
+
+        self.cross_bitmap = None
+        self._load_bitmap()
+
         wx.Frame.__init__(self, None, wx.ID_ANY, _("Ink/Stitch - Cross stitch"), *args, **kwargs)
 
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
 
+        self._setup_timer()
         self.widgets_and_panels()
         self.apply_global_settings()
         self.update()
@@ -25,55 +41,29 @@ class CrossStitchHelperFrame(wx.Frame):
         self.update_color_selection_method()
         self.Show()
 
-    def apply_global_settings(self):
-        self.x_only_checkbox.SetValue(global_settings['square'])
-        self.box_x.SetValue(global_settings['cross_helper_box_x'])
-        self.box_y.SetValue(global_settings['cross_helper_box_y'])
-        self.set_params.SetValue(global_settings['cross_helper_set_params'])
-        cross_method = self.cross_stitch_method.FindString(self.cross_stitch_options[global_settings['cross_helper_cross_method']])
-        self.cross_stitch_method.SetSelection(cross_method)
-        self.pixelize.SetValue(global_settings['cross_helper_pixelize'])
-        self.pixelize_combined.SetValue(global_settings['cross_helper_pixelize_combined'])
-        self.nodes.SetValue(global_settings['cross_helper_nodes'])
-        self.coverage.SetValue(global_settings['cross_helper_coverage'])
-        self.grid_offset.SetValue(global_settings['cross_helper_grid_offset'])
-        self.align_with_canvas.SetValue(global_settings['cross_helper_align_with_canvas'])
-        self.setup_grid.SetValue(global_settings['cross_helper_set_grid'])
-        self.grid_color.SetColour(wx.Colour(global_settings['cross_helper_grid_color']))
-        self.remove_grids.SetValue(global_settings['cross_helper_remove_grids'])
-        self.convert_bitmap.SetValue(global_settings['cross_helper_convert_bitmap'])
-        self.color_selection_method.SetSelection(global_settings['cross_helper_color_method'])
-        self.num_colors.SetValue(global_settings['cross_bitmap_num_colors'])
-        self.quantize_method.SetSelection(global_settings['cross_bitmap_quantize_method'])
-        self.rgb_color_list.SetValue(global_settings['cross_bitmap_rgb_colors'])
-        self.gimp_palette.SetPath(global_settings['cross_bitmap_gimp_palette'])
-        self.saturation.SetValue(int(global_settings['cross_bitmap_saturation'] * 100))
-        self.saturation_numerical_input.SetValue(global_settings['cross_bitmap_saturation'])
-        self.brightness.SetValue(int(global_settings['cross_bitmap_brightness'] * 100))
-        self.brightness_numerical_input.SetValue(global_settings['cross_bitmap_brightness'])
-        self.contrast.SetValue(int(global_settings['cross_bitmap_contrast'] * 100))
-        self.contrast_numerical_input.SetValue(global_settings['cross_bitmap_contrast'])
-        self.transparency_threshold.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
-        self.transparency_threshold_numerical_input.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
-        self.background_color.SetColour(wx.Colour(global_settings['cross_bitmap_background_color']))
-        self.remove_background.SetSelection(global_settings['cross_bitmap_remove_background'])
+    def _setup_timer(self):
+        # Calculating the svg image is relatively expensive.
+        # Let's use a timer for debouncing
+        self._debounce_timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_debounce_timer, self._debounce_timer)
+
+        # Track latest task so we can skip a task later
+        self._current_task_id = 0
 
     def widgets_and_panels(self):
-        self.main_panel = wx.Panel(self, wx.ID_ANY)
+        self.main_panel = wx.Panel(self, name="main_panel")
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        notebook_sizer = wx.BoxSizer(wx.VERTICAL)
+        notebook_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.notebook = wx.Notebook(self.main_panel, wx.ID_ANY)
-        notebook_sizer.Add(self.notebook, 1, wx.EXPAND, 0)
+        notebook_sizer.Add(self.notebook, 1, wx.EXPAND | wx.ALL, 0)
 
         self.settings_panel = wx.Panel(self.notebook, wx.ID_ANY)
         self.notebook.AddPage(self.settings_panel, _("Settings"))
 
         # settings
-        settings_main_sizer = wx.BoxSizer(wx.VERTICAL)
-        settings_options_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        settings_wrapper_sizer = wx.BoxSizer(wx.VERTICAL)
         grid_settings_sizer = wx.BoxSizer(wx.VERTICAL)
-        apply_settings_sizer = wx.BoxSizer(wx.VERTICAL)
-
         grid_sizer = wx.FlexGridSizer(4, 2, 15, 20)
         grid_sizer.AddGrowableCol(1)
 
@@ -87,12 +77,12 @@ class CrossStitchHelperFrame(wx.Frame):
         self.x_only_checkbox.Bind(wx.EVT_CHECKBOX, self.update)
 
         box_x_label = wx.StaticText(self.settings_panel, wx.ID_ANY, _("Grid horizontal spacing (mm)"))
-        self.box_x = wx.SpinCtrlDouble(self.settings_panel, value='3', min=0.5, max=100, initial=3, inc=0.1)
+        self.box_x = wx.SpinCtrlDouble(self.settings_panel, value='3', min=0.1, max=100, initial=3, inc=0.1)
         self.box_x.SetDigits(2)
         self.box_x.Bind(wx.EVT_SPINCTRLDOUBLE, self.update)
 
         self.box_y_label = wx.StaticText(self.settings_panel, wx.ID_ANY, _("Grid vertical spacing (mm)"))
-        self.box_y = wx.SpinCtrlDouble(self.settings_panel, value='3', min=0.5, max=100, initial=3, inc=0.1)
+        self.box_y = wx.SpinCtrlDouble(self.settings_panel, value='3', min=0.1, max=100, initial=3, inc=0.1)
         self.box_y.SetDigits(2)
         self.box_y.Bind(wx.EVT_SPINCTRLDOUBLE, self.update)
 
@@ -125,12 +115,15 @@ class CrossStitchHelperFrame(wx.Frame):
 
         coverage_label = wx.StaticText(self.settings_panel, label=_("Fill coverage (%)"))
         self.coverage = wx.SpinCtrl(self.settings_panel, wx.ID_ANY, min=0, max=100, initial=50)
+        self.coverage.Bind(wx.EVT_SPINCTRL, self.update_bitmap_image)
 
         align_with_canvas_label = wx.StaticText(self.settings_panel, label=_("Align with canvas"))
         self.align_with_canvas = wx.CheckBox(self.settings_panel)
+        self.align_with_canvas.Bind(wx.EVT_CHECKBOX, self.update_bitmap_panel)
 
         grid_offset_label = wx.StaticText(self.settings_panel, label=_("Grid offset (mm) x[ y]"))
         self.grid_offset = wx.TextCtrl(self.settings_panel, wx.ID_ANY)
+        self.grid_offset.Bind(wx.EVT_TEXT, self.update_bitmap_panel)
 
         param_settings_sizer.AddMany([
             (cross_stitch_method_label, 0, wx.ALIGN_CENTER_VERTICAL),
@@ -143,8 +136,22 @@ class CrossStitchHelperFrame(wx.Frame):
             (self.grid_offset, 1, wx.EXPAND)
         ])
 
+        grid_settings_sizer.Add(grid_settings_label, 0, wx.EXPAND | wx.ALL, 5)
+        grid_settings_sizer.Add(grid_sizer, 1, wx.EXPAND | wx.ALL, 10)
+        grid_settings_sizer.Add((30, 30), 0, 0, 0)
+        grid_settings_sizer.Add(param_settings_headline, 0, wx.EXPAND | wx.ALL, 5)
+        grid_settings_sizer.Add(param_settings_sizer, 1, wx.EXPAND | wx.ALL, 10)
+
+        settings_wrapper_sizer.Add(grid_settings_sizer, 1, wx.EXPAND | wx.ALL, 20)
+
         # Apply grid to
-        apply_to_settings = wx.StaticText(self.settings_panel, wx.ID_ANY, _("Apply grid settings to"))
+        self.output_option_panel = wx.Panel(self.notebook, wx.ID_ANY)
+        self.notebook.AddPage(self.output_option_panel, _("Output options"))
+
+        output_wrapper_sizer = wx.BoxSizer(wx.VERTICAL)
+        apply_settings_sizer = wx.BoxSizer(wx.VERTICAL)
+
+        apply_to_settings = wx.StaticText(self.output_option_panel, wx.ID_ANY, _("Apply grid settings to"))
         apply_to_settings.SetFont(font)
 
         apply_to_grid_sizer = wx.FlexGridSizer(4, 2, 15, 20)
@@ -152,24 +159,24 @@ class CrossStitchHelperFrame(wx.Frame):
         apply_page_grid = wx.FlexGridSizer(3, 2, 15, 20)
         apply_page_grid.AddGrowableCol(1)
 
-        set_params_label = wx.StaticText(self.settings_panel, label=_("Params (selected elements)"))
-        self.set_params = wx.CheckBox(self.settings_panel)
+        set_params_label = wx.StaticText(self.output_option_panel, label=_("Params (selected elements)"))
+        self.set_params = wx.CheckBox(self.output_option_panel)
         self.set_params.Bind(wx.EVT_CHECKBOX, self.update)
 
-        pixelize_label = wx.StaticText(self.settings_panel, label=_("Pixelate (selected elements)"))
-        self.pixelize = wx.CheckBox(self.settings_panel)
+        pixelize_label = wx.StaticText(self.output_option_panel, label=_("Pixelate (selected elements)"))
+        self.pixelize = wx.CheckBox(self.output_option_panel)
         self.pixelize.Bind(wx.EVT_CHECKBOX, self.update)
 
-        pixelize_combined_label_text = "     " + _("Avoid overlapping shapes")
-        self.pixelize_combined_label = wx.StaticText(self.settings_panel, label=pixelize_combined_label_text)
-        self.pixelize_combined = wx.CheckBox(self.settings_panel)
-        pixelize_combined_tooltip = _("Inserts a new set of shapes and removes selected elements")
+        pixelize_combined_label_text = "     " + _("Remove overlaps")
+        self.pixelize_combined_label = wx.StaticText(self.output_option_panel, label=pixelize_combined_label_text)
+        self.pixelize_combined = wx.CheckBox(self.output_option_panel)
+        pixelize_combined_tooltip = _("Inserts a new set of non overlapping shapes and removes selected elements")
         self.pixelize_combined_label.SetToolTip(pixelize_combined_tooltip)
         self.pixelize_combined.SetToolTip(pixelize_combined_tooltip)
 
         node_label_text = "     " + _("Add nodes")
-        self.nodes_label = wx.StaticText(self.settings_panel, label=node_label_text)
-        self.nodes = wx.CheckBox(self.settings_panel)
+        self.nodes_label = wx.StaticText(self.output_option_panel, label=node_label_text)
+        self.nodes = wx.CheckBox(self.output_option_panel)
         nodes_tooltip = _("Add nodes at the horizontal grid spacing value")
         self.nodes_label.SetToolTip(nodes_tooltip)
         self.nodes.SetToolTip(nodes_tooltip)
@@ -185,29 +192,23 @@ class CrossStitchHelperFrame(wx.Frame):
             (self.nodes, 1, wx.EXPAND),
         ])
 
-        grid_setup_headline = wx.StaticText(self.settings_panel, wx.ID_ANY, _("Setup page grid"))
+        grid_setup_headline = wx.StaticText(self.output_option_panel, wx.ID_ANY, _("Setup page grid"))
         grid_setup_headline.SetFont(font)
 
-        setup_grid_label = wx.StaticText(self.settings_panel, label=_("Page grid"))
-        self.setup_grid = wx.CheckBox(self.settings_panel)
+        setup_grid_label = wx.StaticText(self.output_option_panel, label=_("Page grid"))
+        self.setup_grid = wx.CheckBox(self.output_option_panel)
         self.setup_grid.Bind(wx.EVT_CHECKBOX, self.update)
 
         grid_color_label_text = "     " + _("Grid color")
-        self.grid_color_label = wx.StaticText(self.settings_panel, label=grid_color_label_text)
-        self.grid_color = wx.ColourPickerCtrl(self.settings_panel, colour=wx.Colour('#00d9e5'))
+        self.grid_color_label = wx.StaticText(self.output_option_panel, label=grid_color_label_text)
+        self.grid_color = wx.ColourPickerCtrl(self.output_option_panel, colour=wx.Colour('#00d9e5'))
 
         remove_grids_label_text = "     " + _("Remove previous")
-        self.remove_grids_label = wx.StaticText(self.settings_panel, label=remove_grids_label_text)
-        self.remove_grids = wx.CheckBox(self.settings_panel)
+        self.remove_grids_label = wx.StaticText(self.output_option_panel, label=remove_grids_label_text)
+        self.remove_grids = wx.CheckBox(self.output_option_panel)
         remove_grids_tooltip = _("Remove previous cross stitch page grids")
         self.remove_grids_label.SetToolTip(remove_grids_tooltip)
         self.remove_grids.SetToolTip(remove_grids_tooltip)
-
-        grid_settings_sizer.Add(grid_settings_label, 0, wx.EXPAND | wx.ALL, 5)
-        grid_settings_sizer.Add(grid_sizer, 1, wx.EXPAND | wx.ALL, 10)
-        grid_settings_sizer.Add((30, 30), 0, 0, 0)
-        grid_settings_sizer.Add(param_settings_headline, 0, wx.EXPAND | wx.ALL, 5)
-        grid_settings_sizer.Add(param_settings_sizer, 1, wx.EXPAND | wx.ALL, 10)
 
         apply_page_grid.AddMany([
             (setup_grid_label, 0, wx.ALIGN_CENTER_VERTICAL),
@@ -223,24 +224,19 @@ class CrossStitchHelperFrame(wx.Frame):
         apply_settings_sizer.Add(grid_setup_headline, 0, wx.EXPAND | wx.ALL, 10)
         apply_settings_sizer.Add(apply_page_grid, 1, wx.EXPAND | wx.ALL, 10)
 
-        settings_options_sizer.Add(grid_settings_sizer, 1, wx.ALL, 20)
-        settings_options_sizer.Add(wx.StaticLine(self.settings_panel, 2, style=wx.LI_VERTICAL), 0, wx.ALL | wx.EXPAND, 20)
-        settings_options_sizer.Add(apply_settings_sizer, 1, wx.ALL, 20)
-
-        settings_main_sizer.Add(settings_options_sizer, 1, wx.ALL, 10)
+        output_wrapper_sizer.Add(apply_settings_sizer, 1, wx.EXPAND | wx.ALL, 20)
 
         # image conversion
         self.bitmap = wx.Panel(self.notebook, wx.ID_ANY)
         self.notebook.AddPage(self.bitmap, _("Bitmap Settings"))
 
         self.bitmap_wrapper_sizer = wx.BoxSizer(wx.HORIZONTAL)
-
-        self.bitmap_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.bitmap_settings_sizer = wx.BoxSizer(wx.VERTICAL)
 
         bitmap_headline = wx.StaticText(self.bitmap, wx.ID_ANY, _("Convert bitmaps to pixelated fill areas"))
         bitmap_headline.SetFont(font)
 
-        bitmap_grid_sizer = wx.FlexGridSizer(12, 2, 15, 20)
+        bitmap_grid_sizer = wx.FlexGridSizer(13, 2, 15, 20)
         bitmap_grid_sizer.AddGrowableCol(1)
 
         convert_bitmap_label = wx.StaticText(self.bitmap, label=_("Convert bitmaps"))
@@ -375,24 +371,10 @@ class CrossStitchHelperFrame(wx.Frame):
             (self.remove_background, 1, wx.EXPAND),
         ])
 
-        bitmap_panel = wx.Panel(self.bitmap, style=wx.BORDER_THEME)
-        bitmap_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.cross_bitmap = None
-        if self.image:
-            self.staticbitmap = wx.StaticBitmap(bitmap_panel, size=(500, 700))
-            self.cross_bitmap = BitmapToCrossStitch(None, self.image, self.settings, self.palette)
-            self.staticbitmap.SetToolTip(_("Preview image (not pixelated)"))
-            bitmap_sizer.Add(self.staticbitmap, 0, wx.ALL, 0)
-        else:
-            no_image_info = wx.StaticText(bitmap_panel, label=_("No image selected"))
-            no_image_info.SetForegroundColour(wx.RED)
-            bitmap_sizer.Add(no_image_info, 0, wx.ALL | wx.EXPAND, 20)
-        bitmap_panel.SetSizer(bitmap_sizer)
+        self.bitmap_settings_sizer.Add(bitmap_headline, 0, wx.EXPAND | wx.ALL, 10)
+        self.bitmap_settings_sizer.Add(bitmap_grid_sizer, 1, wx.EXPAND | wx.ALL, 10)
 
-        self.bitmap_sizer.Add(bitmap_headline, 0, wx.TOP | wx.LEFT, 20)
-        self.bitmap_sizer.Add(bitmap_grid_sizer, 1, wx.EXPAND | wx.ALL, 20)
-        self.bitmap_wrapper_sizer.Add(self.bitmap_sizer, 1, wx.ALL, 20)
-        self.bitmap_wrapper_sizer.Add(bitmap_panel, 0, wx.ALL | wx.ALIGN_TOP, 20)
+        self.bitmap_wrapper_sizer.Add(self.bitmap_settings_sizer, 1, wx.EXPAND | wx.ALL, 20)
 
         # help
         self.help = wx.Panel(self.notebook, wx.ID_ANY)
@@ -427,6 +409,33 @@ class CrossStitchHelperFrame(wx.Frame):
         )
         help_sizer.Add(self.website_link, 0, wx.BOTTOM | wx.LEFT | wx.RIGHT, 20)
 
+        bitmap_wrapper_sizer = wx.BoxSizer(wx.VERTICAL)
+        bitmap_panel = wx.Panel(self.main_panel)
+        bitmap_panel.SetWindowStyle(wx.BORDER_SUNKEN)
+        # bitmap_panel.SetBackgroundColour("red")  # TODO: set background color
+        bitmap_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.staticbitmap = wx.StaticBitmap(bitmap_panel, size=(600, 600))
+        self.staticbitmap.SetToolTip(_("Preview image (if applicable)"))
+        bitmap_sizer.Add(self.staticbitmap, 0, wx.ALL, 10)
+        bitmap_panel.SetSizer(bitmap_sizer)
+
+        bmp_grid_sizer = wx.FlexGridSizer(2, 2, 15, 20)
+        bmp_grid_sizer.AddGrowableCol(1)
+        display_svg_image_label = wx.StaticText(self.main_panel, label=_("SVG Preview (slow)"))
+        self.display_svg_image = wx.CheckBox(self.main_panel)
+        self.display_svg_image.Bind(wx.EVT_CHECKBOX, self.update_bitmap_panel)
+
+        bmp_grid_sizer.AddMany([
+            (display_svg_image_label, 0, wx.ALIGN_CENTER_VERTICAL),
+            (self.display_svg_image, 1, wx.EXPAND | wx.ALIGN_CENTER_VERTICAL)
+        ])
+
+        bitmap_wrapper_sizer.Add(bitmap_panel, 0, wx.ALL, 10)
+        bitmap_wrapper_sizer.Add(bmp_grid_sizer, 1, wx.EXPAND | wx.ALL, 10)
+
+        notebook_sizer.Add(bitmap_wrapper_sizer, 0, wx.LEFT, 10)
+        main_sizer.Add(notebook_sizer, 1, wx.EXPAND | wx.ALL, 10)
+
         # apply or cancel
         apply_sizer = wx.BoxSizer(wx.HORIZONTAL)
         self.reset_button = wx.Button(self.main_panel, label=_("Reset values"))
@@ -440,22 +449,59 @@ class CrossStitchHelperFrame(wx.Frame):
         apply_sizer.Add(self.cancel_button, 0, wx.RIGHT | wx.BOTTOM, 10)
         apply_sizer.Add(self.apply_button, 0, wx.RIGHT | wx.BOTTOM, 10)
 
-        notebook_sizer.Add(apply_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        main_sizer.Add(apply_sizer, 0, wx.EXPAND | wx.ALL, 0)
 
         # set sizers
-        self.settings_panel.SetSizer(settings_main_sizer)
+        self.settings_panel.SetSizer(settings_wrapper_sizer)
+        self.output_option_panel.SetSizer(output_wrapper_sizer)
         self.bitmap.SetSizer(self.bitmap_wrapper_sizer)
         self.help.SetSizer(help_sizer)
 
-        self.main_panel.SetSizerAndFit(notebook_sizer)
+        self.main_panel.SetSizerAndFit(main_sizer)
         self.Fit()
         self.Layout()
+
+    def apply_global_settings(self):
+        self.x_only_checkbox.SetValue(global_settings['square'])
+        self.box_x.SetValue(global_settings['cross_helper_box_x'])
+        self.box_y.SetValue(global_settings['cross_helper_box_y'])
+        self.set_params.SetValue(global_settings['cross_helper_set_params'])
+        cross_method = self.cross_stitch_method.FindString(self.cross_stitch_options[global_settings['cross_helper_cross_method']])
+        self.cross_stitch_method.SetSelection(cross_method)
+        self.pixelize.SetValue(global_settings['cross_helper_pixelize'])
+        self.pixelize_combined.SetValue(global_settings['cross_helper_pixelize_combined'])
+        self.nodes.SetValue(global_settings['cross_helper_nodes'])
+        self.coverage.SetValue(global_settings['cross_helper_coverage'])
+        self.grid_offset.SetValue(global_settings['cross_helper_grid_offset'])
+        self.align_with_canvas.SetValue(global_settings['cross_helper_align_with_canvas'])
+        self.setup_grid.SetValue(global_settings['cross_helper_set_grid'])
+        self.grid_color.SetColour(wx.Colour(global_settings['cross_helper_grid_color']))
+        self.remove_grids.SetValue(global_settings['cross_helper_remove_grids'])
+        self.convert_bitmap.SetValue(global_settings['cross_helper_convert_bitmap'])
+        self.color_selection_method.SetSelection(global_settings['cross_helper_color_method'])
+        self.num_colors.SetValue(global_settings['cross_bitmap_num_colors'])
+        self.quantize_method.SetSelection(global_settings['cross_bitmap_quantize_method'])
+        self.rgb_color_list.SetValue(global_settings['cross_bitmap_rgb_colors'])
+        self.gimp_palette.SetPath(global_settings['cross_bitmap_gimp_palette'])
+        self.saturation.SetValue(int(global_settings['cross_bitmap_saturation'] * 100))
+        self.saturation_numerical_input.SetValue(global_settings['cross_bitmap_saturation'])
+        self.brightness.SetValue(int(global_settings['cross_bitmap_brightness'] * 100))
+        self.brightness_numerical_input.SetValue(global_settings['cross_bitmap_brightness'])
+        self.contrast.SetValue(int(global_settings['cross_bitmap_contrast'] * 100))
+        self.contrast_numerical_input.SetValue(global_settings['cross_bitmap_contrast'])
+        self.transparency_threshold.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
+        self.transparency_threshold_numerical_input.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
+        self.background_color.SetColour(wx.Colour(global_settings['cross_bitmap_background_color']))
+        self.remove_background.SetSelection(global_settings['cross_bitmap_remove_background'])
+        self.display_svg_image.SetValue(False)  # defaults always to False to avoid longer startup times
 
     def update_by_stitch_length(self, event=None):
         stitch_length = self.stitch_length.GetValue()
         xy = stitch_length / sqrt(2)
         self.box_x.SetValue(xy)
         self.box_y.SetValue(xy)
+        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
+            self.update_bitmap_panel()
 
     def update(self, event=None):
         y_on = not self.x_only_checkbox.GetValue()
@@ -485,6 +531,9 @@ class CrossStitchHelperFrame(wx.Frame):
         self.grid_color.Enable(self.setup_grid.GetValue())
         self.remove_grids_label.Enable(self.setup_grid.GetValue())
         self.remove_grids.Enable(self.setup_grid.GetValue())
+
+        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
+            self.update_bitmap_panel()
 
     def on_color_slider_change(self, rule, event):
         # update numberical color values
@@ -542,6 +591,9 @@ class CrossStitchHelperFrame(wx.Frame):
         self.remove_background_label.Enable(convert)
         self.remove_background.Enable(convert)
 
+        if not convert:
+            self.staticbitmap.SetBitmap(wx.NullBitmap)
+
     def update_color_selection_method(self, event=None):
         method = self.color_selection_method.GetSelection()
         self.num_colors_label.Show(method == 0)
@@ -559,30 +611,135 @@ class CrossStitchHelperFrame(wx.Frame):
         self.bitmap.Layout()
         self.update_bitmap_panel()
 
-    def update_bitmap_panel(self, event=None):
-        if self.image:
-            self.apply_settings()
-            self.update_image()
+    def _load_bitmap(self):
+        bitmaps = []
+        for image in self.images:
+            cross_bitmap = BitmapToCrossStitch(None, image, self.settings, self.palette)
+            if cross_bitmap.original_image is not None:
+                bitmaps.append(cross_bitmap)
+        self.cross_bitmaps = bitmaps
 
-    def update_image(self):
-        if self.image is None or self.cross_bitmap.original_image is None:
+    def _on_debounce_timer(self, event):
+        # Debounce timer fired — start a new task
+        self._current_task_id += 1
+        task_id = self._current_task_id
+
+        # Run image rendering in a thread
+        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
+            threading.Thread(target=self.update_svg_image, args=[task_id], daemon=True).start()
+        else:
+            threading.Thread(target=self.update_bitmap_image, args=[task_id], daemon=True).start()
+
+    def update_bitmap_panel(self, event=None):
+        if self.cross_bitmap and self.cross_bitmap.original_image is None:
             return
-        self.cross_bitmap.apply_color_corrections()
-        cross_bitmap = self.cross_bitmap.reduced_image
-        cross_bitmap = self.cross_bitmap.apply_clip(cross_bitmap)
-        width, height = cross_bitmap.size
-        width, height = self.scale_bitmap(cross_bitmap, width, height, 400)
-        height, width = self.scale_bitmap(cross_bitmap, height, width, 600)
-        cross_bitmap = cross_bitmap.resize((width, height))
-        bitmap_prev = wx.Bitmap.FromBufferRGBA(width, height, cross_bitmap.tobytes())
+
+        self.apply_settings()
+
+        # Restart debounce timer (200 ms)
+        if self._debounce_timer.IsRunning():
+            self._debounce_timer.Stop()
+        self._debounce_timer.Start(200, oneShot=True)
+
+    def _get_max_image_bounds(self):
+        minx = miny = maxx = maxy = 0
+        for bmp in self.cross_bitmaps:
+            sx, sy, mx, my = bmp.bitmap.original_shape.bounds
+            if sx < minx:
+                minx = sx
+            if sy < miny:
+                miny = sy
+            if mx > maxx:
+                maxx = mx
+            if my > maxy:
+                maxy = my
+        return minx, miny, maxx, maxy
+
+    def update_bitmap_image(self, task_id):
+        if not self.cross_bitmaps:
+            image = Image.new('RGBA', (10, 10), (255, 255, 255, 1))
+        else:
+            minx, miny, maxx, maxy = self._get_max_image_bounds()
+            width = int(maxx - minx)
+            height = int(maxy - miny)
+
+            image = Image.new('RGBA', (width, height), (255, 255, 255, 1))
+
+            for cross_bitmap in self.cross_bitmaps:
+                recolored_image = cross_bitmap.apply_color_corrections(cross_bitmap.original_image)
+                image = cross_bitmap.combine_images(image, recolored_image, (minx, miny))
+
+            image = self.cross_bitmaps[0].apply_clip(image)
+        width, height = self.scaled_size(*image.size)
+        image = image.resize((width, height))
+        bitmap_prev = wx.Bitmap.FromBufferRGBA(width, height, image.tobytes())
+
+        if task_id != self._current_task_id:
+            # a newer task has already finished, do nothing
+            return
+
         self.staticbitmap.SetBitmap(bitmap_prev)
 
-    def scale_bitmap(self, bitmap, a, b, max_size):
-        # scale bitmap and preserve aspect ratio
-        if a > max_size:
-            b = int(b / (a / max_size))
-            a = max_size
-        return a, b
+    def update_svg_image(self, task_id):
+        svg_groups = Group()
+        if self.cross_bitmaps:
+            for cross_bitmap in self.cross_bitmaps:
+                svg_groups.extend(cross_bitmap.svg_nodes())
+        if self.fills:
+            if self.settings['pixelize']:
+                if self.settings['pixelize_combined']:
+                    svg_groups = pixelate_multiple(svg_groups, self.fills, self.settings)
+                else:
+                    for fill in self.fills:
+                        pixelated_outline = pixelate_element(fill, self.settings)
+                        path = self._multipolygon_to_pathelement(pixelated_outline, fill)
+                        svg_groups.append(path)
+            else:
+                for fill in self.fills:
+                    svg_groups.append(fill.node.copy())
+
+        if svg_groups is None:
+            return
+        bmp = self.svg_groups_to_bmp(svg_groups)
+
+        if task_id == self._current_task_id:
+            # no newer task has already taken over, insert the bitmap
+            self.staticbitmap.SetBitmap(bmp)
+
+    def _multipolygon_to_pathelement(self, pixelated_outline, fill):
+        for polygon in pixelated_outline.geoms:
+            path = Path(list(polygon.exterior.coords))
+            for interior in polygon.interiors:
+                interior_path = Path(list(interior.coords))
+                interior_path.close()
+                path += interior_path
+            path.close()
+        return PathElement(attrib={'d': str(path), 'style': f'fill:{fill.fill_color}'})
+
+    def scaled_size(self, orig_width, orig_height):
+        # calculate width and height for the bitmap, keeping aspect ratio
+        # use a fixed size to satisfy windows
+        max_width = 600
+        max_height = 600
+        ratio = min(max_width / orig_width, max_height / orig_height)
+        return int(orig_width * ratio), int(orig_height * ratio)
+
+    def svg_groups_to_bmp(self, svg_groups):
+        # I'd love to use SvgDocumentElement("svg", nsmap=inkex.NSS) but wxpython seems to be confused about namespaces
+        # So let's wrap the color groups manually
+        svg_string = '<svg xmlns="http://www.w3.org/2000/svg">'
+        svg_string += svg_groups.tostring().decode('utf-8')
+        svg_string += '</svg>'
+
+        svg = wx.svg.SVGimage.CreateFromBytes(svg_string.encode("utf-8"))
+
+        bbox = svg_groups.bounding_box()
+        if bbox is None:
+            return
+        width, height = int(bbox.width), int(bbox.height)
+        width, height = self.scaled_size(width, height)
+
+        return svg.ConvertToScaledBitmap(wx.Size(width, height))
 
     def reset_values(self, event):
         self.box_x.SetValue(self.default_settings['box_x'])
@@ -634,12 +791,14 @@ class CrossStitchHelperFrame(wx.Frame):
         self.settings['bitmap_gimp_palette'] = self.gimp_palette.GetPath()
         self.settings['bitmap_background_color'] = self.background_color.GetColour().Get(False)
         self.settings['bitmap_remove_background'] = self.remove_background.GetSelection()
+        self.settings['bitmap_display_svg_image'] = self.display_svg_image.GetValue()
 
     def get_cross_method(self):
         current_cross_method = self.cross_stitch_method.GetString(self.cross_stitch_method.GetSelection())
         return [method_id for method_id, method in self.cross_stitch_options.items() if method == current_cross_method][0]
 
     def apply(self, event):
+        self._current_task_id += 1
         self.settings['applied'] = True
         self.apply_settings()
 
@@ -674,18 +833,22 @@ class CrossStitchHelperFrame(wx.Frame):
         return
 
     def cancel(self, event=None):
+        self._current_task_id += 1
         self.Destroy()
 
 
 class CrossStitchHelperApp(wx.App):
-    def __init__(self, settings, image, palette):
+    def __init__(self, settings, fills, images, palette):
         self.settings = settings
-        self.image = image
+        self.fills = fills
+        self.images = []
+        if images:
+            self.images = images
         self.palette = palette
         super().__init__()
 
     def OnInit(self):
-        frame = CrossStitchHelperFrame(settings=self.settings, image=self.image, palette=self.palette)
+        frame = CrossStitchHelperFrame(settings=self.settings, images=self.images, fills=self.fills, palette=self.palette)
         self.SetTopWindow(frame)
         frame.Show()
         return True

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -155,6 +155,8 @@ class CrossStitchHelperFrame(wx.Frame):
 
         apply_to_grid_sizer = wx.FlexGridSizer(4, 2, 15, 20)
         apply_to_grid_sizer.AddGrowableCol(1)
+        element_handling_sizer = wx.FlexGridSizer(1, 2, 15, 20)
+        element_handling_sizer.AddGrowableCol(1)
         apply_page_grid = wx.FlexGridSizer(3, 2, 15, 20)
         apply_page_grid.AddGrowableCol(1)
 
@@ -163,15 +165,11 @@ class CrossStitchHelperFrame(wx.Frame):
         self.set_params.Bind(wx.EVT_CHECKBOX, self.update)
 
         pixelize_label = wx.StaticText(self.output_option_panel, label=_("Pixelate (selected elements)"))
+        pixelize_tooltip = _("Fill shapes remain unchanged when disabled.")
         self.pixelize = wx.CheckBox(self.output_option_panel)
+        pixelize_label.SetToolTip(pixelize_tooltip)
+        self.pixelize.SetToolTip(pixelize_tooltip)
         self.pixelize.Bind(wx.EVT_CHECKBOX, self.update)
-
-        pixelize_combined_label_text = "     " + _("Remove overlaps")
-        self.pixelize_combined_label = wx.StaticText(self.output_option_panel, label=pixelize_combined_label_text)
-        self.pixelize_combined = wx.CheckBox(self.output_option_panel)
-        pixelize_combined_tooltip = _("Inserts a new set of non overlapping shapes and removes selected elements")
-        self.pixelize_combined_label.SetToolTip(pixelize_combined_tooltip)
-        self.pixelize_combined.SetToolTip(pixelize_combined_tooltip)
 
         node_label_text = "     " + _("Add nodes")
         self.nodes_label = wx.StaticText(self.output_option_panel, label=node_label_text)
@@ -185,10 +183,23 @@ class CrossStitchHelperFrame(wx.Frame):
             (self.set_params, 1, wx.EXPAND),
             (pixelize_label, 0, wx.ALIGN_CENTER_VERTICAL),
             (self.pixelize, 1, wx.EXPAND),
-            (self.pixelize_combined_label, 0, wx.ALIGN_CENTER_VERTICAL),
-            (self.pixelize_combined, 1, wx.EXPAND),
             (self.nodes_label, 0, wx.ALIGN_CENTER_VERTICAL),
             (self.nodes, 1, wx.EXPAND),
+        ])
+
+        element_handling_headline = wx.StaticText(self.output_option_panel, wx.ID_ANY, _("Element handling"))
+        element_handling_headline.SetFont(font)
+
+        remove_overlaps_label_text = _("Remove overlaps")
+        remove_overlaps_label = wx.StaticText(self.output_option_panel, label=remove_overlaps_label_text)
+        self.remove_overlaps = wx.CheckBox(self.output_option_panel)
+        remove_overlaps_tooltip = _("Inserts a new set of non overlapping shapes and removes selected elements")
+        remove_overlaps_label.SetToolTip(remove_overlaps_tooltip)
+        self.remove_overlaps.SetToolTip(remove_overlaps_tooltip)
+
+        element_handling_sizer.AddMany([
+            (remove_overlaps_label, 0, wx.ALIGN_CENTER_VERTICAL),
+            (self.remove_overlaps, 1, wx.EXPAND),
         ])
 
         grid_setup_headline = wx.StaticText(self.output_option_panel, wx.ID_ANY, _("Setup page grid"))
@@ -220,6 +231,8 @@ class CrossStitchHelperFrame(wx.Frame):
 
         apply_settings_sizer.Add(apply_to_settings, 0, wx.EXPAND | wx.ALL, 5)
         apply_settings_sizer.Add(apply_to_grid_sizer, 0, wx.EXPAND | wx.ALL, 10)
+        apply_settings_sizer.Add(element_handling_headline, 0, wx.EXPAND | wx.ALL, 10)
+        apply_settings_sizer.Add(element_handling_sizer, 0, wx.ALL, 10)
         apply_settings_sizer.Add(grid_setup_headline, 0, wx.EXPAND | wx.ALL, 10)
         apply_settings_sizer.Add(apply_page_grid, 1, wx.EXPAND | wx.ALL, 10)
 
@@ -487,8 +500,6 @@ class CrossStitchHelperFrame(wx.Frame):
             self.stitch_length.Enable(True)
 
         enable = self.pixelize.GetValue()
-        self.pixelize_combined_label.Enable(enable)
-        self.pixelize_combined.Enable(enable)
         self.nodes_label.Enable(enable)
         self.nodes.Enable(enable)
 
@@ -653,7 +664,7 @@ class CrossStitchHelperFrame(wx.Frame):
                 elif self.settings['convert_bitmap']:
                     svg_groups.extend(self._get_image_nodes(element, True))
         else:
-            if self.settings['pixelize_combined']:
+            if self.settings['remove_overlaps']:
                 svg_groups = self._update_svg_image_combined(svg_groups)
             else:
                 svg_groups = self._update_svg_imgae_single(svg_groups)
@@ -762,7 +773,7 @@ class CrossStitchHelperFrame(wx.Frame):
         cross_method = self.cross_stitch_method.FindString(self.cross_stitch_options[global_settings['cross_helper_cross_method']])
         self.cross_stitch_method.SetSelection(cross_method)
         self.pixelize.SetValue(global_settings['cross_helper_pixelize'])
-        self.pixelize_combined.SetValue(global_settings['cross_helper_pixelize_combined'])
+        self.remove_overlaps.SetValue(global_settings['cross_helper_remove_overlaps'])
         self.nodes.SetValue(global_settings['cross_helper_nodes'])
         self.coverage.SetValue(global_settings['cross_helper_coverage'])
         self.grid_offset.SetValue(global_settings['cross_helper_grid_offset'])
@@ -795,11 +806,11 @@ class CrossStitchHelperFrame(wx.Frame):
         self.settings['set_params'] = self.set_params.GetValue()
         self.settings['cross_method'] = self.get_cross_method()
         self.settings['pixelize'] = self.pixelize.GetValue()
-        self.settings['pixelize_combined'] = self.pixelize_combined.GetValue()
         self.settings['nodes'] = self.nodes.GetValue()
         self.settings['coverage'] = self.coverage.GetValue()
         self.settings['grid_offset'] = self.grid_offset.GetValue()
         self.settings['align_with_canvas'] = self.align_with_canvas.GetValue()
+        self.settings['remove_overlaps'] = self.remove_overlaps.GetValue()
         self.settings['set_grid'] = self.setup_grid.GetValue()
         self.settings['grid_color'] = self.grid_color.GetColour().Get(False)
         self.settings['remove_grids'] = self.remove_grids.GetValue()
@@ -832,7 +843,7 @@ class CrossStitchHelperFrame(wx.Frame):
         global_settings['cross_helper_set_params'] = self.set_params.GetValue()
         global_settings['cross_helper_cross_method'] = self.get_cross_method()
         global_settings['cross_helper_pixelize'] = self.pixelize.GetValue()
-        global_settings['cross_helper_pixelize_combined'] = self.pixelize_combined.GetValue()
+        global_settings['cross_helper_remove_overlaps'] = self.remove_overlaps.GetValue()
         global_settings['cross_helper_nodes'] = self.nodes.GetValue()
         global_settings['cross_helper_coverage'] = self.coverage.GetValue()
         global_settings['cross_helper_grid_offset'] = self.grid_offset.GetValue()

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -22,8 +22,7 @@ class CrossStitchHelperFrame(wx.Frame):
     def __init__(self, *args, **kwargs):
         self.settings = kwargs.pop("settings")
         self.default_settings = self.settings.copy()
-        self.images = kwargs.pop("images")
-        self.fills = kwargs.pop("fills")
+        self.elements = kwargs.pop("elements")
         self.palette = kwargs.pop("palette")
 
         self.cross_bitmap = None
@@ -461,47 +460,13 @@ class CrossStitchHelperFrame(wx.Frame):
         self.Fit()
         self.Layout()
 
-    def apply_global_settings(self):
-        self.x_only_checkbox.SetValue(global_settings['square'])
-        self.box_x.SetValue(global_settings['cross_helper_box_x'])
-        self.box_y.SetValue(global_settings['cross_helper_box_y'])
-        self.set_params.SetValue(global_settings['cross_helper_set_params'])
-        cross_method = self.cross_stitch_method.FindString(self.cross_stitch_options[global_settings['cross_helper_cross_method']])
-        self.cross_stitch_method.SetSelection(cross_method)
-        self.pixelize.SetValue(global_settings['cross_helper_pixelize'])
-        self.pixelize_combined.SetValue(global_settings['cross_helper_pixelize_combined'])
-        self.nodes.SetValue(global_settings['cross_helper_nodes'])
-        self.coverage.SetValue(global_settings['cross_helper_coverage'])
-        self.grid_offset.SetValue(global_settings['cross_helper_grid_offset'])
-        self.align_with_canvas.SetValue(global_settings['cross_helper_align_with_canvas'])
-        self.setup_grid.SetValue(global_settings['cross_helper_set_grid'])
-        self.grid_color.SetColour(wx.Colour(global_settings['cross_helper_grid_color']))
-        self.remove_grids.SetValue(global_settings['cross_helper_remove_grids'])
-        self.convert_bitmap.SetValue(global_settings['cross_helper_convert_bitmap'])
-        self.color_selection_method.SetSelection(global_settings['cross_helper_color_method'])
-        self.num_colors.SetValue(global_settings['cross_bitmap_num_colors'])
-        self.quantize_method.SetSelection(global_settings['cross_bitmap_quantize_method'])
-        self.rgb_color_list.SetValue(global_settings['cross_bitmap_rgb_colors'])
-        self.gimp_palette.SetPath(global_settings['cross_bitmap_gimp_palette'])
-        self.saturation.SetValue(int(global_settings['cross_bitmap_saturation'] * 100))
-        self.saturation_numerical_input.SetValue(global_settings['cross_bitmap_saturation'])
-        self.brightness.SetValue(int(global_settings['cross_bitmap_brightness'] * 100))
-        self.brightness_numerical_input.SetValue(global_settings['cross_bitmap_brightness'])
-        self.contrast.SetValue(int(global_settings['cross_bitmap_contrast'] * 100))
-        self.contrast_numerical_input.SetValue(global_settings['cross_bitmap_contrast'])
-        self.transparency_threshold.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
-        self.transparency_threshold_numerical_input.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
-        self.background_color.SetColour(wx.Colour(global_settings['cross_bitmap_background_color']))
-        self.remove_background.SetSelection(global_settings['cross_bitmap_remove_background'])
-        self.display_svg_image.SetValue(False)  # defaults always to False to avoid longer startup times
-
     def update_by_stitch_length(self, event=None):
         stitch_length = self.stitch_length.GetValue()
         xy = stitch_length / sqrt(2)
         self.box_x.SetValue(xy)
         self.box_y.SetValue(xy)
-        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
-            self.update_bitmap_panel()
+
+        self.update_bitmap_panel()
 
     def update(self, event=None):
         y_on = not self.x_only_checkbox.GetValue()
@@ -532,8 +497,7 @@ class CrossStitchHelperFrame(wx.Frame):
         self.remove_grids_label.Enable(self.setup_grid.GetValue())
         self.remove_grids.Enable(self.setup_grid.GetValue())
 
-        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
-            self.update_bitmap_panel()
+        self.update_bitmap_panel()
 
     def on_color_slider_change(self, rule, event):
         # update numberical color values
@@ -591,8 +555,7 @@ class CrossStitchHelperFrame(wx.Frame):
         self.remove_background_label.Enable(convert)
         self.remove_background.Enable(convert)
 
-        if not convert:
-            self.staticbitmap.SetBitmap(wx.NullBitmap)
+        self.update_bitmap_panel()
 
     def update_color_selection_method(self, event=None):
         method = self.color_selection_method.GetSelection()
@@ -612,12 +575,14 @@ class CrossStitchHelperFrame(wx.Frame):
         self.update_bitmap_panel()
 
     def _load_bitmap(self):
-        bitmaps = []
-        for image in self.images:
-            cross_bitmap = BitmapToCrossStitch(None, image, self.settings, self.palette)
+        self.cross_bitmaps = {}
+        for element in self.elements:
+            if element.name == "FillStitch":
+                continue
+            el_id = element.node.get_id()
+            cross_bitmap = BitmapToCrossStitch(None, element, self.settings, self.palette)
             if cross_bitmap.original_image is not None:
-                bitmaps.append(cross_bitmap)
-        self.cross_bitmaps = bitmaps
+                self.cross_bitmaps[el_id] = (cross_bitmap)
 
     def _on_debounce_timer(self, event):
         # Debounce timer fired — start a new task
@@ -625,15 +590,14 @@ class CrossStitchHelperFrame(wx.Frame):
         task_id = self._current_task_id
 
         # Run image rendering in a thread
-        if self.settings['convert_bitmap'] and self.settings['bitmap_display_svg_image']:
+        if self.settings['bitmap_display_svg_image']:
             threading.Thread(target=self.update_svg_image, args=[task_id], daemon=True).start()
-        else:
+        elif self.settings['convert_bitmap']:
             threading.Thread(target=self.update_bitmap_image, args=[task_id], daemon=True).start()
+        else:
+            self.staticbitmap.SetBitmap(wx.NullBitmap)
 
     def update_bitmap_panel(self, event=None):
-        if self.cross_bitmap and self.cross_bitmap.original_image is None:
-            return
-
         self.apply_settings()
 
         # Restart debounce timer (200 ms)
@@ -643,7 +607,7 @@ class CrossStitchHelperFrame(wx.Frame):
 
     def _get_max_image_bounds(self):
         minx = miny = maxx = maxy = 0
-        for bmp in self.cross_bitmaps:
+        for bmp in self.cross_bitmaps.values():
             sx, sy, mx, my = bmp.bitmap.original_shape.bounds
             if sx < minx:
                 minx = sx
@@ -665,11 +629,11 @@ class CrossStitchHelperFrame(wx.Frame):
 
             image = Image.new('RGBA', (width, height), (255, 255, 255, 1))
 
-            for cross_bitmap in self.cross_bitmaps:
+            for cross_bitmap in self.cross_bitmaps.values():
                 recolored_image = cross_bitmap.apply_color_corrections(cross_bitmap.original_image)
+                recolored_image = cross_bitmap.apply_clip(recolored_image)
                 image = cross_bitmap.combine_images(image, recolored_image, (minx, miny))
 
-            image = self.cross_bitmaps[0].apply_clip(image)
         width, height = self.scaled_size(*image.size)
         image = image.resize((width, height))
         bitmap_prev = wx.Bitmap.FromBufferRGBA(width, height, image.tobytes())
@@ -682,29 +646,55 @@ class CrossStitchHelperFrame(wx.Frame):
 
     def update_svg_image(self, task_id):
         svg_groups = Group()
-        if self.cross_bitmaps:
-            for cross_bitmap in self.cross_bitmaps:
-                svg_groups.extend(cross_bitmap.svg_nodes())
-        if self.fills:
-            if self.settings['pixelize']:
-                if self.settings['pixelize_combined']:
-                    svg_groups = pixelate_multiple(svg_groups, self.fills, self.settings)
-                else:
-                    for fill in self.fills:
-                        pixelated_outline = pixelate_element(fill, self.settings)
-                        path = self._multipolygon_to_pathelement(pixelated_outline, fill)
-                        svg_groups.append(path)
+        if not self.settings['pixelize']:
+            for element in self.elements:
+                if element.name == "FillStitch":
+                    svg_groups.append(element.node.copy())
+                elif self.settings['convert_bitmap']:
+                    svg_groups.extend(self._get_image_nodes(element, True))
+        else:
+            if self.settings['pixelize_combined']:
+                svg_groups = self._update_svg_image_combined(svg_groups)
             else:
-                for fill in self.fills:
-                    svg_groups.append(fill.node.copy())
+                svg_groups = self._update_svg_imgae_single(svg_groups)
 
-        if svg_groups is None:
+        if not svg_groups:
             return
-        bmp = self.svg_groups_to_bmp(svg_groups)
 
+        bmp = self.svg_groups_to_bmp(svg_groups)
         if task_id == self._current_task_id:
             # no newer task has already taken over, insert the bitmap
             self.staticbitmap.SetBitmap(bmp)
+
+    def _update_svg_imgae_single(self, svg_groups):
+        for element in self.elements:
+            if element.name == "FillStitch":
+                pixelated_outline = pixelate_element(element, self.settings)
+                path = self._multipolygon_to_pathelement(pixelated_outline, element)
+                svg_groups.append(path)
+            else:
+                if self.settings['convert_bitmap']:
+                    svg_groups.extend(self._get_image_nodes(element, False))
+        return svg_groups
+
+    def _update_svg_image_combined(self, svg_groups):
+        fills = []
+        for element in self.elements:
+            if element.name == "FillStitch":
+                fills.append(element)
+            else:
+                if not self.settings['convert_bitmap']:
+                    continue
+                nodes = self._get_image_nodes(element, False)
+                for color_group in nodes:
+                    for element in color_group:
+                        fills.append(FillStitch(element))
+        return pixelate_multiple(svg_groups, fills, self.settings)
+
+    def _get_image_nodes(self, element, transform):
+        el_id = element.node.get_id()
+        cross_bitmap = self.cross_bitmaps[el_id]
+        return cross_bitmap.svg_nodes(transform)
 
     def _multipolygon_to_pathelement(self, pixelated_outline, fill):
         for polygon in pixelated_outline.geoms:
@@ -763,6 +753,40 @@ class CrossStitchHelperFrame(wx.Frame):
         self.update()
         self.update_color_selection_method()
         self.apply_settings()
+
+    def apply_global_settings(self):
+        self.x_only_checkbox.SetValue(global_settings['square'])
+        self.box_x.SetValue(global_settings['cross_helper_box_x'])
+        self.box_y.SetValue(global_settings['cross_helper_box_y'])
+        self.set_params.SetValue(global_settings['cross_helper_set_params'])
+        cross_method = self.cross_stitch_method.FindString(self.cross_stitch_options[global_settings['cross_helper_cross_method']])
+        self.cross_stitch_method.SetSelection(cross_method)
+        self.pixelize.SetValue(global_settings['cross_helper_pixelize'])
+        self.pixelize_combined.SetValue(global_settings['cross_helper_pixelize_combined'])
+        self.nodes.SetValue(global_settings['cross_helper_nodes'])
+        self.coverage.SetValue(global_settings['cross_helper_coverage'])
+        self.grid_offset.SetValue(global_settings['cross_helper_grid_offset'])
+        self.align_with_canvas.SetValue(global_settings['cross_helper_align_with_canvas'])
+        self.setup_grid.SetValue(global_settings['cross_helper_set_grid'])
+        self.grid_color.SetColour(wx.Colour(global_settings['cross_helper_grid_color']))
+        self.remove_grids.SetValue(global_settings['cross_helper_remove_grids'])
+        self.convert_bitmap.SetValue(global_settings['cross_helper_convert_bitmap'])
+        self.color_selection_method.SetSelection(global_settings['cross_helper_color_method'])
+        self.num_colors.SetValue(global_settings['cross_bitmap_num_colors'])
+        self.quantize_method.SetSelection(global_settings['cross_bitmap_quantize_method'])
+        self.rgb_color_list.SetValue(global_settings['cross_bitmap_rgb_colors'])
+        self.gimp_palette.SetPath(global_settings['cross_bitmap_gimp_palette'])
+        self.saturation.SetValue(int(global_settings['cross_bitmap_saturation'] * 100))
+        self.saturation_numerical_input.SetValue(global_settings['cross_bitmap_saturation'])
+        self.brightness.SetValue(int(global_settings['cross_bitmap_brightness'] * 100))
+        self.brightness_numerical_input.SetValue(global_settings['cross_bitmap_brightness'])
+        self.contrast.SetValue(int(global_settings['cross_bitmap_contrast'] * 100))
+        self.contrast_numerical_input.SetValue(global_settings['cross_bitmap_contrast'])
+        self.transparency_threshold.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
+        self.transparency_threshold_numerical_input.SetValue(int(global_settings['cross_bitmap_transparency_threshold']))
+        self.background_color.SetColour(wx.Colour(global_settings['cross_bitmap_background_color']))
+        self.remove_background.SetSelection(global_settings['cross_bitmap_remove_background'])
+        self.display_svg_image.SetValue(False)  # defaults always to False to avoid longer startup times
 
     def apply_settings(self):
         self.settings['square'] = self.x_only_checkbox.GetValue()
@@ -838,17 +862,14 @@ class CrossStitchHelperFrame(wx.Frame):
 
 
 class CrossStitchHelperApp(wx.App):
-    def __init__(self, settings, fills, images, palette):
+    def __init__(self, settings, elements, palette):
         self.settings = settings
-        self.fills = fills
-        self.images = []
-        if images:
-            self.images = images
+        self.elements = elements
         self.palette = palette
         super().__init__()
 
     def OnInit(self):
-        frame = CrossStitchHelperFrame(settings=self.settings, images=self.images, fills=self.fills, palette=self.palette)
+        frame = CrossStitchHelperFrame(settings=self.settings, elements=self.elements, palette=self.palette)
         self.SetTopWindow(frame)
         frame.Show()
         return True

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -689,17 +689,17 @@ class CrossStitchHelperFrame(wx.Frame):
             if self.settings['remove_overlaps']:
                 svg_groups = self._update_svg_image_combined(svg_groups)
             else:
-                svg_groups = self._update_svg_imgae_single(svg_groups)
+                svg_groups = self._update_svg_image_single(svg_groups)
 
         if not svg_groups:
-            return
+            self.staticbitmap.SetBitmap(wx.NullImage)
 
         bmp = self.svg_groups_to_bmp(svg_groups)
         if task_id == self._current_task_id:
             # no newer task has already taken over, insert the bitmap
             self.staticbitmap.SetBitmap(bmp)
 
-    def _update_svg_imgae_single(self, svg_groups):
+    def _update_svg_image_single(self, svg_groups):
         for element in self.elements:
             if element.name == "FillStitch":
                 pixelated_outline = pixelate_element(element, self.settings)
@@ -761,7 +761,7 @@ class CrossStitchHelperFrame(wx.Frame):
 
         bbox = svg_groups.bounding_box()
         if bbox is None:
-            return
+            return wx.NullBitmap
         width, height = int(bbox.width), int(bbox.height)
         width, height = self.scaled_size(width, height)
 

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -401,11 +401,12 @@ class CrossStitchHelperFrame(wx.Frame):
             self.help,
             wx.ID_ANY,
             _("This extension helps to generate cross stitches in Ink/Stitch. It can:\n\n"
-              "* Calculate stitch length for given grid spacing values\n"
-              "* Apply cross stitch parameters to selected fill elements.\n"
+              "* Define the grid size by either the maximum stitch length or grid spacing values\n"
+              "* Apply cross stitch parameters.\n"
               "* Pixelate outlines of selected fill elements.\n"
               "* Generate pixelated fills from bitmaps.\n"
-              "* Apply spacing values to page grid."),
+              "* Remove overlaps.\n"
+              "* Setup a page grid."),
             style=wx.ALIGN_LEFT
         )
         help_text.Wrap(500)

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -732,6 +732,7 @@ class CrossStitchHelperFrame(wx.Frame):
         return cross_bitmap.svg_nodes(transform)
 
     def _multipolygon_to_pathelement(self, pixelated_outline, fill):
+        path = ''
         for polygon in pixelated_outline.geoms:
             path = Path(list(polygon.exterior.coords))
             for interior in polygon.interiors:

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -631,7 +631,7 @@ class CrossStitchHelperFrame(wx.Frame):
         return minx, miny, maxx, maxy
 
     def update_bitmap_image(self, task_id):
-        if not self.cross_bitmaps:
+        if not self.cross_bitmaps.values():
             image = Image.new('RGBA', (10, 10), (255, 255, 255, 1))
         else:
             minx, miny, maxx, maxy = self._get_max_image_bounds()
@@ -644,6 +644,13 @@ class CrossStitchHelperFrame(wx.Frame):
                 recolored_image = cross_bitmap.apply_color_corrections(cross_bitmap.original_image)
                 recolored_image = cross_bitmap.apply_clip(recolored_image)
                 image = cross_bitmap.combine_images(image, recolored_image, (minx, miny))
+
+        # Get bounding box of non-transparent areas
+        # and crop the image for display
+        alpha_mask = image.getchannel("A").point(lambda a: 255 if a > 1 else 0)
+        bbox = alpha_mask.getbbox()
+        if bbox:
+            image = image.crop(bbox)
 
         width, height = self.scaled_size(*image.size)
         image = image.resize((width, height))
@@ -685,7 +692,9 @@ class CrossStitchHelperFrame(wx.Frame):
                 svg_groups.append(path)
             else:
                 if self.settings['convert_bitmap']:
-                    svg_groups.extend(self._get_image_nodes(element, False))
+                    elements = self._get_image_nodes(element, False)
+                    if elements:
+                        svg_groups.extend(elements)
         return svg_groups
 
     def _update_svg_image_combined(self, svg_groups):
@@ -722,7 +731,7 @@ class CrossStitchHelperFrame(wx.Frame):
         # use a fixed size to satisfy windows
         max_width = 600
         max_height = 600
-        ratio = min(max_width / orig_width, max_height / orig_height)
+        ratio = min(max_width / max(1, orig_width), max_height / max(1, orig_height))
         return int(orig_width * ratio), int(orig_height * ratio)
 
     def svg_groups_to_bmp(self, svg_groups):

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -114,7 +114,7 @@ class CrossStitchHelperFrame(wx.Frame):
 
         coverage_label = wx.StaticText(self.settings_panel, label=_("Fill coverage (%)"))
         self.coverage = wx.SpinCtrl(self.settings_panel, wx.ID_ANY, min=0, max=100, initial=50)
-        self.coverage.Bind(wx.EVT_SPINCTRL, self.update_bitmap_image)
+        self.coverage.Bind(wx.EVT_SPINCTRL, self.update_bitmap_panel)
 
         align_with_canvas_label = wx.StaticText(self.settings_panel, label=_("Align with canvas"))
         self.align_with_canvas = wx.CheckBox(self.settings_panel)

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -160,13 +160,16 @@ class CrossStitchHelperFrame(wx.Frame):
         apply_page_grid = wx.FlexGridSizer(3, 2, 15, 20)
         apply_page_grid.AddGrowableCol(1)
 
-        set_params_label = wx.StaticText(self.output_option_panel, label=_("Params (selected elements)"))
+        set_params_label = wx.StaticText(self.output_option_panel, label=_("Params"))
         self.set_params = wx.CheckBox(self.output_option_panel)
+        params_tooltip = _("Defines whether params for all selected elements should be updated or not.")
+        set_params_label.SetToolTip(params_tooltip)
+        self.set_params.SetToolTip(params_tooltip)
         self.set_params.Bind(wx.EVT_CHECKBOX, self.update)
 
-        pixelize_label = wx.StaticText(self.output_option_panel, label=_("Pixelate (selected elements)"))
-        pixelize_tooltip = _("Fill shapes remain unchanged when disabled.")
+        pixelize_label = wx.StaticText(self.output_option_panel, label=_("Pixelate"))
         self.pixelize = wx.CheckBox(self.output_option_panel)
+        pixelize_tooltip = _("Defines whether the outlines of selected fill shapes should be pixelated or not.")
         pixelize_label.SetToolTip(pixelize_tooltip)
         self.pixelize.SetToolTip(pixelize_tooltip)
         self.pixelize.Bind(wx.EVT_CHECKBOX, self.update)
@@ -193,7 +196,7 @@ class CrossStitchHelperFrame(wx.Frame):
         remove_overlaps_label_text = _("Remove overlaps")
         remove_overlaps_label = wx.StaticText(self.output_option_panel, label=remove_overlaps_label_text)
         self.remove_overlaps = wx.CheckBox(self.output_option_panel)
-        remove_overlaps_tooltip = _("Inserts a new set of non overlapping shapes and removes selected elements")
+        remove_overlaps_tooltip = _("Inserts a new set of non-overlapping shapes and removes selected fill elements")
         remove_overlaps_label.SetToolTip(remove_overlaps_tooltip)
         self.remove_overlaps.SetToolTip(remove_overlaps_tooltip)
 

--- a/lib/gui/cross_stitch_helper.py
+++ b/lib/gui/cross_stitch_helper.py
@@ -258,6 +258,13 @@ class CrossStitchHelperFrame(wx.Frame):
         self.convert_bitmap = wx.CheckBox(self.bitmap)
         self.convert_bitmap.Bind(wx.EVT_CHECKBOX, self.enable_bitmap_settings)
 
+        self.pixel_by_pixel_label = wx.StaticText(self.bitmap, label=_("One cross each pixel"))
+        self.pixel_by_pixel = wx.CheckBox(self.bitmap)
+        pixel_tooltip = _("Scales the image up by using one cross for each pixel")
+        self.pixel_by_pixel_label.SetToolTip(pixel_tooltip)
+        self.pixel_by_pixel.SetToolTip(pixel_tooltip)
+        self.pixel_by_pixel.Bind(wx.EVT_CHECKBOX, self.update_bitmap_panel)
+
         color_choices = [
             _("Number of colors"),
             _("Selected stroke colors"),
@@ -362,6 +369,8 @@ class CrossStitchHelperFrame(wx.Frame):
         bitmap_grid_sizer.AddMany([
             (convert_bitmap_label, 0, wx.ALIGN_CENTER_VERTICAL),
             (self.convert_bitmap, 1, wx.EXPAND),
+            (self.pixel_by_pixel_label, 0, wx.ALIGN_CENTER_VERTICAL),
+            (self.pixel_by_pixel, 1, wx.EXPAND),
             (self.color_selection_method_label, 0, wx.ALIGN_CENTER_VERTICAL),
             (self.color_selection_method, 1, wx.EXPAND),
             (self.num_colors_label, 0, wx.ALIGN_CENTER_VERTICAL),
@@ -543,6 +552,8 @@ class CrossStitchHelperFrame(wx.Frame):
 
     def enable_bitmap_settings(self, event=None):
         convert = self.convert_bitmap.GetValue()
+        self.pixel_by_pixel_label.Enable(convert)
+        self.pixel_by_pixel.Enable(convert)
         self.color_selection_method_label.Enable(convert)
         self.color_selection_method.Enable(convert)
         self.num_colors_label.Enable(convert)
@@ -795,6 +806,7 @@ class CrossStitchHelperFrame(wx.Frame):
         self.grid_color.SetColour(wx.Colour(global_settings['cross_helper_grid_color']))
         self.remove_grids.SetValue(global_settings['cross_helper_remove_grids'])
         self.convert_bitmap.SetValue(global_settings['cross_helper_convert_bitmap'])
+        self.pixel_by_pixel.SetValue(global_settings['cross_helper_pixel_by_pixel'])
         self.color_selection_method.SetSelection(global_settings['cross_helper_color_method'])
         self.num_colors.SetValue(global_settings['cross_bitmap_num_colors'])
         self.quantize_method.SetSelection(global_settings['cross_bitmap_quantize_method'])
@@ -829,6 +841,7 @@ class CrossStitchHelperFrame(wx.Frame):
         self.settings['remove_grids'] = self.remove_grids.GetValue()
         self.settings['color_method'] = self.color_selection_method.GetSelection()
         self.settings['convert_bitmap'] = self.convert_bitmap.GetValue()
+        self.settings['pixel_by_pixel'] = self.pixel_by_pixel.GetValue()
         self.settings['bitmap_num_colors'] = self.num_colors.GetValue()
         self.settings['bitmap_quantize_method'] = self.quantize_method.GetSelection()
         self.settings['bitmap_saturation'] = self.saturation.GetValue() / 100
@@ -865,6 +878,7 @@ class CrossStitchHelperFrame(wx.Frame):
         global_settings['cross_helper_grid_color'] = self.grid_color.GetColour().Get(False)
         global_settings['cross_helper_remove_grids'] = self.remove_grids.GetValue()
         global_settings['cross_helper_convert_bitmap'] = self.convert_bitmap.GetValue()
+        global_settings['cross_helper_pixel_by_pixel'] = self.pixel_by_pixel.GetValue()
         global_settings['cross_helper_color_method'] = self.color_selection_method.GetSelection()
         global_settings['cross_bitmap_num_colors'] = self.num_colors.GetValue()
         global_settings['cross_bitmap_quantize_method'] = self.quantize_method.GetSelection()

--- a/lib/stitches/cross_stitch.py
+++ b/lib/stitches/cross_stitch.py
@@ -85,7 +85,7 @@ def _grid_rotate(fill, shape):
     elif not fill.canvas_grid_origin:
         rotation_center = (minx, maxy)
     else:
-        rotation_center = fill.cross_offset
+        rotation_center = tuple(fill.cross_offset)
     rotated_shape = rotate(shape, -fill.cross_rotation, origin=rotation_center)
     return rotation_center, rotated_shape
 

--- a/lib/utils/pixelate.py
+++ b/lib/utils/pixelate.py
@@ -1,0 +1,139 @@
+# Authors: see git history
+#
+# Copyright (c) 2026 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from collections import defaultdict
+from inkex import Color, Group, Path, PathElement
+from shapely import make_valid, unary_union
+from ..stitches.utils.cross_stitch import CrossGeometries
+from ..svg import PIXELS_PER_MM, get_correction_transform
+from .geometry import ensure_multi_polygon
+
+
+def pixelate_element(element, settings):
+    ''' Takes a fill element and returns a multipolygon with its pixelated shape
+    '''
+    geometries = CrossGeometries(
+        element.shrink_or_grow_shape(element.shape, 0.1),
+        (settings['box_x'] * PIXELS_PER_MM, settings['box_y'] * PIXELS_PER_MM),
+        settings['coverage'],
+        'simple_cross',
+        _get_grid_offset(settings),
+        settings['align_with_canvas']
+    )
+
+    outline = _prepare_outline(geometries.boxes, settings)
+    return outline
+
+
+def pixelate_multiple(destination_group, fills, settings):
+    ''' Pixelate multiple fill areas and generate path elements
+        Returns the given destination_group with color sorted pixelated fill elements
+    '''
+    colored_boxes = _get_colored_boxes(fills, settings)
+    if not colored_boxes:
+        return destination_group
+
+    for color, boxes in colored_boxes.items():
+        color_group = Group()
+        color_group.label = color
+        # setup the path
+        outline = _prepare_outline(boxes, settings)
+        for polygon in outline.geoms:
+            path = Path(list(polygon.exterior.coords))
+            for interior in polygon.interiors:
+                interior_path = Path(list(interior.coords))
+                interior_path.close()
+                path += interior_path
+            path.close()
+
+            path_element = PathElement()
+            path_element.set('d', str(path))
+            path_element.transform = get_correction_transform(fills[-1].node)
+            path_element.style['fill'] = color_group.label
+            color_group.append(path_element)
+        if len(color_group) > 1:
+            destination_group.append(color_group)
+        else:
+            destination_group.append(color_group[0])
+
+    return destination_group
+
+
+def _prepare_outline(boxes, settings):
+    outline = unary_union(boxes)
+    # add a small buffer to connect otherwise unconnected elements
+    outline = outline.buffer(0.001)
+    # the buffer has added some unwanted nodes at corners
+    # remove them with simplify
+    outline = outline.simplify(0.1)
+    outline = make_valid(outline)
+    # simplify has removed nodes at grid intersections.
+    # the user chose to have some additional nodes (to pull the shape out, let's add some nodes back in
+    if settings['nodes']:
+        outline = outline.segmentize(settings['box_x'] * PIXELS_PER_MM + 0.002)
+    return ensure_multi_polygon(outline)
+
+
+def _get_grid_offset(settings):
+    grid_offset = settings['grid_offset'].split(' ')
+    try:
+        grid_offset = settings['grid_offset'].split(' ')
+        if len(grid_offset) == 1:
+            offset = float(grid_offset[0]) * PIXELS_PER_MM
+            return (offset, offset)
+        elif len(grid_offset) == 2:
+            return (float(grid_offset[0]) * PIXELS_PER_MM, float(grid_offset[1] * PIXELS_PER_MM))
+    except ValueError:
+        pass
+    return (0, 0)  # Fallback
+
+
+def _get_colored_boxes(fills, settings):
+    ''' Gets all fill while also removing overlaps.
+        Combines all fills and genereates a bunch of little boxes to fill the entire area.
+        Then assigns most prominent color to each box.
+    '''
+    fill_areas = []
+    fill_areas_by_color = defaultdict(list)
+    # Walk in reversed order through the fill shapes, so we can remove visually covered areas easily
+    for fill in reversed(fills):
+        # subtract areas already filled with a color
+        area = unary_union(fill_areas)
+        adapted_shape = fill.shape.difference(area)
+        if not adapted_shape.is_empty:
+            color = Color(fill.fill_color).to('named')
+            fill_areas_by_color[color].append(fill.shape.difference(area))
+        # add a little expand value to connect otherwise unconnected
+        fill_areas.append(fill.shrink_or_grow_shape(fill.shape, 0.1))
+
+    # combine all selected fill shape areas to generate all squares at once
+    full_area = ensure_multi_polygon(unary_union(fill_areas))
+    # get squares
+    grid_offset = _get_grid_offset(settings)
+    geometries = CrossGeometries(
+        full_area,
+        (settings['box_x'] * PIXELS_PER_MM, settings['box_y'] * PIXELS_PER_MM),
+        settings['coverage'],
+        'simple_cross',
+        grid_offset,
+        settings['align_with_canvas']
+    )
+
+    color_shape_dict = {}
+    for color, shapes in fill_areas_by_color.items():
+        color_shape_dict[color] = make_valid(unary_union(shapes))
+
+    colored_boxes = defaultdict(list)
+    for box in geometries.boxes:
+        current_color = None
+        highest_overlap = 0
+        for color, shape in color_shape_dict.items():
+            overlap = box.intersection(shape).area
+            if overlap > highest_overlap:
+                current_color = color
+                highest_overlap = overlap
+        if current_color is not None:
+            colored_boxes[current_color].append(box)
+    return colored_boxes

--- a/lib/utils/pixelate.py
+++ b/lib/utils/pixelate.py
@@ -58,6 +58,7 @@ def pixelate_multiple(destination_group, fills, settings):
         else:
             destination_group.append(color_group[0])
 
+    destination_group[:] = sorted(destination_group, key=lambda group: len(group), reverse=True)
     return destination_group
 
 

--- a/lib/utils/pixelate.py
+++ b/lib/utils/pixelate.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from inkex import Color, Group, Path, PathElement
 from shapely import make_valid, unary_union
 from ..stitches.utils.cross_stitch import CrossGeometries
-from ..svg import PIXELS_PER_MM, get_correction_transform
+from ..svg import PIXELS_PER_MM
 from .geometry import ensure_multi_polygon
 
 
@@ -51,7 +51,6 @@ def pixelate_multiple(destination_group, fills, settings):
 
             path_element = PathElement()
             path_element.set('d', str(path))
-            path_element.transform = get_correction_transform(fills[-1].node)
             path_element.style['fill'] = color_group.label
             color_group.append(path_element)
         if len(color_group) > 1:

--- a/lib/utils/pixelate.py
+++ b/lib/utils/pixelate.py
@@ -104,7 +104,7 @@ def _get_colored_boxes(fills, settings):
         area = unary_union(fill_areas)
         adapted_shape = fill.shape.difference(area)
         if not adapted_shape.is_empty:
-            color = Color(fill.fill_color).to('named')
+            color = Color(fill.color).to('named')
             fill_areas_by_color[color].append(fill.shape.difference(area))
         # add a little expand value to connect otherwise unconnected
         fill_areas.append(fill.shrink_or_grow_shape(fill.shape, 0.1))

--- a/lib/utils/pixelate.py
+++ b/lib/utils/pixelate.py
@@ -20,7 +20,8 @@ def pixelate_element(element, settings):
         settings['coverage'],
         'simple_cross',
         _get_grid_offset(settings),
-        settings['align_with_canvas']
+        settings['align_with_canvas'],
+        4
     )
 
     outline = _prepare_outline(geometries.boxes, settings)
@@ -91,8 +92,8 @@ def _get_grid_offset(settings):
 
 
 def _get_colored_boxes(fills, settings):
-    ''' Gets all fill while also removing overlaps.
-        Combines all fills and genereates a bunch of little boxes to fill the entire area.
+    ''' Pixelate all fills while also removing overlaps.
+        Combines all fills and generates a bunch of little boxes to fill the entire area.
         Then assigns most prominent color to each box.
     '''
     fill_areas = []
@@ -118,7 +119,8 @@ def _get_colored_boxes(fills, settings):
         settings['coverage'],
         'simple_cross',
         grid_offset,
-        settings['align_with_canvas']
+        settings['align_with_canvas'],
+        4
     )
 
     color_shape_dict = {}

--- a/lib/utils/settings.py
+++ b/lib/utils/settings.py
@@ -48,7 +48,7 @@ DEFAULT_SETTINGS = {
     'cross_helper_set_params': True,
     'cross_helper_cross_method': 'simple_cross',
     'cross_helper_pixelize': False,
-    'cross_helper_pixelize_combined': True,
+    'cross_helper_remove_overlaps': True,
     'cross_helper_coverage': 50,
     'cross_helper_grid_offset': '0',
     'cross_helper_align_with_canvas': True,

--- a/lib/utils/settings.py
+++ b/lib/utils/settings.py
@@ -57,6 +57,7 @@ DEFAULT_SETTINGS = {
     'cross_helper_grid_color': (0, 153, 229),
     'cross_helper_remove_grids': True,
     'cross_helper_convert_bitmap': False,
+    'cross_helper_pixel_by_pixel': False,
     'cross_helper_color_method': 0,
     'cross_bitmap_num_colors': 5,
     'cross_bitmap_quantize_method': 1,


### PR DESCRIPTION
A cross stitch helper update.
The preview window has been extended to also (on request) show fills along with the image.
Images and fills can be combined to a non overlapping output all together.