### PR TITLE
Add simple shape option to knockdown

### DIFF
--- a/lib/extensions/knockdown_fill.py
+++ b/lib/extensions/knockdown_fill.py
@@ -29,6 +29,7 @@ class KnockdownFill(InkstitchExtension):
         self.arg_parser.add_argument("-m", "--mitre-limit", type=float, default=5.0, dest="mitre_limit")
 
         self.arg_parser.add_argument("-s", "--shape", type=str, default='', dest="shape")
+        self.arg_parser.add_argument("-a", "--simple-shape", type=Boolean, default=False, dest="simple_shape")
         self.arg_parser.add_argument("-f", "--shape-offset", type=float, default=0, dest="shape_offset")
         self.arg_parser.add_argument("-p", "--shape-join-style", type=str, default="1", dest="shape_join_style")
         # TODO: Layer options: underlay, row spacing, angle
@@ -125,9 +126,10 @@ class KnockdownFill(InkstitchExtension):
         offset_shape = offset_shape.reverse()
         d = str(Path(offset_shape.exterior.coords))
 
-        for polygon in combined_shape.geoms:
-            d += str(Path(polygon.exterior.coords))
-            d += self._get_hole_paths(polygon)
+        if not self.options.simple_shape:
+            for polygon in combined_shape.geoms:
+                d += str(Path(polygon.exterior.coords))
+                d += self._get_hole_paths(polygon)
 
         self.insert_path(d, transform, parent, index)
 

--- a/templates/knockdown_fill.xml
+++ b/templates/knockdown_fill.xml
@@ -34,6 +34,8 @@
            <option value="rect">Rectangle</option>
            <option value="circle">Circle</option>
         </param>
+        <param name="simple-shape" type="bool" gui-text="Use only shape"
+               gui-description="Whether or not the motif should be cut out of the shape.">false</param>
         <param name="shape-offset" type="float" gui-text="Shape offset" min="0" max="50">1</param>
         <param name="shape-join-style" type="optiongroup" appearance="combo" gui-text="Join style">
            <option value="1">Round</option>


### PR DESCRIPTION
Allows to underlay a motif entirely with a shaped knockdown path (circle or rectangle), without cutting out the motif (which isn't exactly embossing anymore)...