### PR TITLE
Fix simulator slider sometimes disappearing

### DIFF
--- a/lib/gui/simulator/simulator_slider.py
+++ b/lib/gui/simulator/simulator_slider.py
@@ -114,7 +114,7 @@ class SimulatorSlider(wx.Panel):
         gc = wx.GraphicsContext.Create(dc)
 
         if self._value < self._min:
-            return
+            self._value = self._min
 
         width, height = self.GetSize()
         min_value = self._min


### PR DESCRIPTION
The simulator slider sometimes just disappeared. This should fix it.

When there are no stitches it will show the empty box and the slider instead of nothing - but that's better than showing nothing when there are stitches.