### PR TITLE
Rejbasket/wxpython build fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,7 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
-          pip install wxPython
+          pip install wxPython --no-binary wxPython
           pip install -r requirements.txt
           # for networkx
           pip install pandas
@@ -440,7 +440,7 @@ jobs:
           pip --version
           pip install wheel
           pip install PyGObject
-          pip install wxPython
+          pip install wxPython --no-binary wxPython
           pip install -r requirements.txt
           # for networkx
           pip install pandas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,9 +369,8 @@ jobs:
 
           brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt libiconv || true
 
-          # these exports are for wxpython to be linked aginst
-          # libiconv from homebrew, inkscape libiconv cause issues
-          # with wxpython binary
+          # These exports of libiconv to build wxpython
+          # inkscape libiconv has issues with wxpython pip wheel
           export PATH="/usr/local/opt/libiconv/bin:$PATH"
           export LDFLAGS="-L/usr/local/opt/libiconv/lib"
           export CPPFLAGS="-I/usr/local/opt/libiconv/include"
@@ -435,9 +434,8 @@ jobs:
 
           brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt libiconv || true
 
-          # these exports are for wxpython to be linked aginst
-          # libiconv from homebrew, inkscape libiconv cause issues
-          # with wxpython binary
+          # These exports of libiconv to build wxpython
+          # inkscape libiconv has issues with wxpython pip wheel
           export PATH="/opt/homebrew/opt/libiconv/bin:$PATH"
           export LDFLAGS="-L/opt/homebrew/opt/libiconv/lib"
           export CPPFLAGS="-I/opt/homebrew/opt/libiconv/include"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,7 +367,14 @@ jobs:
         run: |
           brew update
 
-          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt || true
+          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt libiconv || true
+
+          # these exports are for wxpython to be linked aginst
+          # libiconv from homebrew, inkscape libiconv cause issues
+          # with wxpython binary
+          export PATH="/opt/homebrew/opt/libiconv/bin:$PATH"
+          export LDFLAGS="-L/opt/homebrew/opt/libiconv/lib"
+          export CPPFLAGS="-I/opt/homebrew/opt/libiconv/include"
 
           export LDFLAGS="-L/usr/local/opt/libffi/lib"
           export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
@@ -426,7 +433,14 @@ jobs:
         run: |
           brew update
 
-          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt || true
+          brew install gtk+3 pkg-config gobject-introspection geos libffi gettext jq gnu-getopt libiconv || true
+
+          # these exports are for wxpython to be linked aginst
+          # libiconv from homebrew, inkscape libiconv cause issues
+          # with wxpython binary
+          export PATH="/opt/homebrew/opt/libiconv/bin:$PATH"
+          export LDFLAGS="-L/opt/homebrew/opt/libiconv/lib"
+          export CPPFLAGS="-I/opt/homebrew/opt/libiconv/include"
 
           export LDFLAGS="-L/opt/homebrew/opt/libffi/lib"
           export PKG_CONFIG_PATH="/opt/homebrew/opt/libffi/lib/pkgconfig"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,9 +372,9 @@ jobs:
           # these exports are for wxpython to be linked aginst
           # libiconv from homebrew, inkscape libiconv cause issues
           # with wxpython binary
-          export PATH="/opt/homebrew/opt/libiconv/bin:$PATH"
-          export LDFLAGS="-L/opt/homebrew/opt/libiconv/lib"
-          export CPPFLAGS="-I/opt/homebrew/opt/libiconv/include"
+          export PATH="/usr/local/opt/libiconv/bin:$PATH"
+          export LDFLAGS="-L/usr/local/opt/libiconv/lib"
+          export CPPFLAGS="-I/usr/local/opt/libiconv/include"
 
           export LDFLAGS="-L/usr/local/opt/libffi/lib"
           export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"


### PR DESCRIPTION
Fixed the issue with Inkscape's version of libiconv and wxpython wheel incompatibility. Solved by building wxpython and linking the homebrew version of libiconv which pyinstaller packages with inkstitch for wxpython. 