### PR TITLE
Lettering fixes

### DIFF
--- a/lib/gui/edit_json/main_panel.py
+++ b/lib/gui/edit_json/main_panel.py
@@ -311,7 +311,7 @@ class LetteringEditJsonPanel(wx.Panel):
         # reset font_meta
         self.font_meta = defaultdict(list)
         self.font_meta['name'] = self.font.name
-        self.font_meta['description'] = self.font.metadata['description']  # untranslated description
+        self.font_meta['description'] = self.font.untranslated_description
         self.font_meta['font_license'] = self.font.font_license
         self.font_meta['text_direction'] = self.font.text_direction
         self.font_meta['keywords'] = self.font.keywords
@@ -334,7 +334,7 @@ class LetteringEditJsonPanel(wx.Panel):
 
         # update ctrl
         self.settings_panel.font_info.name.ChangeValue(self.font.name)
-        self.settings_panel.font_info.description.ChangeValue(self.font.metadata['description'])
+        self.settings_panel.font_info.description.ChangeValue(self.font.untranslated_description)
         self.settings_panel.font_info.font_license.ChangeValue(self.font.font_license)
         selection = ['ltr', 'rtl', 'ttb', 'btt'].index(self.font.json_default_variant)
         self.settings_panel.font_settings.default_variant.SetSelection(selection)
@@ -432,7 +432,7 @@ class LetteringEditJsonPanel(wx.Panel):
         json_xz_file = path.join(self.font.path, 'font.json.xz')
 
         if not path.isfile(json_file) and not path.isfile(json_xz_file):
-            self._show_warning(_("Could not read json file."))
+            self._show_warning(_("Could not find the json file for this font. Please create one with Font Management > Generate JSON"))
             return
 
         # If we can't write to the json file (as it may not exist, as in the case of font.json.xz w/ no font.json),
@@ -447,8 +447,8 @@ class LetteringEditJsonPanel(wx.Panel):
         json_file = path.join(self.font.path, 'font.json')
         json_xz_file = path.join(self.font.path, 'font.json.xz')
 
-        if not path.isfile(json_file) or not path.isfile(json_file):
-            errormsg(_("Could not read json file."))
+        if not path.isfile(json_file):
+            errormsg(_("Could not find a json file for this font. Please create one with Font Management > Generate JSON"))
             self.cancel()
             return
 

--- a/lib/gui/edit_json/main_panel.py
+++ b/lib/gui/edit_json/main_panel.py
@@ -447,7 +447,7 @@ class LetteringEditJsonPanel(wx.Panel):
         json_file = path.join(self.font.path, 'font.json')
         json_xz_file = path.join(self.font.path, 'font.json.xz')
 
-        if not path.isfile(json_file):
+        if not path.isfile(json_file) and not path.isfile(json_xz_file):
             errormsg(_("Could not find a json file for this font. Please create one with Font Management > Generate JSON"))
             self.cancel()
             return

--- a/lib/lettering/font.py
+++ b/lib/lettering/font.py
@@ -159,6 +159,7 @@ class Font(object):
 
     name = font_metadata('name', '')
     description = localized_font_metadata('description', '')
+    untranslated_description = font_metadata('description', '')
     font_license = font_metadata('font_license', 'SIL Open Font License v1.1')
     keywords = font_metadata('keywords', '')
     original_font = font_metadata('original_font', '')


### PR DESCRIPTION
When the key for the description is missing in the json file, editjson was failing. This will fix the issue and add the key when editjson is applied.

Adds a hint on how to generate the json file when it is missing in the first place.