### PR TITLE
Add commands: skip on empty shapes

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -440,6 +440,8 @@ def get_command_pos(element, index, total, distance=10):
         shape = element.as_multi_line_string()
     else:
         shape = element.shape
+    if shape.is_empty:
+        return None
     polygon = ensure_multi_polygon(shape.buffer(distance)).geoms[-1]
     outline = polygon.exterior
 
@@ -465,8 +467,9 @@ def add_commands(element, commands, pos=None):
             else:
                 position = get_command_pos(element, i, len(commands))
 
-        symbol = add_symbol(svg, group, command, position)
-        add_connector(svg, symbol, command, element)
+        if position is not None:
+            symbol = add_symbol(svg, group, command, position)
+            add_connector(svg, symbol, command, element)
 
 
 def add_layer_commands(layer, commands):

--- a/lib/extensions/jump_to_trim.py
+++ b/lib/extensions/jump_to_trim.py
@@ -32,11 +32,12 @@ class JumpToTrim(InkstitchExtension):
         last_element = None
         last_stitch_group = None
         for element, next_element in zip(self.elements, next_elements):
-            last = last_element
-            last_element = element
             stitch_groups = element.embroider(last_stitch_group, next_element)
             if not stitch_groups:
                 continue
+
+            last = last_element
+            last_element = element
 
             stitch_group = stitch_groups[0]
             if last_stitch_group is None or stitch_group.color != last_stitch_group.color:


### PR DESCRIPTION
Fixes #4337

When trying to insert commands on a straight line with a fill, the fill element will basically have an empty shape. So we need to skip command insertion on this one.