### PR TITLE
guided fill: tolerance value

### DIFF
--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely.prepared
 from networkx import is_empty
 from shapely import geometry as shgeo
-from shapely.affinity import translate
+from shapely.affinity import scale, translate
 from shapely.ops import linemerge, nearest_points, unary_union
 
 from lib.utils import prng
@@ -258,6 +258,9 @@ def intersect_region_with_grating_guideline(shape, line, row_spacing, num_stagge
 
     shape_envelope = shapely.prepared.prep(shape.convex_hull)
 
+    if num_staggers == 0:
+        num_staggers = 1  # sanity check to avoid division by zero.
+
     start_row = _get_start_row(line, shape, row_spacing, translate_direction)
     row = start_row
     direction = 1
@@ -267,9 +270,11 @@ def intersect_region_with_grating_guideline(shape, line, row_spacing, num_stagge
         check_stop_flag()
 
         if strategy == 0:
+            # Copy
             translate_amount = translate_direction * row * row_spacing
             offset_line = translate(line, xoff=translate_amount.x, yoff=translate_amount.y)
         elif strategy == 1:
+            # parallel offset
             offset = row * row_spacing
             if offset == 0:
                 # this is needed for macOS builds
@@ -282,10 +287,20 @@ def intersect_region_with_grating_guideline(shape, line, row_spacing, num_stagge
 
         if enable_random_stitch_length:
             points = [InkstitchPoint(*x) for x in offset_line.coords]
+
+            # stagger rows
+            start = ((row / num_staggers) % 1) * max_stitch_length
+            first_segment = shgeo.LineString(points[:2])
+            segment_length = max(first_segment.length, 0.1)
+            target_length = segment_length + 2 * start
+            scale_factor = target_length / segment_length
+            extended_line = scale(first_segment, scale_factor, scale_factor)
+            points = [InkstitchPoint(*extended_line.coords[0])] + points
+
             stitched_line = shgeo.LineString(random_running_stitch(
                 points, [max_stitch_length], tolerance, random_sigma, prng.join_args(random_seed, row)))
         else:
-            stitched_line = apply_stitches(offset_line, [max_stitch_length], num_staggers, row_spacing, row)
+            stitched_line = apply_stitches(offset_line, [max_stitch_length], num_staggers, row_spacing, row, tolerance)
         intersection = shape.intersection(stitched_line)
 
         if not intersection.is_empty and shape_envelope.intersects(stitched_line):


### PR DESCRIPTION
Use the tolerance value as a threshold for the stitch length. This is supposed to help avoiding stitch positions lining up on a curved guide which looks distracting. If the tolerance value is too high, this may cut the path at curves, overlapping previous lines, leaving gaps in the stitchout in between the lines. But it gives little more control for the stitch placement and if used well, it can improve the stitch out a lot.

Needs to be tested, also on the embroidery machine. I'll make it a pull request at this point nevertheless... I tend to forget uploaded branches ... this will help me to remember.

Maybe that's not the best method neither. It could also serve as a reminder to the problem.

The problem: 
<img width="922" height="820" alt="guided fill with lines of stitches" src="https://github.com/user-attachments/assets/5817333f-1fa4-4eb1-bc11-92c0610be2c4" />
