### PR TITLE
Cut satins: enable cutting with strokes (additionally)

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1063,7 +1063,7 @@ class SatinColumn(EmbroideryElement):
         Case #1: If the split point is between the end and the last rung, then
         one of the satins will have no rungs.  It will be treated as an old-style
         satin, but it may not have an equal number of points in each rail.  Adding
-        a rung will make it stitch properly.
+        three rungs will make it stitch properly.
 
         Case #2: If one of the satins ends up with exactly two rungs, it's
         ambiguous which of the subpaths are rails and which are rungs.  Adding
@@ -1079,8 +1079,8 @@ class SatinColumn(EmbroideryElement):
                 # Add the rung just after the start of the satin.
                 # If the rails have opposite directions it may end up at the end of the satin.
                 self._add_rung(path_list, 0.3)
-            # When rails are intersecting, add two more rung to prevent bad rail detection
-            if num_paths == 2 and path_list[0].intersects(path_list[1]):
+            # Add two more rung to prevent bad rail detection
+            if num_paths == 2:
                 self._add_rung(path_list, 0.5, True)
                 self._add_rung(path_list, -0.3)
 

--- a/lib/extensions/cut_satin.py
+++ b/lib/extensions/cut_satin.py
@@ -4,16 +4,25 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import inkex
-from shapely.geometry import Point
+from shapely.geometry import LineString, Point
+from shapely.ops import nearest_points
 
-from ..elements import SatinColumn
+from ..commands import Command
+from ..elements import SatinColumn, Stroke
 from ..i18n import _
 from ..svg import get_correction_transform
+from ..utils import Point as InkstitchPoint
 from .base import InkstitchExtension
 
 
 class CutSatin(InkstitchExtension):
-    def effect(self):
+    """This extension splits a satin column at specified points
+
+    The cut points can be specified by either one or multiple cut commands and/or selected strokes.
+    Strokes must intersect with at least one rail. Combined stroke subpaths are handled individually.
+
+    Strokes and command are removed by the extension."""
+    def effect(self) -> None:
         if not self.get_elements():
             return
 
@@ -21,38 +30,85 @@ class CutSatin(InkstitchExtension):
             inkex.errormsg(_("Please select one or more satin columns to cut."))
             return
 
-        for satin in self.elements:
-            if isinstance(satin, SatinColumn):
-                old_satin = satin
-                self.split = False
-                transform = get_correction_transform(satin.node)
-                parent = satin.node.getparent()
-                self.index = parent.index(satin.node)
-                self.label_index = 0
+        cut_lines, cut_line_nodes, satin_elements = self._select_elements()
+        self._split_satin(satin_elements, cut_lines)
 
-                commands = satin.get_commands("satin_cut_point")
+        # delete selected strokes
+        for element in cut_line_nodes:
+            element.delete()
 
-                if commands is None:
-                    # L10N will have the satin's id prepended, like this:
-                    # path12345: error: this satin column does not ...
-                    satin.fatal(_('this satin column does not have a "satin column cut point" command attached to it. '
-                                  'Please use the "Attach commands" extension and attach the "Satin Column cut point" command first.'))
+    def _split_satin(self, satin_elements, split_elements) -> list[SatinColumn]:
+        new_satins = []
+        for satin in satin_elements:
+            old_satin = satin
+            self.split = False
+            transform = get_correction_transform(satin.node)
+            parent = satin.node.getparent()
+            self.index = parent.index(satin.node)
+            self.label_index = 0
 
-                commands.sort(key=lambda command: satin.center_line.project(Point(command.target_point)), reverse=True)
+            # collect cut points from split lines and commands (there must be at least one point)
+            cut_point_list = self._get_cut_points(satin, split_elements)
+            commands = satin.get_commands("satin_cut_point")
+            cut_point_list.extend([[Point(point.target_point)] for point in commands])
+            # sort cut points according to their distance on the first rail of the satin
+            first_rail = satin.line_string_rails[0]
+            cut_point_list.sort(key=lambda points: first_rail.project(nearest_points(points[0], first_rail)[0]), reverse=True)
 
-                satins = [None, None]
-                for command in commands:
-                    satins = self.split_satin(satin, command)
-                    if None in satins:
-                        continue
-                    self.insert_satin(satins[1], parent, transform)
-                    satin = satins[0]
-                if satins[0] is not None:
-                    self.insert_satin(satins[0], parent, transform)
-                if self.split:
-                    old_satin.node.delete()
+            satins = [None, None]
+            for cut_points in cut_point_list:
+                if len(cut_points) == 1:
+                    point = list(cut_points[0].coords)[0]
+                    satins = satin.split(InkstitchPoint(point[0], point[1]))
+                else:
+                    satins = satin.split(None, cut_points)
+                if None in satins:
+                    continue
+                self.insert_satin(satins[1], parent, transform)
+                new_satins.append(satins[1])
+                satin = satins[0]
+            if satins[0] is not None:
+                self.insert_satin(satins[0], parent, transform)
+                new_satins.append(satins[0])
 
-    def insert_satin(self, satin, parent, transform):
+            if self.split:
+                old_satin.node.delete()
+                self._remove_commands(commands)
+
+        if new_satins:
+            return new_satins
+        return satin_elements
+
+    def _get_cut_points(self, satin: SatinColumn, cut_lines: list[LineString]) -> list[tuple[Point, Point]]:
+        """Cut lines must intersect each rail once
+        This filters cut lines and returns the cut points"""
+        rails = satin.line_string_rails
+        filtered_cut_points = []
+        for cut_line in cut_lines:
+            cut_points = []
+            cut_point1 = rails[0].intersection(cut_line)
+            if cut_point1.geom_type == "Point":
+                cut_points.append(cut_point1)
+            cut_point2 = rails[1].intersection(cut_line)
+            if cut_point2.geom_type == "Point":
+                cut_points.append(cut_point2)
+            if len(cut_points) > 0:
+                filtered_cut_points.append(tuple(cut_points))
+        return filtered_cut_points
+
+    def _select_elements(self) -> tuple[list[LineString], list[inkex.BaseElement], list[SatinColumn]]:
+        satins = []
+        cut_lines = []
+        cut_line_nodes = []
+        for element in self.elements:
+            if isinstance(element, SatinColumn):
+                satins.append(element)
+            elif isinstance(element, Stroke):
+                cut_line_nodes.append(element.node)
+                cut_lines.extend(list(element.as_multi_line_string().geoms))
+        return cut_lines, cut_line_nodes, satins
+
+    def insert_satin(self, satin: SatinColumn, parent: inkex.BaseElement, transform: str) -> None:
         if satin is None:
             return
         node = satin.node
@@ -64,14 +120,11 @@ class CutSatin(InkstitchExtension):
         self.label_index += 1
         self.split = True
 
-    def split_satin(self, satin, command):
-        split_point = command.target_point
-        command_group = command.use.getparent()
-        if command_group is not None and command_group.get('id').startswith('command_group'):
-            command_group.delete()
-        else:
-            command.use.delete()
-            command.connector.delete()
-
-        new_satins = satin.split(split_point)
-        return new_satins
+    def _remove_commands(self, commands: list[Command]) -> None:
+        for command in commands:
+            command_group = command.use.getparent()
+            if command_group is not None and command_group.get('id').startswith('command_group'):
+                command_group.delete()
+            else:
+                command.use.delete()
+                command.connector.delete()


### PR DESCRIPTION
Seems to be easier (I was told)... enjoy.

Both, cut commands and selected stroke elements will now cut a satin column with the cut satin extension.

When a stroke intersect with only one rail, the second cut point will be calculated (just like with the commands). If it intersects twice, both points will define the cut position.