### PR TITLE
Guided fill: fill holes when using parallel offset strategy

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -185,7 +185,7 @@ class FillStitch(EmbroideryElement):
 
     @property
     @param('guided_fill_strategy', _('Guided Fill Strategy'), type='dropdown', default=0,
-           options=[_("Copy"), _("Parallel Offset")], select_items=[('fill_method', 'guided_fill')], sort_index=10,
+           options=[_("Copy"), _("Parallel Offset"), _("Buffer")], select_items=[('fill_method', 'guided_fill')], sort_index=10,
            tooltip=_('Copy (the default) will fill the shape with shifted copies of the line. '
                      'Parallel offset will ensure that each line is always a consistent distance from its neighbor. '
                      'Sharp corners may be introduced.'))
@@ -267,7 +267,7 @@ class FillStitch(EmbroideryElement):
            type='float',
            unit='mm',
            default=0,
-           select_items=[('fill_method', 'contour_fill'), ('fill_method', 'meander_fill')],
+           select_items=[('fill_method', 'contour_fill'), ('fill_method', 'guided_fill'), ('fill_method', 'meander_fill')],
            sort_index=14)
     def smoothness(self):
         return self.get_float_param('smoothness_mm', 0)
@@ -1143,7 +1143,7 @@ class FillStitch(EmbroideryElement):
             )
             stitch_groups.append(underlay)
             starting_point = underlay.stitches[-1]
-        return [stitch_groups, starting_point]
+        return stitch_groups, starting_point
 
     def do_auto_fill(self, shape, starting_point, ending_point):
         stitch_group = StitchGroup(
@@ -1235,32 +1235,39 @@ class FillStitch(EmbroideryElement):
         if not guide_line:
             return self.do_auto_fill(shape, starting_point, ending_point)
 
-        stitch_group = StitchGroup(
-            color=self.color,
-            tags=("guided_fill", "auto_fill_top"),
-            force_lock_stitches=self.force_lock_stitches,
-            lock_stitches=self.lock_stitches,
-            stitches=guided_fill(
-                shape,
-                guide_line.geoms[0],
-                self.angle,
-                self.row_spacing,
-                self.staggers,
-                self.bean_stitch_repeats,
-                self.max_stitch_length,
-                self.running_stitch_length,
-                self.running_stitch_tolerance,
-                self.skip_last,
-                starting_point,
-                ending_point,
-                self.underpath,
-                self.guided_fill_strategy,
-                self.enable_random_stitch_length,
-                self.random_stitch_length_jitter,
-                self.random_seed,
-            )
+        stitch_groups = []
+        guided_stitch_groups = guided_fill(
+            shape,
+            guide_line,
+            self.angle,
+            self.row_spacing,
+            self.staggers,
+            self.bean_stitch_repeats,
+            self.max_stitch_length,
+            self.running_stitch_length,
+            self.running_stitch_tolerance,
+            self.smoothness,
+            self.skip_last,
+            starting_point,
+            ending_point,
+            self.underpath,
+            self.guided_fill_strategy,
+            self.enable_random_stitch_length,
+            self.random_stitch_length_jitter,
+            self.random_seed,
         )
-        return [stitch_group]
+
+        for stitches in guided_stitch_groups:
+            stitch_groups.append(
+                StitchGroup(
+                    color=self.color,
+                    tags=("guided_fill", "auto_fill_top"),
+                    force_lock_stitches=self.force_lock_stitches,
+                    lock_stitches=self.lock_stitches,
+                    stitches=stitches
+                )
+            )
+        return stitch_groups
 
     @cache
     def _get_guide_lines(self, multiple=False):

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -2,11 +2,11 @@ from math import atan2, copysign
 from random import random
 
 import numpy as np
-import shapely.prepared
-from networkx import is_empty
+from networkx import connected_components, is_empty
 from shapely import geometry as shgeo
 from shapely.affinity import scale, translate
-from shapely.ops import linemerge, nearest_points, unary_union
+from shapely.ops import linemerge, nearest_points, substring, unary_union
+from shapely.prepared import prep
 
 from lib.utils import prng
 
@@ -14,7 +14,9 @@ from ..debug.debug import debug
 from ..stitch_plan import Stitch
 from ..utils.geometry import Point as InkstitchPoint
 from ..utils.geometry import (ensure_geometry_collection,
-                              ensure_multi_line_string, reverse_line_string)
+                              ensure_multi_line_string, ensure_multi_point,
+                              reverse_line_string, roll_linear_ring)
+from ..utils.smoothing import smooth_path
 from ..utils.threading import check_stop_flag
 from .auto_fill import (auto_fill, build_fill_stitch_graph, build_travel_graph,
                         collapse_sequential_outline_edges, find_stitch_path,
@@ -31,6 +33,7 @@ def guided_fill(shape,
                 max_stitch_length,
                 running_stitch_length,
                 running_stitch_tolerance,
+                smoothness,
                 skip_last,
                 starting_point,
                 ending_point,
@@ -40,39 +43,405 @@ def guided_fill(shape,
                 random_sigma,
                 random_seed,
                 ):
-    segments = intersect_region_with_grating_guideline(shape, guideline, row_spacing, num_staggers, max_stitch_length, strategy,
-                                                       enable_random_stitch_length, running_stitch_tolerance, random_sigma, random_seed,)
+    segments = intersect_region_with_grating_guideline(
+        shape, guideline, row_spacing, num_staggers, max_stitch_length, strategy, running_stitch_tolerance, smoothness,
+        enable_random_stitch_length, random_sigma, random_seed
+    )
+
+    if strategy > 0 and segments:
+        segments = _connect_parallel_offset_segments(shape, segments, row_spacing, skip_last, max_stitch_length)
+
+        segments = _stagger_and_cut_segments(
+            shape, segments, max_stitch_length, row_spacing, num_staggers, strategy,
+            enable_random_stitch_length, random_sigma, random_seed, running_stitch_tolerance, smoothness
+        )
+    else:
+        segments = [line.coords for line in segments]
+
     if not segments:
         return fallback(shape, guideline, row_spacing, max_stitch_length, running_stitch_length, running_stitch_tolerance,
                         num_staggers, skip_last, starting_point, ending_point, underpath)
 
     fill_stitch_graph = build_fill_stitch_graph(shape, segments, starting_point, ending_point)
-
     if is_empty(fill_stitch_graph):
         return fallback(shape, guideline, row_spacing, max_stitch_length, running_stitch_length, running_stitch_tolerance,
                         num_staggers, skip_last, starting_point, ending_point, underpath)
-    graph_make_valid(fill_stitch_graph)
 
-    travel_graph = build_travel_graph(fill_stitch_graph, shape, angle, underpath)
-    path = find_stitch_path(fill_stitch_graph, travel_graph, starting_point, ending_point, underpath)
-    result = path_to_stitches(shape, path, travel_graph, fill_stitch_graph,
-                              max_stitch_length, running_stitch_length, running_stitch_tolerance, skip_last,
-                              underpath)
+    # if the shape has holes, we may run into a problem with disconnected components
+    # TODO: we may want to solve this in a different way in some future day,
+    # but for now, let's render those components independently (which will result in jumps)
+    connected_graphs = [fill_stitch_graph.subgraph(c).copy() for c in connected_components(fill_stitch_graph)]
+    result = []
+    for guided_graph in connected_graphs:
+        check_stop_flag()
+        graph_make_valid(guided_graph)
 
-    if any(bean_stitch_repeats):
-        # add bean stitches, but ignore travel stitches
-        result = bean_stitch(result, bean_stitch_repeats, ['auto_fill_travel', 'fill_row_start'])
+        travel_graph = build_travel_graph(guided_graph, shape, angle, underpath)
 
+        path = find_stitch_path(guided_graph, travel_graph, starting_point, ending_point, underpath)
+        stitches = path_to_stitches(
+            shape, path, travel_graph, guided_graph, max_stitch_length, running_stitch_length, running_stitch_tolerance,
+            skip_last, underpath
+        )
+
+        if any(bean_stitch_repeats):
+            # add bean stitches, but ignore travel stitches
+            stitches = bean_stitch(stitches, bean_stitch_repeats, ['auto_fill_travel', 'fill_row_start'])
+        result.append(stitches)
     return result
+
+
+def _stagger_and_cut_segments(
+        shape, segments, max_stitch_length, row_spacing, num_staggers, strategy,
+        enable_random_stitch_length, random_sigma, random_seed, tolerance, smoothness) -> list[list[tuple[float, ...]]]:
+
+    # sort segments so that they are well prepared for staggering
+    if num_staggers:
+        _sort_segments(shape, segments)
+
+    # apply stagger and smoothness
+    new_segments = []
+    i = 0
+    for segment in segments:
+        check_stop_flag()
+        linestring = segment
+
+        if shgeo.Point(linestring.coords[0]).within(shape):
+            # we just assume that all lines which possibly end within the shape are actually rings (even when not recognized as such)
+            diff = linestring.difference(shape)
+            if not diff.is_empty:
+                outside_point = take_only_line_strings(diff).geoms[0].interpolate(0.5, True)
+                linestring = shgeo.LineString(roll_linear_ring(linestring, linestring.project(outside_point)))
+                stagger = 1
+            i -= 1
+        else:
+            stagger = num_staggers
+
+        if smoothness:
+            points = smooth_path([InkstitchPoint(*coord) for coord in linestring.coords], smoothness)
+            linestring = shgeo.LineString(points)
+
+        if enable_random_stitch_length:
+            start = ((i / (stagger)) % 1) * max_stitch_length
+            first_segment = substring(linestring, 0, 1)
+            segment_length = max(first_segment.length, 0.1)
+            target_length = segment_length + 2 * start
+            scale_factor = target_length / segment_length
+            extended_line = scale(first_segment, scale_factor, scale_factor, origin='centroid')
+            points = [InkstitchPoint(*extended_line.coords[0])] + [InkstitchPoint(*coord) for coord in linestring.coords]
+            linestring = shgeo.LineString(random_running_stitch(points, [max_stitch_length], tolerance, random_sigma, prng.join_args(random_seed, i)))
+        else:
+            linestring = apply_stitches(linestring, [max_stitch_length], stagger, row_spacing, i, tolerance)
+
+        # restrict segments to shape
+        new_segments.extend(_linestring_to_segments(shape, linestring))
+        i += 1
+
+    return new_segments
+
+
+def _sort_segments(shape, segments) -> None:
+    # sort segments
+    # construct a line going through all the segments
+    envelope = shape.envelope.boundary
+    if envelope.is_empty:
+        return
+    segments.sort(key=lambda line: envelope.project(shgeo.Point(line.coords[0])))
+
+
+def _linestring_to_segments(shape, linestring) -> list[list[tuple[float, ...]]]:
+    # We could restrict the lines to the shape with linestring.intersection(shape), but this sadly would destroy
+    # lines with self-intersections - and this may very well be the case with some of our lines
+    # (ring connections, smoothing, running stitch tolerance). So let's put some more effort into this
+    segments: list[list[tuple[float, ...]]] = []
+    # Find where the line enters/exits the polygon
+    boundary_intersections = ensure_multi_point(linestring.intersection(shape.boundary))
+    # Get the distances along the line
+    projections = sorted(linestring.project(point, True) for point in boundary_intersections.geoms)
+    if projections:
+        projections = [0] + projections + [1]
+    elif shgeo.Point(linestring.coords[0]).within(shape):
+        # line is fully within the shape
+        return [linestring]
+    # Collect inside segments
+    segments = []
+    for d0, d1 in zip(projections[:-1], projections[1:]):
+        seg = substring(linestring, d0, d1, True)
+        if isinstance(seg, shgeo.Point):
+            continue
+        if shape.contains(substring(seg, 0.4, -0.4, True)):
+            segments.append(seg.coords[:])
+    return segments
+
+
+def _connect_parallel_offset_segments(shape, segments, row_spacing, skip_last, max_stitch_length):
+    outline_segments, segments_within = _split_segment_types(shape, segments, row_spacing)
+    if not segments_within:
+        return segments
+    if not outline_segments:
+        outline_segments = list(ensure_multi_line_string(shape.boundary).geoms)
+
+    # sort inside segments from small to big
+    segments_within.sort(key=lambda pg: pg.area)
+
+    # now that we found out which segments need to be connected
+    # let's see how they are related to each other
+    connected_segments = _get_segment_relations(segments_within)
+
+    # the polygons were helpful to figure out the geometric relationsship between the shapes
+    # up from now we prefer to work with LinearRings, the index positions will stay the same
+    linearrings_within = [shgeo.LinearRing(seg.exterior.coords) for seg in segments_within]
+
+    # now let's loop through the connected_segments dictionary and connect the shapes as good as possible
+    _connect_within(connected_segments, linearrings_within, row_spacing, skip_last, max_stitch_length)
+
+    # now we cleaned up the inner circles
+    # we only need to connect them to the outside
+    _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing)
+
+    debug.add_layer('segments complete')
+    debug.log_line_strings(outline_segments)
+
+    return outline_segments
+
+
+def _connect_within(connected_segments, linearrings_within, row_spacing, skip_last, max_stitch_length):
+    # while we are connecting the shapes, we will update the shape at the outer_index position to contain the connected shape
+    # therefore we will need to collect the indices of the inner shapes that are now duplicated
+    # this way we can remove them from the list in the end
+    segments_to_remove = []
+    for inner_index, outer_index in connected_segments.items():
+        if outer_index is None:
+            continue
+
+        if row_spacing == 0:
+            row_spacing = 0.001
+
+        # First we are more restrict in order to find a good spot
+        d_tolerance = row_spacing * 1.5
+        shapes_are_connected = _connect_linearrings(
+            linearrings_within, segments_to_remove, inner_index, outer_index, row_spacing, skip_last, max_stitch_length, d_tolerance
+        )
+        if not shapes_are_connected:
+            # we couldn't find an ok spot, so let's skip this element
+            segments_to_remove.append(inner_index)
+
+    # remove the duplicated inner segments
+    segments_to_remove.sort(reverse=True)
+    for segment_index in segments_to_remove:
+        try:
+            linearrings_within.pop(segment_index)
+        except IndexError:
+            pass
+
+
+def _connect_linearrings(
+        linearrings_within, segments_to_remove, inner_index, outer_index, row_spacing, skip_last, max_stitch_length, d_tolerance):
+    # ensure consistent direction
+    inner = ensure_ccw(linearrings_within[inner_index])
+    outer = ensure_ccw(linearrings_within[outer_index])
+    # We could speed things up by predefining a good spot,
+    # but we get nicer connections for smoothing if we don't (speed vs stitch path...)
+    # nearest = nearest_points(inner, outer)
+    # inner = roll_linear_ring(inner, inner.project(nearest[0]))
+    offset = 0
+    # move around the inner ring and check combining conditions in sections of row_spacing width
+    while offset + row_spacing < inner.length:
+        check_stop_flag()
+        p1_inner, p2_inner, p1_outer, p2_outer, d1, d2 = _get_possible_connector_points(inner, outer, offset, row_spacing)
+        # check if distances are within tolerance
+        if d1 < row_spacing + d_tolerance and d2 < row_spacing + d_tolerance:
+            proj1 = inner.project(p2_inner)
+            proj2 = outer.project(p2_outer)
+            rolled_inner = shgeo.LineString(roll_linear_ring(inner, proj1))
+            rolled_outer = shgeo.LineString(roll_linear_ring(outer, proj2))
+            rolled_inner = substring(rolled_inner, 0, -row_spacing)
+            rolled_outer = substring(rolled_outer, 0, -row_spacing)
+            if skip_last:
+                # TODO: this could be improved, maybe with a substring,
+                # but I'm goig to leave it like this for now, because taking simply the substring would not be correct neither
+                connected_line = shgeo.LinearRing(rolled_outer.coords[:] + rolled_inner.segmentize(max_stitch_length).reverse().coords[1:-1])
+            else:
+                connected_line = shgeo.LinearRing(rolled_outer.coords[:] + rolled_inner.reverse().coords[:])
+            linearrings_within[outer_index] = connected_line
+            segments_to_remove.append(inner_index)
+            return True
+        offset += 1
+    return False
+
+
+def _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing) -> None:
+    remove: list[int] = []
+    add: list[shgeo.LineString] = []
+    for ring in linearrings_within:
+        _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, remove, add)
+    # remove the duplicated inner segments
+    for segment_index in sorted(remove, reverse=True):
+        try:
+            outline_segments.pop(segment_index)
+        except IndexError:
+            pass
+    outline_segments.extend(add)
+
+
+def _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, remove, add) -> None:
+    original_ring = ring
+    connected = None
+    for i in range(len(outline_segments)):
+        if i in remove:
+            continue
+        line = outline_segments[i]
+        if original_ring.distance(line) <= row_spacing + 0.001:
+            if connected is None:
+                new_segment = _connect_linearring_with_linestring(ring, line, row_spacing)
+                if new_segment is not None:
+                    outline_segments[i] = new_segment
+                    ring = new_segment
+                    connected = i
+                    if line.intersects(shape.exterior):
+                        break
+            else:
+                if shgeo.Point(line.coords[0]).within(shape):
+                    seg1 = _connect_linearring_with_linestring(ring, line, row_spacing)
+                    if seg1 is None:
+                        continue
+                else:
+                    seg1, seg2 = _connect_linestrings(ring, line, row_spacing)
+                    add.append(seg2)
+                outline_segments[connected] = seg1
+                remove.append(i)
+                # let's not try any harder
+                break
+
+
+def _get_segment_relations(segments_within) -> dict[int, int | None]:
+    # this creates a dictionary with the index positions of the inner shapes
+    # and the value represents the index postion of the outer shape
+    connected_segments: dict[int, int | None] = {}
+    for i, inner in enumerate(segments_within):
+        segment_connected = False
+        for j, outer in enumerate(segments_within):
+            if j <= i:
+                continue
+            if outer.covers(inner):
+                segment_connected = True
+                connected_segments[i] = j
+                break
+        if not segment_connected:
+            connected_segments[i] = None
+    return connected_segments
+
+
+def _connect_linestrings(line1, line2, row_spacing):
+    # connect two linestrings
+    p1, p3 = nearest_points(line1, line2)
+    p2 = line1.interpolate(line1.project(p1) + row_spacing)
+    p4 = line2.interpolate(line2.project(p3) + row_spacing)
+    if _needs_reverse(p1, p2, p3, p4):
+        p4 = line2.interpolate(line2.project(p3) - row_spacing)
+        line2 = line2.reverse()
+    segment1 = substring(line1, 0, line1.project(p1))
+    segment2 = substring(line2, 0, line2.project(p3)).reverse()
+    segment3 = substring(line1, line1.project(p2), line1.length).reverse()
+    segment4 = substring(line2, line2.project(p4), line2.length)
+    connected = shgeo.LineString(list(segment1.coords) + list(segment2.coords)), shgeo.LineString(list(segment3.coords) + list(segment4.coords))
+    return connected
+
+
+def _needs_reverse(p1, p2, p3, p4):
+    p1p3 = shgeo.LineString([p1, p3])
+    p2p4 = shgeo.LineString([p2, p4])
+    if p1p3.intersects(p2p4):
+        return True
+    return False
+
+
+def _connect_linearring_with_linestring(ring, line, row_spacing, threshold=0.01):
+    offset = 0
+    while ring.length >= row_spacing + offset:
+        check_stop_flag()
+        p1, p2, p3, p4, d1, d2 = _get_possible_connector_points(ring, line, offset, row_spacing)
+        if d1 < row_spacing * 1.5 and d2 < row_spacing * 1.5:
+            # line start
+            proj1 = line.project(p3)
+            proj2 = line.project(p4)
+            if proj1 > proj2:
+                proj1, proj2 = proj2, proj1
+            if abs(proj1 - proj2) > row_spacing + threshold:
+                proj2 = proj1 + row_spacing
+            o1 = substring(line, 0, proj1)
+            o2 = substring(line, proj1 + row_spacing, line.length)
+            # open the ring
+            proj1 = ring.project(p1)
+            rolled_ring = shgeo.LineString(roll_linear_ring(ring, proj1))
+            rolled_ring = substring(rolled_ring, row_spacing, rolled_ring.length)
+            # connect the parts
+            connected = shgeo.LineString(o1.coords[:] + rolled_ring.coords[:] + o2.coords[:])
+            if not connected.is_simple:
+                connected = shgeo.LineString(o1.coords[:] + rolled_ring.coords[::-1] + o2.coords[:])
+            return connected
+        offset += 1
+    return None
+
+
+def _split_segment_types(shape, segments, row_spacing) -> tuple[list[shgeo.LineString], list[shgeo.Polygon]]:
+    # we have two different kinds of segments:
+    # the ones that are touching the outline
+    # and the ones, that are entirely within the shape (those are the ones we need to connect)
+
+    prepared_shape = prep(shape)
+    prepared_boundary = prep(shape.boundary)
+
+    outline_segments = []
+    segments_within = []
+    for line in segments:
+        if not prepared_shape.intersects(line):
+            continue
+        if not prepared_boundary.intersects(line):
+            # ensure the line has at least 4 points, which is necessary for both, polygon or linearring
+            if len(line.coords) < 4:
+                length = line.length
+                line = line.segmentize(max_segment_length=length/3).coords[:]
+            segments_within.append(shgeo.Polygon(line))
+        else:
+            # if this segment has the same starting and ending point (linearring),
+            # we need to ensure, that this point lies outside of the shape
+            if line.coords[0] == line.coords[-1] and shgeo.Point(line.coords[0]).within(shape):
+                outside_point = take_only_line_strings(line.difference(shape)).geoms[0].interpolate(0.5, True)
+                line = shgeo.LineString(roll_linear_ring(line, line.project(outside_point)))
+            outline_segments.append(line)
+    return outline_segments, segments_within
+
+
+def _get_possible_connector_points(inner, outer, offset, row_spacing) -> tuple[shgeo.Point, shgeo.Point, shgeo.Point, shgeo.Point, float, float]:
+    # define two points on the inner ring according to offset and row_spacing
+    p1 = inner.interpolate(offset)
+    p2 = inner.interpolate(offset + row_spacing)
+    # get nearest points on the outer ring
+    p1_outer = nearest_points(outer, p1)[0]
+    p2_outer = nearest_points(outer, p2)[0]
+    # get the distances between the corresponding points
+    d1 = p1.distance(p1_outer)
+    d2 = p2.distance(p2_outer)
+    return p1, p2, p1_outer, p2_outer, d1, d2
+
+
+def ensure_ccw(ring) -> shgeo.LinearRing:
+    # True if counter-clockwise
+    if ring.is_ccw:
+        return ring
+    else:
+        return ring.reverse()
 
 
 def fallback(shape, guideline, row_spacing, max_stitch_length, running_stitch_length, running_stitch_tolerance,
              num_staggers, skip_last, starting_point, ending_point, underpath):
     # fall back to normal auto-fill with an angle that matches the guideline (sorta)
+    guideline = guideline.geoms[0]
     guide_start, guide_end = [guideline.coords[0], guideline.coords[-1]]
     angle = atan2(guide_end[1] - guide_start[1], guide_end[0] - guide_start[0]) * -1
-    return auto_fill(shape, angle, row_spacing, None, max_stitch_length, running_stitch_length, running_stitch_tolerance,
-                     num_staggers, skip_last, starting_point, ending_point, underpath)
+    return [auto_fill(shape, angle, row_spacing, None, max_stitch_length, running_stitch_length, running_stitch_tolerance,
+                      num_staggers, skip_last, starting_point, ending_point, underpath)]
 
 
 def path_to_stitches(shape, path, travel_graph, fill_stitch_graph,
@@ -114,16 +483,15 @@ def path_to_stitches(shape, path, travel_graph, fill_stitch_graph,
     return stitches
 
 
-def extend_line(line, shape):
-    (minx, miny, maxx, maxy) = shape.bounds
-
-    upper_left = InkstitchPoint(minx, miny)
-    lower_right = InkstitchPoint(maxx, maxy)
-    length = (upper_left - lower_right).length()
-
+def extend_line(line, shape) -> shgeo.LineString:
     start_point = InkstitchPoint.from_tuple(line.coords[0])
     end_point = InkstitchPoint.from_tuple(line.coords[-1])
     direction = (end_point - start_point).unit()
+
+    length = max(
+        shgeo.Point(start_point).hausdorff_distance(shape.envelope),
+        shgeo.Point(end_point).hausdorff_distance(shape.envelope)
+    )
 
     new_start_point = start_point - direction * length
     new_end_point = end_point + direction * length
@@ -136,44 +504,35 @@ def extend_line(line, shape):
     return shgeo.LineString((new_start_point, *line.coords, new_end_point))
 
 
-def repair_multiple_parallel_offset_curves(multi_line):
-    lines = ensure_multi_line_string(linemerge(multi_line))
-    longest_line = max(lines.geoms, key=lambda line: line.length)
-
-    # need simplify to avoid doubled points caused by linemerge
-    return longest_line.simplify(0.01, False)
-
-
-def repair_non_simple_line(line):
-    repaired = unary_union(line)
+def repair_non_simple_line(line) -> shgeo.LineString:
+    repaired = ensure_multi_line_string(unary_union(line))
     counter = 0
     # Do several iterations since we might have several concatenated selfcrossings
-    while repaired.geom_type != 'LineString' and counter < 4:
+    while len(repaired.geoms) != 1 and counter < 4:
         line_segments = []
         for line_seg in repaired.geoms:
             if not line_seg.is_ring:
                 line_segments.append(line_seg)
 
-        repaired = unary_union(linemerge(line_segments))
+        repaired = ensure_multi_line_string(unary_union(linemerge(line_segments)))
         counter += 1
-    if repaired.geom_type != 'LineString':
+    if len(repaired.geoms) > 1:
         # They gave us a line with complicated self-intersections.  Use a fallback.
         return shgeo.LineString((line.coords[0], line.coords[-1]))
     else:
-        return repaired
+        return repaired.geoms[0]
 
 
-def take_only_line_strings(thing):
+def take_only_line_strings(thing) -> shgeo.MultiLineString:
     things = ensure_geometry_collection(thing)
-    line_strings = [line for line in things.geoms if isinstance(line, shgeo.LineString)]
-
-    return shgeo.MultiLineString(line_strings)
+    line_strings = linemerge([line for line in things.geoms if isinstance(line, (shgeo.LineString, shgeo.LinearRing))])
+    return ensure_multi_line_string(line_strings)
 
 
 def apply_stitches(line, max_stitch_length, num_staggers, row_spacing, row_num, threshold=None) -> shgeo.LineString:
+    max_stitch_length = max_stitch_length[0]
     if num_staggers == 0:
         num_staggers = 1  # sanity check to avoid division by zero.
-    max_stitch_length = max_stitch_length[0]
     start = ((row_num / num_staggers) % 1) * max_stitch_length
     projections = np.arange(start, line.length, max_stitch_length)
     points = np.array([line.interpolate(projection).coords[0] for projection in projections])
@@ -206,7 +565,8 @@ def apply_stitches(line, max_stitch_length, num_staggers, row_spacing, row_num, 
     return shgeo.LineString(points)
 
 
-def prepare_guide_line(line, shape):
+def prepare_copy_guide(line, shape) -> shgeo.LineString:
+    line = line.geoms[0]
     if line.geom_type != 'LineString' or not line.is_simple:
         line = repair_non_simple_line(line)
 
@@ -217,20 +577,30 @@ def prepare_guide_line(line, shape):
 
     # extend the end points away from each other
     line = extend_line(line, shape)
+    return line
+
+
+def prepare_offset_guide(line, shape) -> shgeo.LineString | shgeo.LinearRing:
+    line = line.geoms[0]
+    if not line.is_ring:
+        # extend the end points away from each other
+        line = extend_line(line, shape)
+
+    if line.geom_type != 'LineString' or not line.is_simple:
+        line = repair_non_simple_line(line)
+
+    if line.is_ring:
+        line = shgeo.LinearRing(line)
 
     return line
 
 
-def clean_offset_line(offset_line):
-    offset_line = take_only_line_strings(offset_line)
-
-    if isinstance(offset_line, shgeo.MultiLineString):
-        offset_line = repair_multiple_parallel_offset_curves(offset_line)
-
-    if not offset_line.is_simple:
-        offset_line = repair_non_simple_line(offset_line)
-
-    return offset_line
+def prepare_guide_line(line, shape, strategy) -> shgeo.LinearRing | shgeo.LineString | shgeo.MultiLineString:
+    if strategy == 0:
+        return prepare_copy_guide(line, shape)
+    elif strategy == 2:
+        return line.normalize()
+    return prepare_offset_guide(line, shape)
 
 
 def _get_start_row(line, shape, row_spacing, line_direction):
@@ -247,65 +617,99 @@ def _get_start_row(line, shape, row_spacing, line_direction):
     return copysign(row, shape_direction * line_direction)
 
 
-def intersect_region_with_grating_guideline(shape, line, row_spacing, num_staggers, max_stitch_length, strategy,
-                                            enable_random_stitch_length, tolerance, random_sigma, random_seed):
-    line = prepare_guide_line(line, shape)
+def intersect_region_with_grating_guideline(shape, line, row_spacing, num_staggers, max_stitch_length, strategy, tolerance, smoothness,  # noqa: C901
+                                            enable_random_stitch_length, random_sigma, random_seed) -> list[shgeo.LineString]:
+    line = prepare_guide_line(line, shape, strategy)
 
-    debug.log_line_string(shape.exterior, "guided fill shape")
-
-    translate_direction = InkstitchPoint(*line.coords[-1]) - InkstitchPoint(*line.coords[0])
-    translate_direction = translate_direction.unit().rotate_left()
-
-    shape_envelope = shapely.prepared.prep(shape.convex_hull)
+    shape_envelope = prep(shape.convex_hull)
 
     if num_staggers == 0:
         num_staggers = 1  # sanity check to avoid division by zero.
 
-    start_row = _get_start_row(line, shape, row_spacing, translate_direction)
+    if strategy != 2:
+        translate_direction = InkstitchPoint(*line.coords[-1]) - InkstitchPoint(*line.coords[0])
+        translate_direction = translate_direction.unit().rotate_left()
+
+        start_row = _get_start_row(line, shape, row_spacing, translate_direction)
+    else:
+        start_row = int(line.distance(shape) / row_spacing)
+
     row = start_row
     direction = 1
     offset_line = None
     rows = []
+    buffer_offset = 0
+
     while True:
         check_stop_flag()
 
-        if strategy == 0:
-            # Copy
-            translate_amount = translate_direction * row * row_spacing
-            offset_line = translate(line, xoff=translate_amount.x, yoff=translate_amount.y)
-        elif strategy == 1:
-            # parallel offset
+        if strategy > 0:
+            # parallel_offset
             offset = row * row_spacing
             if offset == 0:
                 # this is needed for macOS builds
                 offset = 0.0001
-            offset_line = line.parallel_offset(offset, 'left', join_style=shgeo.JOIN_STYLE.round)
+            if strategy == 1:
+                stitched_line = line.offset_curve(offset, quad_segs=16)
+                if not isinstance(stitched_line, (shgeo.LineString, shgeo.LinearRing)):
+                    # sometimes for an odd reason parallel_offset will split up a part of the offset line
+                    # we can put it back together with the line_merge method and still keepthe disjoint parts
+                    stitched_line = list(ensure_multi_line_string(stitched_line).geoms)
+                    stitched_line = linemerge(stitched_line)
+            elif strategy == 2:
+                # buffer
+                # buffer reaches out to both sides at once, when we reach the end of the first direction
+                # we have enough lines to work with
+                if direction == -1:
+                    break
 
-        offset_line = clean_offset_line(offset_line)
-
-        debug.log_line_string(offset_line, f"offset {row}")
-
-        if enable_random_stitch_length:
-            points = [InkstitchPoint(*x) for x in offset_line.coords]
-
-            # stagger rows
-            start = ((row / num_staggers) % 1) * max_stitch_length
-            first_segment = shgeo.LineString(points[:2])
-            segment_length = max(first_segment.length, 0.1)
-            target_length = segment_length + 2 * start
-            scale_factor = target_length / segment_length
-            extended_line = scale(first_segment, scale_factor, scale_factor)
-            points = [InkstitchPoint(*extended_line.coords[0])] + points
-
-            stitched_line = shgeo.LineString(random_running_stitch(
-                points, [max_stitch_length], tolerance, random_sigma, prng.join_args(random_seed, row)))
+                # the first line can be used as a simple line in case all parts start and end outside of the shape
+                # or we received a closed shape
+                # when it ends within the shape, we still want to apply a small buffer as there is no way to connect
+                # the endpoint properly otherwise
+                if offset < row_spacing:
+                    lines = ensure_multi_line_string(line)
+                    end_points_within = []
+                    for buffered_geoms in lines.geoms:
+                        end_points_within.extend([
+                            shgeo.Point(buffered_geoms.coords[0]).within(shape),
+                            shgeo.Point(buffered_geoms.coords[-1]).within(shape)
+                        ])
+                    if line.is_simple and (line.is_ring or not any(end_points_within)):
+                        # we would like to avoid avoid doubling up the first line with a small buffer value
+                        # but we can only do that, when the line is intersecting with the outline or isa linear ring
+                        # otherwise it will be difficult to connect it properly
+                        stitched_line = line
+                    else:
+                        # set an inital offset to avoid a doubled line at the center
+                        buffer_offset = row_spacing / 2
+                        stitched_line = line.buffer(offset + buffer_offset).boundary
+                else:
+                    stitched_line = line.buffer(offset + buffer_offset).boundary
         else:
+            # Copy
+            translate_amount = translate_direction * row * row_spacing
+            offset_line = translate(line, xoff=translate_amount.x, yoff=translate_amount.y)
+            if smoothness:
+                offset_line = shgeo.LineString(smooth_path(offset_line.coords, smoothness))
             stitched_line = apply_stitches(offset_line, [max_stitch_length], num_staggers, row_spacing, row, tolerance)
-        intersection = shape.intersection(stitched_line)
 
-        if not intersection.is_empty and shape_envelope.intersects(stitched_line):
-            for segment in take_only_line_strings(intersection).geoms:
-                rows.append(segment.coords[:])
+        intersection = shape.intersection(stitched_line)
+        if shape_envelope.intersects(stitched_line):
+            if not intersection.is_empty:
+                if strategy == 1:
+                    # cut later in order to sort them for stagger
+                    for segment in take_only_line_strings(stitched_line).geoms:
+                        rows.append(segment)
+                elif strategy == 2:
+                    # apply stitches reduces the line length, so when we cut our lines here, we'll need to add at least the stitch length to it
+                    intersection = stitched_line.intersection(shape.envelope.buffer(max_stitch_length + 0.2))
+                    for segment in take_only_line_strings(intersection).geoms:
+                        if segment.intersects(shape):
+                            rows.append(segment)
+                else:
+                    for segment in take_only_line_strings(intersection).geoms:
+                        rows.append(segment)
             row += direction
         else:
             if direction == 1:
@@ -313,5 +717,11 @@ def intersect_region_with_grating_guideline(shape, line, row_spacing, num_stagge
                 row = start_row - 1
             else:
                 break
+
+    # Add some debug infos
+    debug.log_line_strings(ensure_multi_line_string(line), 'guide line')
+    debug.log_line_strings(ensure_multi_line_string(shape.boundary), "guided fill shape")
+    debug.add_layer("Grating rows")
+    debug.log_line_strings([shgeo.LineString(row) for row in rows])
 
     return rows

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -199,7 +199,7 @@ def _connect_parallel_offset_segments(shape, segments, row_spacing, skip_last, m
     # we only need to connect them to the outside
     _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing)
 
-    debug.add_layer('segments complete')
+    debug.add_layer('connected offset segments')
     debug.log_line_strings(outline_segments)
 
     return outline_segments
@@ -270,11 +270,12 @@ def _connect_linearrings(
     return False
 
 
-def _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing) -> None:
+def _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing, iteration=0) -> None:
     remove: list[int] = []
     add: list[shgeo.LineString] = []
+    unconnected: list[shgeo.LineString] = []
     for ring in linearrings_within:
-        _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, remove, add)
+        _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, unconnected, remove, add)
     # remove the duplicated inner segments
     for segment_index in sorted(remove, reverse=True):
         try:
@@ -282,9 +283,14 @@ def _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within,
         except IndexError:
             pass
     outline_segments.extend(add)
+    if unconnected and iteration < 3:
+        # it it a second try, we may have made helping connections
+        linearrings_within = unconnected
+        iteration += 1
+        _connect_rings_to_regular_lines(shape, outline_segments, linearrings_within, row_spacing, iteration)
 
 
-def _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, remove, add) -> None:
+def _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing, unconnected, remove, add) -> None:
     original_ring = ring
     connected = None
     for i in range(len(outline_segments)):
@@ -299,7 +305,7 @@ def _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing
                     ring = new_segment
                     connected = i
                     if line.intersects(shape.exterior):
-                        break
+                        return
             else:
                 if shgeo.Point(line.coords[0]).within(shape):
                     seg1 = _connect_linearring_with_linestring(ring, line, row_spacing)
@@ -311,7 +317,8 @@ def _connect_ring(ring, shape, outline_segments, linearrings_within, row_spacing
                 outline_segments[connected] = seg1
                 remove.append(i)
                 # let's not try any harder
-                break
+                return
+    unconnected.append(ring)
 
 
 def _get_segment_relations(segments_within) -> dict[int, int | None]:

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -162,7 +162,7 @@ def _linestring_to_segments(shape, linestring) -> list[list[tuple[float, ...]]]:
         projections = [0] + projections + [1]
     elif shgeo.Point(linestring.coords[0]).within(shape):
         # line is fully within the shape
-        return [linestring]
+        return [linestring.coords[:]]
     # Collect inside segments
     segments = []
     for d0, d1 in zip(projections[:-1], projections[1:]):

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -263,6 +263,7 @@ def stitch_curve_evenly(
 
     i: typing.Optional[int] = 1
     last = points[0]
+    last_real_stitch = points[0]
     stitches: typing.List[Point] = []
     while i is not None and i < len(points):
         d = last.distance(points[i]) + dist_left[i]
@@ -271,14 +272,22 @@ def stitch_curve_evenly(
         # correction for rounding error
         stitch_len = d / math.ceil(d / stitch_length[stitch_length_pos]) + 0.000001
 
+        if last_real_stitch != last and last_real_stitch.distance(last) < stitch_len:
+            stitch_len -= last_real_stitch.distance(last)
+
         stitch, newidx = take_stitch(last, points, i, stitch_len, tolerance)
         i = newidx
         if stitch is not None:
             stitches.append(stitch)
+            # when we use this for fill stitch type such as guided fill where rows of lines are visibile,
+            # we do not want to break the stitch pattern through shortcoming stitches
+            # therefore we save the last actual meant to be stitch position and subtract this from the current stitch length
+            if last_real_stitch.distance(stitch) >= stitch_len:
+                last_real_stitch = stitch
+                stitch_length_pos += 1
+                if stitch_length_pos >= len(stitch_length):
+                    stitch_length_pos = 0
             last = stitch
-            stitch_length_pos += 1
-            if stitch_length_pos > len(stitch_length) - 1:
-                stitch_length_pos = 0
     return stitches, stitch_length_pos
 
 

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -87,10 +87,14 @@ def roll_linear_ring(ring, distance, normalized=False):
     """
 
     if not isinstance(ring, LinearRing):
+        # a ring can only be build with at least 4 points, so let's ensure 4 points
+        if len(ring.coords) < 4:
+            length = ring.length
+            ring = ring.segmentize(max_segment_length=length/3)
         # In case they handed us a LineString
         ring = LinearRing(ring)
 
-    pieces = cut(LinearRing(ring), distance, normalized=False)
+    pieces = cut(LinearRing(ring), distance, normalized)
 
     if None in pieces:
         # We cut exactly at the start or end.
@@ -161,7 +165,7 @@ def ensure_multi_polygon(thing: BaseGeometry, min_size=0) -> MultiPolygon:
     return multi_polygon
 
 
-def ensure_multi_point(thing):
+def ensure_multi_point(thing, line_endpoints=False):
     """Given a shapely geometry, return a MultiPoint"""
     multi_point = MultiPoint()
     if thing.is_empty:
@@ -170,6 +174,8 @@ def ensure_multi_point(thing):
         return thing
     elif thing.geom_type == "Point":
         return MultiPoint([thing])
+    elif line_endpoints and thing.geom_type == "LineString":
+        return MultiPoint([ShapelyPoint(thing.coords[0]), ShapelyPoint(thing.coords[-1])])
     elif thing.geom_type == "GeometryCollection":
         points = []
         for shape in thing.geoms:
@@ -177,6 +183,9 @@ def ensure_multi_point(thing):
                 points.append(shape)
             elif shape.geom_type == "MultiPoint":
                 points.extend(shape.geoms)
+            elif line_endpoints and shape.geom_type == "LineString":
+                points.append(ShapelyPoint(shape.coords[0]))
+                points.append(ShapelyPoint(shape.coords[-1]))
         return MultiPoint(points)
     return multi_point
 


### PR DESCRIPTION
* Fills in holes in guided fill parallel offset
* Adds a smooth parameter to enable users to control the ridge effect even better
* Fixes a small problem with roll_linear_ring which has a normalized attribute, but wasn't using it
* Adds a line_endpoints option to ensure_multi_point, so when a linestring is delivered (or a linestring within a geometry collection), it will not completely remove it, but returns the end points

Fixes #4306