### PR TITLE
Letters to font: align letters and baseline at bottom left

### DIFF
--- a/lib/extensions/letters_to_font.py
+++ b/lib/extensions/letters_to_font.py
@@ -44,6 +44,7 @@ class LettersToFont(InkstitchExtension):
         document = self.document.getroot()  # type: ignore
         unit_multiplier = self.svg.viewport_to_unit(1)
         page_bbox = self.svg.get_page_bbox()
+        container_group = inkex.Group()
         group = None
         for glyph in glyphs:
             letter = self.get_glyph_element(glyph)
@@ -61,11 +62,11 @@ class LettersToFont(InkstitchExtension):
             # there will only be one object per color block anyway
             if self.options.import_commands == "none":
                 for element in letter.iter(SVG_PATH_TAG):
-                    group.insert(0, element)
+                    group.append(element)
             else:
-                group.insert(0, letter)
+                group.append(letter)
 
-            document.insert(0, group)
+            container_group.append(group)
 
             # move letter to the bottom left of the page
             bbox = group.bounding_box()
@@ -80,15 +81,15 @@ class LettersToFont(InkstitchExtension):
         if group is None:
             return
 
-        # users may be confused if they get an empty document
-        # make last letter visible again
-        group.set('style', None)
-
         if self.options.import_commands == "symbols":
             # In most cases trims are inserted with the imported letters.
             # Let's make sure the trim symbol exists in the defs section
             ensure_symbol(document, 'trim')
 
+        # insert sorted glyph list
+        self.insert_sorted_glyphs_to_document(document, container_group)
+
+        # insert baseline
         self.insert_baseline(page_bbox.bottom)
 
     def get_glyph_element(self, glyph: Path) -> inkex.Group:
@@ -115,3 +116,11 @@ class LettersToFont(InkstitchExtension):
 
     def insert_baseline(self, page_bottom: float) -> None:
         self.svg.namedview.add_guide(position=page_bottom, name="baseline")
+
+    def insert_sorted_glyphs_to_document(self, document: inkex.Group, container_group: inkex.Group) -> None:
+        container_group[:] = sorted(container_group, key=lambda glyph: glyph.label, reverse=True)
+        for group in container_group:
+            document.append(group)
+        # users may be confused if they get an empty document
+        # make last letter visible
+        group.set('style', None)

--- a/lib/extensions/letters_to_font.py
+++ b/lib/extensions/letters_to_font.py
@@ -30,7 +30,7 @@ class LettersToFont(InkstitchExtension):
         self.arg_parser.add_argument("-f", "--file-format", type=str, default="", dest="file_format")
         self.arg_parser.add_argument("-c", "--import-commands", type=str, default="params", dest="import_commands")
 
-    def effect(self):
+    def effect(self) -> None:
         font_dir = self.options.font_dir
         file_format = self.options.file_format
 
@@ -41,10 +41,14 @@ class LettersToFont(InkstitchExtension):
         if not glyphs:
             glyphs = list(Path(font_dir).rglob(file_format.lower()))
 
-        document = self.document.getroot()
+        document = self.document.getroot()  # type: ignore
+        unit_multiplier = self.svg.viewport_to_unit(1)
+        page_bbox = self.svg.get_page_bbox()
         group = None
         for glyph in glyphs:
             letter = self.get_glyph_element(glyph)
+            if not letter:
+                continue
             label = unescape(letter.get(INKSCAPE_LABEL, ' ')).split('.')[0][-1]
             label = f"GlyphLayer-{ label }"
             group = inkex.Group(attrib={
@@ -62,6 +66,14 @@ class LettersToFont(InkstitchExtension):
                 group.insert(0, letter)
 
             document.insert(0, group)
+
+            # move letter to the bottom left of the page
+            bbox = group.bounding_box()
+            if bbox is not None:
+                translate_x = (page_bbox.left - bbox.left) / unit_multiplier
+                translate_y = (page_bbox.bottom - bbox.bottom) / unit_multiplier
+                group.transform @= inkex.Transform(f'translate({translate_x}, {translate_y})')
+
             group.set('style', 'display:none')
 
         # We found no glyphs, no need to proceed
@@ -77,9 +89,9 @@ class LettersToFont(InkstitchExtension):
             # Let's make sure the trim symbol exists in the defs section
             ensure_symbol(document, 'trim')
 
-        self.insert_baseline()
+        self.insert_baseline(page_bbox.bottom)
 
-    def get_glyph_element(self, glyph):
+    def get_glyph_element(self, glyph: Path) -> inkex.Group:
         label = os.path.basename(glyph)
         if self.options.file_format.endswith('SVG'):
             stitch_plan = self.get_svg_elements(glyph)
@@ -93,7 +105,7 @@ class LettersToFont(InkstitchExtension):
         stitch_plan.label = label
         return stitch_plan
 
-    def get_svg_elements(self, glyph):
+    def get_svg_elements(self, glyph: Path) -> inkex.Group:
         glyph_svg = self.load(glyph).getroot()
         glyph_group = inkex.Group()
         # move all embroiderable child elements and groups of the svg file into a group
@@ -101,5 +113,5 @@ class LettersToFont(InkstitchExtension):
             glyph_group.add(child)
         return glyph_group
 
-    def insert_baseline(self):
-        self.svg.namedview.add_guide(position=0.0, name="baseline")
+    def insert_baseline(self, page_bottom: float) -> None:
+        self.svg.namedview.add_guide(position=page_bottom, name="baseline")

--- a/lib/extensions/letters_to_font.py
+++ b/lib/extensions/letters_to_font.py
@@ -13,7 +13,7 @@ from inkex import errormsg
 from ..commands import ensure_symbol
 from ..i18n import _
 from ..stitch_plan import generate_stitch_plan
-from ..svg import get_correction_transform
+from ..svg import PIXELS_PER_MM, get_correction_transform
 from ..svg.tags import (EMBROIDERABLE_TAGS, INKSCAPE_GROUPMODE, INKSCAPE_LABEL,
                         SVG_GROUP_TAG, SVG_PATH_TAG)
 from .base import InkstitchExtension
@@ -28,18 +28,20 @@ class LettersToFont(InkstitchExtension):
         self.arg_parser.add_argument("--notebook")
         self.arg_parser.add_argument("-d", "--font-dir", type=str, default="", dest="font_dir")
         self.arg_parser.add_argument("-f", "--file-format", type=str, default="", dest="file_format")
+        self.arg_parser.add_argument("-m", "--margin-left", type=float, default=0, dest="margin_left")
         self.arg_parser.add_argument("-c", "--import-commands", type=str, default="params", dest="import_commands")
 
     def effect(self) -> None:
         font_dir = self.options.font_dir
         file_format = self.options.file_format
+        margin_left = self.options.margin_left * PIXELS_PER_MM
 
         if not os.path.isdir(font_dir):
             errormsg(_("Font directory not found. Please specify an existing directory."))
 
+        # up from python 3.12 we will be able to use a case_sensitive attribute for this
         glyphs = list(Path(font_dir).rglob(file_format))
-        if not glyphs:
-            glyphs = list(Path(font_dir).rglob(file_format.lower()))
+        glyphs += list(Path(font_dir).rglob(file_format.lower()))
 
         document = self.document.getroot()  # type: ignore
         unit_multiplier = self.svg.viewport_to_unit(1)
@@ -71,7 +73,7 @@ class LettersToFont(InkstitchExtension):
             # move letter to the bottom left of the page
             bbox = group.bounding_box()
             if bbox is not None:
-                translate_x = (page_bbox.left - bbox.left) / unit_multiplier
+                translate_x = margin_left - bbox.left / unit_multiplier
                 translate_y = (page_bbox.bottom - bbox.bottom) / unit_multiplier
                 group.transform @= inkex.Transform(f'translate({translate_x}, {translate_y})')
 

--- a/templates/letters_to_font.xml
+++ b/templates/letters_to_font.xml
@@ -13,6 +13,8 @@
             </param>
             <param type="path" name="font-dir" gui-text="Font directory" mode="folder" filetypes="svg"/>
             <spacer />
+            <param type="float" name="margin-left" gui-text="Margin left (mm)"
+                   gui-description='With "Use glyph width" enabled in the json, the margin to the left page border defines the distance between glyphs'>0</param>
             <param name="import-commands" type="optiongroup" appearance="combo" gui-text="Import commands">
                  <option value="params">As param</option>
                  <option value="symbols">As symbol</option>


### PR DESCRIPTION
Takes away a bit of the aligning work for imported embroidery font glyphs.
Aligns them all at the bottom left of the page.