### PR TITLE
ripple: multiple subpath guide is satin guide

### DIFF
--- a/lib/elements/stroke.py
+++ b/lib/elements/stroke.py
@@ -19,6 +19,7 @@ from ..threads import ThreadColor
 from ..utils import Point, cache
 from ..utils.param import ParamOption
 from .element import EmbroideryElement, param
+from .satin_column import SatinColumn
 from .validation import ValidationWarning
 
 
@@ -952,7 +953,7 @@ class Stroke(EmbroideryElement):
         return stitch_groups
 
     @cache
-    def get_guide_line(self):
+    def get_guide_line(self, force_satin=False):
         """Return the guide line element."""
         guide_lines = get_marker_elements(self.node, "guide-line", False, True, True)
         # No or empty guide line
@@ -963,6 +964,8 @@ class Stroke(EmbroideryElement):
         # ignore multiple guide lines
         if len(guide_lines["satin"]) >= 1:
             return guide_lines["satin"][0]
+        elif force_satin and len(guide_lines["stroke"][0].geoms) > 1:
+            return SatinColumn(guide_lines["stroke_data"][0]['marker_element'])
         return guide_lines["stroke"][0]
 
     @cache

--- a/lib/marker.py
+++ b/lib/marker.py
@@ -86,6 +86,7 @@ def get_marker_elements(node, marker, get_fills=True, get_strokes=True, get_sati
             line_strings = [shgeo.LineString(path) for path in stroke]
             strokes.append(shgeo.MultiLineString(line_strings))
             stroke_data.append({
+                'marker_element': marker,
                 'pattern_interval': element.get_multiple_int_param('pattern_interval', "1"),
                 'pattern_offset': element.get_int_param('pattern_offset', 0)
             })

--- a/lib/stitches/ripple_stitch.py
+++ b/lib/stitches/ripple_stitch.py
@@ -579,7 +579,7 @@ def _do_grid(stroke, helper_lines, skip_start, skip_end, is_linear, last_stitch)
 
 def _get_guided_helper_lines(stroke, outline, max_distance):
     # for each point generate a line going along and pointing to the guide line
-    guide_line = stroke.get_guide_line()
+    guide_line = stroke.get_guide_line(True)
     if isinstance(guide_line, SatinColumn):
         # satin type guide line
         return generate_satin_guide_helper_lines(stroke, outline, guide_line)


### PR DESCRIPTION
For reference: #4369

This will use multi-part stroke guides as a satin guide, no matter if the guide actually has a satin stitch parameter.