### PR TITLE
Satin: do not reverse

### DIFF
--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1996,9 +1996,6 @@ class SatinColumn(EmbroideryElement):
         # allowing the user to control how the zigzags flow around corners.
 
         start_point = self.start_point(last_stitch_group)
-        if start_point and self.center_line.project(shgeo.Point(start_point), normalized=True) > 0.5:
-            satin = self.reverse()
-            return satin.to_stitch_groups()
         end_point = self.end_point(self.next_stitch(next_element))
         stitch_groups = []
 


### PR DESCRIPTION
This reverts a change made in #4357

This specific part was meant to reverse the satin when the path to shorten the path to the start point, but it turns out, that this is causing more trouble than doing good.

One of the issues: #4395
We'd need to send the last_stitch_group and the next element to the to_stitch_groups method, which sounds like an easy solution, but the new satin isn't in the document and will therefore return an error message.

It has also been reported that this is cause to a strangely jumping stitch plan for rectangles (explicitly, when turned into a path, we are good). This also only happens when working with a start point (command or previous element).

We could plan to implement this in a better way ... one day, but for now, I rather would like to simply revert this change.
