### PR TITLE
Experimental CI changes to reduce package size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,6 @@ jobs:
           python -m pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxpython-4.2.4-cp311-cp311-linux_x86_64.whl
 
           python -m pip install -r requirements.txt
-          # for networkx
-          python -m pip install pandas
-          python -m pip install pyarrow
 
           python -m pip install pyinstaller
 
@@ -124,9 +121,6 @@ jobs:
           python -m pip install numpy --no-binary numpy
 
           python -m pip install -r requirements.txt
-          # for networkx
-          python -m pip install pandas
-          python -m pip install pyarrow
 
           python -m pip install pyinstaller
 
@@ -277,9 +271,6 @@ jobs:
           python -m pip install wheel
           pip install wxPython
           python -m pip install -r requirements.txt
-          # for networkx
-          python -m pip install pandas
-          python -m pip install pyarrow
 
           python -m pip install pyinstaller
 
@@ -383,9 +374,6 @@ jobs:
           pip install PyGObject
           pip install wxPython
           pip install -r requirements.txt
-          # for networkx
-          pip install pandas
-          pip install pyarrow
 
           pip install pyinstaller
 
@@ -442,9 +430,6 @@ jobs:
           pip install PyGObject
           pip install wxPython
           pip install -r requirements.txt
-          # for networkx
-          pip install pandas
-          pip install pyarrow
 
           pip install pyinstaller
 

--- a/bin/build-linux32-venv
+++ b/bin/build-linux32-venv
@@ -18,9 +18,6 @@ virtualenv/bin/pip install -v shapely
 
 virtualenv/bin/pip install -r requirements.txt
 
-# for networkx
-virtualenv/bin/pip install pandas
-
 virtualenv/bin/pip install pyinstaller
 
 deactivate

--- a/bin/build-python
+++ b/bin/build-python
@@ -9,6 +9,9 @@ pyinstaller_args+="--contents-directory . "
 # output useful debugging info that helps us trace library dependency issues
 pyinstaller_args+="--log-level DEBUG "
 
+# Erroneous dependencies
+pyinstaller_args+="--exclude-module sphinx " # Pulled in by scipy docscrape if present.
+
 # Setting up pyinstaller arguments for each OS.
 # This adds bundle identifier in reverse DSN format for macos
 if [ "$BUILD" = "osx" ]; then
@@ -54,6 +57,11 @@ if [ "$BUILD" = "osx" -o "$BUILD" = "windows" ]; then
 fi
 # Run command to build the inkstich program
 python -m PyInstaller $pyinstaller_args inkstitch.py
+
+if [ "$BUILD" = "linux" ] || [ "$BUILD" = "linux32"]; then
+	# Delete some GTK icons that pyinstaller shouldn't have pulled in
+	rm -rf dist/inkstitch/bin/share/icons
+fi
 
 # pyinstaller put a whole mess of libraries under dist/inkstitch.  We'd like
 # to put some more user-accessible stuff like examples and palettes in

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ lxml
 platformdirs
 numpy==2.2.6
 jinja2>2.9
-requests
 
 # toml release 0.10.2 still buggy for heterogenous arrays
 # tomli is built as tomllib in python 3.11 and higher
@@ -27,7 +26,7 @@ flask>=2.2.0
 fonttools
 trimesh>=3.15.2
 diskcache
-flask-cors
+
 pywinutils ; sys_platform == 'win32'
 pywin32 ; sys_platform == 'win32'
 


### PR DESCRIPTION
These changes are experimental and probably need some testing before they should be merged. [Release is here.](https://github.com/inkstitch/inkstitch/releases/tag/dev-build-capellan-ci-slimdown)

- Networkx pulls in Pandas as a dependency, and PyArrow is an optional dependency of Pandas, but Networkx does not actually use Pandas' PyArrow integration. PyArrow in turn pulls in a bunch of other dependencies like `pytz` we don't otherwise use. Dropping it shaves off ~90MB on Windows, and ~150MB on Linux. Doesn't seem like there's any issues or performance regressions introduced by dropping pyarrow (as it shouldn't have been used in the first place). 
- Deleting the random GTK icons from `bin/share/icons` gets rid of 42MB of unused files? Those icons should probably already be installed if you're using Inkscape (which uses GTK) in the first place, but maybe you theoretically could be running it out of an app image and that might be a problem?