### PR TITLE
Meander: fix straight segment clamped path

### DIFF
--- a/lib/stitches/meander_fill.py
+++ b/lib/stitches/meander_fill.py
@@ -187,7 +187,7 @@ def post_process(points, shape, original_shape, fill):
     if fill.clip:
         # the stitch path may have self intersections
         # therefore we don't want clamp polygon to check for the distance to the start point of a segment
-        stitches = clamp_path_to_polygon(stitches, original_shape, False)
+        stitches = clamp_path_to_polygon(stitches, original_shape, fill.running_stitch_length, False)
 
     if fill.bean_stitch_repeats:
         stitches = bean_stitch(stitches, fill.bean_stitch_repeats)

--- a/lib/utils/clamp_path.py
+++ b/lib/utils/clamp_path.py
@@ -14,7 +14,7 @@ def path_to_segments(path):
         yield LineString((start, end))
 
 
-def segments_to_path(segments):
+def segments_to_path(segments, max_stitch_length=0):
     """Convert a list of contiguous LineStrings into a list of Points."""
     if not segments:
         return []
@@ -22,6 +22,8 @@ def segments_to_path(segments):
     coords = [segments[0].coords[0]]
 
     for segment in segments:
+        if max_stitch_length > 0:
+            segment = segment.segmentize(max_stitch_length)
         coords.extend(segment.coords[1:])
 
     return [Point(x, y) for x, y in coords]
@@ -89,7 +91,7 @@ def clamp_fully_external_path(path, polygon):
     return adjust_line_end(shorter, start)
 
 
-def clamp_path_to_polygon(path, polygon, check_distance=True):
+def clamp_path_to_polygon(path, polygon, max_stitch_length=0, check_distance=True):
     """Constrain a path to a Polygon.
 
     The path is expected to have at least some part inside the Polygon.
@@ -129,7 +131,7 @@ def clamp_path_to_polygon(path, polygon, check_distance=True):
     if not clamped_path:
         return clamp_fully_external_path(path, polygon)
 
-    return segments_to_path(clamped_path)
+    return segments_to_path(clamped_path, max_stitch_length)
 
 
 def _clamp_path(split_path, buffered_polygon, polygon, check_distance):


### PR DESCRIPTION
<img width="568" height="475" alt="clamped meander path" src="https://github.com/user-attachments/assets/e3671883-37dc-4df7-9ebf-5586760284f6" />


Stitch length of clamped meander paths was too long for straight segments.