### PR TITLE
Apply thread palette: match tartan palette colors

### DIFF
--- a/lib/extensions/apply_palette.py
+++ b/lib/extensions/apply_palette.py
@@ -3,10 +3,14 @@
 # Copyright (c) 2024 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
+from json import dumps
+
 from ..elements import Clone, FillStitch
 from ..gui.abort_message import AbortMessageApp
 from ..gui.apply_palette import ApplyPaletteApp
 from ..i18n import _
+from ..tartan.palette import Palette
+from ..tartan.utils import get_tartan_settings
 from ..threads import ThreadCatalog, ThreadColor
 from .base import InkstitchExtension
 
@@ -50,6 +54,15 @@ class ApplyPalette(InkstitchExtension):
             nearest_color = palette.nearest_color(ThreadColor(element.color))
             if isinstance(element, FillStitch):
                 element.node.style['fill'] = nearest_color.to_hex_str()
+
+                # Apply palette to tartan color palette
+                if element.node.get('inkstitch:tartan', None):
+                    settings = get_tartan_settings(element.node)
+                    tartan_palette = Palette()
+                    tartan_palette.update_from_code(settings['palette'])
+                    tartan_palette.apply_palette(palette)
+                    settings['palette'] = tartan_palette.palette_code
+                    element.node.set('inkstitch:tartan', dumps(settings))
             else:
                 element.node.style['stroke'] = nearest_color.to_hex_str()
 

--- a/lib/tartan/palette.py
+++ b/lib/tartan/palette.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, List, cast
 import wx
 from inkex import Color, ColorError
 
+from ..threads import ThreadColor, ThreadPalette
 from .colors import string_to_color
 
 if TYPE_CHECKING:
@@ -125,6 +126,16 @@ class Palette:
         if not self.symmetry:
             code_str = f'...{code}...'
         self.palette_code = code_str
+
+    def apply_palette(self, palette: ThreadPalette) -> None:
+        """Adapt stripe colors to match nearest colors of a given thread palette
+
+        :param palette: the thread palette to match stripe colors to
+        """
+        for direction in self.palette_stripes:
+            for stripe in direction:
+                stripe['color'] = palette.nearest_color(ThreadColor(stripe['color'])).to_hex_str()
+        self.update_code()
 
     def parse_simple_code(self, code: str) -> None:
         """Example code:


### PR DESCRIPTION
Tartan colors are selectable through the operating system specific color picker and are difficult to match to the colors used within the rest of the design.
We already do have an extension to match colors on a specific thread palette and once used, it will match every color to the chosen palette on export as well... but this is not visible until the export happened - at least for tartan stitch plans.

So let's update the extension to directly match tartan thread colors right away.