### PR TITLE
Pystitch exceptions

### DIFF
--- a/lib/stitch_plan/generate_stitch_plan.py
+++ b/lib/stitch_plan/generate_stitch_plan.py
@@ -25,6 +25,9 @@ def generate_stitch_plan(embroidery_file, import_commands="symbols"):  # noqa: C
     except pystitch.exceptions.NoStitchesError:
         inkex.errormsg(_("Could not open the file: no stitch information found."))
         sys.exit(0)
+    if pattern.count_stitches() < 2:
+        inkex.errormsg(_("Could not open the file: no stitch information found."))
+        sys.exit(0)
     stitch_plan = StitchPlan()
     color_block = None
 

--- a/lib/stitch_plan/generate_stitch_plan.py
+++ b/lib/stitch_plan/generate_stitch_plan.py
@@ -20,7 +20,11 @@ from .stitch_plan import StitchPlan
 
 def generate_stitch_plan(embroidery_file, import_commands="symbols"):  # noqa: C901
     validate_file_path(embroidery_file)
-    pattern = pystitch.read(embroidery_file)
+    try:
+        pattern = pystitch.read(embroidery_file)
+    except pystitch.exceptions.NoStitchesError:
+        inkex.errormsg(_("Could not open the file: no stitch information found."))
+        sys.exit(0)
     stitch_plan = StitchPlan()
     color_block = None
 

--- a/lib/stitch_plan/generate_stitch_plan.py
+++ b/lib/stitch_plan/generate_stitch_plan.py
@@ -25,6 +25,10 @@ def generate_stitch_plan(embroidery_file, import_commands="symbols"):  # noqa: C
     except pystitch.exceptions.NoStitchesError:
         inkex.errormsg(_("Could not open the file: no stitch information found."))
         sys.exit(0)
+    except Exception as exc:
+        inkex.errormsg(_("Could not read embroidery information from this file."))
+        inkex.errormsg(f"\nError: {exc}")
+        sys.exit(0)
     if pattern.count_stitches() < 2:
         inkex.errormsg(_("Could not open the file: no stitch information found."))
         sys.exit(0)


### PR DESCRIPTION
When users try to open files with pystitch, it sometimes happens, that those files are corrupted or not even meant for embroidery. In those cases we get a traceback in Ink/Stitch, which isn't nice.

This pr requires pystitch to be updated on pypi.
It has exceptions for opening corrupted or not meant for embroidery files for HUS and JSON so far. We should add more though.

Fixes #4041