### PR TITLE
Undo simulator refactoring

### DIFF
--- a/lib/gui/simulator/control_panel.py
+++ b/lib/gui/simulator/control_panel.py
@@ -13,21 +13,15 @@ from ...i18n import _
 from ...utils import get_resource_dir
 from ...utils.settings import global_settings
 from . import SimulatorSlider
-from typing import cast, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .simulator_panel import SimulatorPanel
 
 
 class ControlPanel(wx.Panel):
     """"""
 
     @debug.time
-    def __init__(self, parent: "SimulatorPanel", *args, **kwargs) -> None:
+    def __init__(self, parent, *args, **kwargs):
         """"""
         self.parent = parent
-        # Todo: Decouple control panel from its parent simulator panel?
-        self.simulator_panel: "SimulatorPanel" = parent
         self.stitch_plan = kwargs.pop('stitch_plan', None)
         self.detach_callback = kwargs.pop('detach_callback', None)
         self.target_stitches_per_second = kwargs.pop('stitches_per_second')
@@ -35,6 +29,7 @@ class ControlPanel(wx.Panel):
         kwargs['style'] = wx.BORDER_SUNKEN
         wx.Panel.__init__(self, parent, *args, **kwargs)
 
+        self.drawing_panel = None
         self.num_stitches = 0
         self.current_stitch = 0
         self.speed = global_settings['simulator_speed']
@@ -44,8 +39,7 @@ class ControlPanel(wx.Panel):
         self.icons_dir = get_resource_dir("icons")
 
         # Widgets
-        # Redundant cast to make Mypy happy, wxwidgets types are't perfect...
-        self.button_size = cast(wx.Size, self.GetTextExtent("M")).y * 2
+        self.button_size = self.GetTextExtent("M").y * 2
         self.button_style = wx.BU_EXACTFIT | wx.BU_NOTEXT
         self.btnMinus = wx.Button(self, -1, style=self.button_style)
         self.btnMinus.Bind(wx.EVT_BUTTON, self.animation_slow_down)
@@ -151,6 +145,10 @@ class ControlPanel(wx.Panel):
         if self.stitch_plan:
             wx.CallLater(50, self.load, self.stitch_plan)
 
+    def set_drawing_panel(self, drawing_panel):
+        self.drawing_panel = drawing_panel
+        self.drawing_panel.set_speed(self.speed)
+
     def _set_num_stitches(self, num_stitches):
         if num_stitches < 2:
             # otherwise the slider and intctrl get mad
@@ -219,12 +217,12 @@ class ControlPanel(wx.Panel):
             self.set_speed(self.target_stitches_per_second)
 
     def animation_forward(self, event=None):
-        self.simulator_panel.forward()
+        self.drawing_panel.forward()
         self.direction = 1
         self.update_speed_text()
 
     def animation_reverse(self, event=None):
-        self.simulator_panel.reverse()
+        self.drawing_panel.reverse()
         self.direction = -1
         self.update_speed_text()
 
@@ -239,8 +237,8 @@ class ControlPanel(wx.Panel):
         self.speed = int(max(speed, 1))
         self.update_speed_text()
 
-        if self.simulator_panel:
-            self.simulator_panel.set_speed(self.speed)
+        if self.drawing_panel:
+            self.drawing_panel.set_speed(self.speed)
 
     def format_speed_text(self, speed):
         return _('%d stitches/sec') % speed
@@ -253,12 +251,12 @@ class ControlPanel(wx.Panel):
         stitch = event.GetEventObject().GetValue()
         self.stitchBox.SetValue(stitch)
 
-        if self.simulator_panel:
-            self.simulator_panel.set_current_stitch(stitch)
+        if self.drawing_panel:
+            self.drawing_panel.set_current_stitch(stitch)
 
         self.parent.SetFocus()
 
-    def on_current_stitch(self, stitch):
+    def on_current_stitch(self, stitch, command):
         if self.current_stitch != stitch:
             self.current_stitch = stitch
             self.slider.SetValue(stitch)
@@ -285,8 +283,8 @@ class ControlPanel(wx.Panel):
 
         self.slider.SetValue(stitch)
 
-        if self.simulator_panel:
-            self.simulator_panel.set_current_stitch(stitch)
+        if self.drawing_panel:
+            self.drawing_panel.set_current_stitch(stitch)
         event.Skip()
 
     def animation_slow_down(self, event):
@@ -298,10 +296,10 @@ class ControlPanel(wx.Panel):
         self.set_speed(self.speed * 2.0)
 
     def animation_pause(self, event=None):
-        self.simulator_panel.stop()
+        self.drawing_panel.stop()
 
     def animation_start(self, event=None):
-        self.simulator_panel.go()
+        self.drawing_panel.go()
 
     def on_start(self):
         self.btnPlay.SetValue(True)
@@ -317,18 +315,18 @@ class ControlPanel(wx.Panel):
             self.animation_pause()
 
     def play_or_pause(self, event):
-        if self.simulator_panel.animating:
+        if self.drawing_panel.animating:
             self.animation_pause()
         else:
             self.animation_start()
 
     def animation_one_stitch_forward(self, event):
         self.animation_pause()
-        self.simulator_panel.one_stitch_forward()
+        self.drawing_panel.one_stitch_forward()
 
     def animation_one_stitch_backward(self, event):
         self.animation_pause()
-        self.simulator_panel.one_stitch_backward()
+        self.drawing_panel.one_stitch_backward()
 
     def animation_one_command_backward(self, event):
         self.animation_pause()
@@ -339,7 +337,7 @@ class ControlPanel(wx.Panel):
             if stitch.jump or stitch.trim or stitch.stop or stitch.color_change:
                 break
             stitch_number -= 1
-        self.simulator_panel.set_current_stitch(stitch_number)
+        self.drawing_panel.set_current_stitch(stitch_number)
 
     def animation_one_command_forward(self, event):
         self.animation_pause()
@@ -350,7 +348,7 @@ class ControlPanel(wx.Panel):
             if stitch.jump or stitch.trim or stitch.stop or stitch.color_change:
                 break
             stitch_number += 1
-        self.simulator_panel.set_current_stitch(stitch_number)
+        self.drawing_panel.set_current_stitch(stitch_number)
 
     def animation_restart(self, event):
-        self.simulator_panel.restart()
+        self.drawing_panel.restart()

--- a/lib/gui/simulator/design_info.py
+++ b/lib/gui/simulator/design_info.py
@@ -6,17 +6,18 @@
 import wx
 
 from ...i18n import _
-from ...stitch_plan import StitchPlan
-from typing import Optional
 
 
 class DesignInfoDialog(wx.Dialog):
     """A dialog to show design info
     """
 
-    def __init__(self, *args, stitch_plan: Optional[StitchPlan] = None, **kwargs) -> None:
+    def __init__(self, *args, **kwargs):
         super(DesignInfoDialog, self).__init__(*args, **kwargs)
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
+
+        self.view_panel = self.GetParent()
+        self.drawing_panel = self.view_panel.drawing_panel
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         info_sizer = wx.FlexGridSizer(6, 2, 5, 5)
@@ -54,16 +55,15 @@ class DesignInfoDialog(wx.Dialog):
 
         sizer.Add(info_sizer, 1, wx.ALL, 10)
         self.SetSizerAndFit(sizer)
-        self.set_stitch_plan(stitch_plan)
+        self.update()
 
-    def set_stitch_plan(self, stitch_plan: Optional[StitchPlan]) -> None:
-        if stitch_plan is None:
+    def update(self):
+        if not self.drawing_panel.loaded:
             return
-
-        self.dimensions.SetLabel("{:.2f} x {:.2f}".format(stitch_plan.dimensions_mm[0], stitch_plan.dimensions_mm[1]))
-        self.num_stitches.SetLabel(f"{stitch_plan.num_stitches}")
-        self.num_color_changes.SetLabel(f"{stitch_plan.num_color_blocks-1}")
-        self.num_jumps.SetLabel(f"{stitch_plan.num_jumps-1}")
-        self.num_trims.SetLabel(f"{stitch_plan.num_trims}")
-        self.num_stops.SetLabel(f"{stitch_plan.num_stops}")
+        self.dimensions.SetLabel("{:.2f} x {:.2f}".format(self.drawing_panel.dimensions_mm[0], self.drawing_panel.dimensions_mm[1]))
+        self.num_stitches.SetLabel(f"{self.drawing_panel.num_stitches}")
+        self.num_color_changes.SetLabel(f"{self.drawing_panel.num_color_changes}")
+        self.num_jumps.SetLabel(f"{self.drawing_panel.num_jumps}")
+        self.num_trims.SetLabel(f"{self.drawing_panel.num_trims}")
+        self.num_stops.SetLabel(f"{self.drawing_panel.num_stops}")
         self.Fit()

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -2,38 +2,49 @@
 #
 # Copyright (c) 2024 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+import time
 import math
 
 import wx
 from numpy import split
 
-
 from ...debug.debug import debug
+from ...i18n import _
 from ...svg import PIXELS_PER_MM
 from ...utils.settings import global_settings
-from ...stitch_plan import StitchPlan
-from ...threads.color import ThreadColor
 
-from typing import Optional, List, Tuple, Dict, Any
+# L10N command label at bottom of simulator window
+COMMAND_NAMES = [_("STITCH"), _("JUMP"), _("TRIM"), _("STOP"), _("COLOR CHANGE")]
+
+STITCH = 0
+JUMP = 1
+TRIM = 2
+STOP = 3
+COLOR_CHANGE = 4
 
 
 class DrawingPanel(wx.Panel):
     """"""
+
+    # render no faster than this many frames per second
+    TARGET_FPS = 30
+
     # It's not possible to specify a line thickness less than 1 pixel, even
     # though we're drawing anti-aliased lines.  To get around this we scale
     # the stitch positions up by this factor and then scale down by a
     # corresponding amount during rendering.
     PIXEL_DENSITY = 10
 
-    pan: Tuple[float, float]
-    zoom: float
-
-    def __init__(self, parent, *args, **kwargs) -> None:
+    def __init__(self, parent, *args, **kwargs):
         """"""
-        self.stitch_plan: Optional[StitchPlan] = kwargs.pop('stitch_plan', None)
+        self.parent = parent
+        self.stitch_plan = kwargs.pop('stitch_plan', None)
         kwargs['style'] = wx.BORDER_SUNKEN
 
         wx.Panel.__init__(self, parent, *args, **kwargs)
+
+        self.control_panel = parent.cp
+        self.view_panel = parent.vp
 
         # Drawing panel can really be any size, but without this wxpython likes
         # to allow the status bar and control panel to get squished.
@@ -41,25 +52,87 @@ class DrawingPanel(wx.Panel):
         self.SetBackgroundColour('#FFFFFF')
         self.SetDoubleBuffered(True)
 
+        self.animating = False
+        self.timer = wx.Timer(self)
+        self.last_frame_start = 0
+        self.target_frame_period = 1.0 / self.TARGET_FPS
+        self.direction = 1
+        self.current_stitch = 0
         self.black_pen = wx.Pen((128, 128, 128))
         self.width = 0
         self.height = 0
         self.loaded = False
-        self.page_specs: Dict[Any, Any] = {}
+        self.page_specs = {}
         self.show_page = global_settings['toggle_page_button_status']
         self.background_color = None
+
+        # Set initial values as they may be accessed before a stitch plan is available
+        # for example through a focus action on the stitch box
+        self.num_stitches = 1
+        self.commands = [None]
+
+        # desired simulation speed in stitches per second
+        self.speed = global_settings['simulator_speed']
 
         self.Bind(wx.EVT_PAINT, self.OnPaint)
         self.Bind(wx.EVT_SIZE, self.choose_zoom_and_pan)
         self.Bind(wx.EVT_LEFT_DOWN, self.on_left_mouse_button_down)
         self.Bind(wx.EVT_MOUSEWHEEL, self.on_mouse_wheel)
         self.Bind(wx.EVT_SIZE, self.on_resize)
+        self.Bind(wx.EVT_TIMER, self.animate)
 
-    def on_resize(self, event: wx.SizeEvent) -> None:
+        # wait for layouts so that panel size is set
+        if self.stitch_plan:
+            wx.CallLater(50, self.load, self.stitch_plan)
+
+    def on_resize(self, event):
         self.choose_zoom_and_pan()
         self.Refresh()
 
-    def OnPaint(self, e: wx.PaintEvent) -> None:
+    def clamp_current_stitch(self):
+        if self.current_stitch < 1:
+            self.current_stitch = 1
+        elif self.current_stitch > self.num_stitches:
+            self.current_stitch = self.num_stitches
+
+    def stop_if_at_end(self):
+        if self.direction == -1 and self.current_stitch == 1:
+            self.stop()
+        elif self.direction == 1 and self.current_stitch == self.num_stitches:
+            self.stop()
+
+    def start_if_not_at_end(self):
+        if self.direction == -1 and self.current_stitch > 1:
+            self.go()
+        elif self.direction == 1 and self.current_stitch < self.num_stitches:
+            self.go()
+
+    def animate(self, event=None):
+        if not self.animating:
+            return
+
+        # Each frame, we need to advance forward some number of stitches to
+        # match the speed setting.  The tricky thing is that with bigger
+        # designs, it may take a long time to render a frame.  That might
+        # mean that we'll fall behind.  Even if we set our Timer to 30 FPS,
+        # we may only actually manage to render 20 FPS or fewer, and the
+        # duration of each frame may vary.
+        #
+        # To deal with that, we'll figure out how many stitches to advance
+        # based on how long it took to render the last frame.  We'll always
+        # be behind by one frame, but it should work out fine.
+
+        now = time.time()
+        if self.last_frame_start:
+            frame_time = now - self.last_frame_start
+        else:
+            frame_time = self.target_frame_period
+        self.last_frame_start = now
+
+        stitch_increment = self.speed * frame_time
+        self.set_current_stitch(self.current_stitch + self.direction * stitch_increment)
+
+    def OnPaint(self, e):
         dc = wx.PaintDC(self)
 
         if not self.loaded:
@@ -71,7 +144,7 @@ class DrawingPanel(wx.Panel):
         self.draw_stitches(canvas)
         self.draw_scale(canvas)
 
-    def draw_page(self, canvas: wx.GraphicsContext) -> None:
+    def draw_page(self, canvas):
         self._update_background_color()
 
         if not self.page_specs or not self.show_page:
@@ -80,8 +153,7 @@ class DrawingPanel(wx.Panel):
         with debug.log_exceptions():
             border_color = wx.Colour(self.page_specs['border_color'])
             if self.page_specs['show_page_shadow']:
-                # TRANSPARENT_PEN isn't in the types, but it is defined.
-                canvas.SetPen(wx.TRANSPARENT_PEN)  # type: ignore[attr-defined]
+                canvas.SetPen(wx.TRANSPARENT_PEN)
                 canvas.SetBrush(canvas.CreateBrush(wx.Brush(wx.Colour(border_color.Red(), border_color.Green(), border_color.Blue(), alpha=65))))
                 canvas.DrawRoundedRectangle(
                     (-self.page_specs['x'] + 4) * self.PIXEL_DENSITY, (-self.page_specs['y'] + 4) * self.PIXEL_DENSITY,
@@ -90,7 +162,7 @@ class DrawingPanel(wx.Panel):
                 )
 
             pen = canvas.CreatePen(
-                wx.GraphicsPenInfo().Colour(wx.Colour(border_color)).Width(1 * self.PIXEL_DENSITY).Join(wx.JOIN_MITER)
+                wx.GraphicsPenInfo(wx.Colour(border_color)).Width(1 * self.PIXEL_DENSITY).Join(wx.JOIN_MITER)
             )
             canvas.SetPen(pen)
             canvas.SetBrush(wx.Brush(wx.Colour(self.background_color or self.page_specs['page_color'])))
@@ -100,7 +172,7 @@ class DrawingPanel(wx.Panel):
                 self.page_specs['width'] * self.PIXEL_DENSITY, self.page_specs['height'] * self.PIXEL_DENSITY
             )
 
-    def draw_stitches(self, canvas: wx.GraphicsContext) -> None:
+    def draw_stitches(self, canvas):
         canvas.BeginLayer(1)
 
         transform = canvas.GetTransform()
@@ -118,23 +190,23 @@ class DrawingPanel(wx.Panel):
             if stitch + len(stitches) < self.current_stitch:
                 stitch += len(stitches)
                 if len(stitches) > 1:
-                    self.draw_stitch_lines(canvas, stitches, jumps)
+                    self.draw_stitch_lines(canvas, pen, stitches, jumps)
                     self.draw_needle_penetration_points(canvas, pen, stitches)
                     last_stitch = stitches[-1]
             else:
                 stitches = stitches[:int(self.current_stitch) - stitch]
                 if len(stitches) > 1:
-                    self.draw_stitch_lines(canvas, stitches, jumps)
+                    self.draw_stitch_lines(canvas, pen, stitches, jumps)
                     self.draw_needle_penetration_points(canvas, pen, stitches)
                     last_stitch = stitches[-1]
                 break
 
-        if last_stitch and global_settings['display_crosshair']:
+        if last_stitch and self.view_panel.btnCursor.GetValue():
             self.draw_crosshair(last_stitch[0], last_stitch[1], canvas, transform)
 
         canvas.EndLayer()
 
-    def draw_crosshair(self, x: float, y: float, canvas: wx.GraphicsContext, transform: wx.GraphicsMatrix) -> None:
+    def draw_crosshair(self, x, y, canvas, transform):
         x, y = transform.TransformPoint(float(x), float(y))
         canvas.SetTransform(canvas.CreateMatrix())
         crosshair_radius = global_settings['simulator_crosshair_radius']
@@ -143,13 +215,11 @@ class DrawingPanel(wx.Panel):
         canvas.StrokeLines(((x - crosshair_radius, y), (x + crosshair_radius, y)))
         canvas.StrokeLines(((x, y - crosshair_radius), (x, y + crosshair_radius)))
 
-    def draw_scale(self, canvas: wx.GraphicsContext) -> None:
+    def draw_scale(self, canvas):
         canvas.SetTransform(canvas.CreateMatrix())
         canvas.BeginLayer(1)
 
-        size: wx.Rect = self.GetClientSize()
-        canvas_width = size.Width
-        canvas_height = size.Height
+        canvas_width, canvas_height = self.GetClientSize()
 
         one_mm = PIXELS_PER_MM * self.zoom
         scale_width = one_mm
@@ -194,8 +264,8 @@ class DrawingPanel(wx.Panel):
 
         canvas.EndLayer()
 
-    def draw_stitch_lines(self, canvas: wx.GraphicsContext, stitches: List[Tuple[float, float]], jumps: List[int]) -> None:
-        render_jumps = global_settings['jump_button_status']
+    def draw_stitch_lines(self, canvas, pen, stitches, jumps):
+        render_jumps = self.view_panel.btnJump.GetValue()
         if render_jumps:
             canvas.StrokeLines(stitches)
         else:
@@ -204,35 +274,54 @@ class DrawingPanel(wx.Panel):
                 if len(block) > 1:
                     canvas.StrokeLines(block)
 
-    def draw_needle_penetration_points(self, canvas: wx.GraphicsContext, pen: wx.Pen, stitches: List[Tuple[float, float]]) -> None:
-        if global_settings['npp_button_status']:
+    def draw_needle_penetration_points(self, canvas, pen, stitches):
+        if self.view_panel.btnNpp.GetValue():
             npp_size = global_settings['simulator_npp_size'] * PIXELS_PER_MM * self.PIXEL_DENSITY
             npp_pen = wx.Pen(pen.GetColour(), width=int(npp_size))
             canvas.SetPen(npp_pen)
             canvas.StrokeLineSegments(stitches, [(stitch[0] + 0.001, stitch[1]) for stitch in stitches])
 
-    def load(self, stitch_plan: StitchPlan) -> None:
-        self.direction = 1
-        self.minx, self.miny, self.maxx, self.maxy = stitch_plan.bounding_box
-        self.width = self.maxx - self.minx
-        self.height = self.maxy - self.miny
-        self.parse_stitch_plan(stitch_plan)
-        self.choose_zoom_and_pan()
-        self.loaded = True
-
     def clear(self):
         self.loaded = False
         self.Refresh()
 
-    def set_page_specs(self, page_specs) -> None:
+    def load(self, stitch_plan):
+        self.current_stitch = 1
+        self.direction = 1
+        self.minx, self.miny, self.maxx, self.maxy = stitch_plan.bounding_box
+        self.width = self.maxx - self.minx
+        self.height = self.maxy - self.miny
+        self.dimensions_mm = stitch_plan.dimensions_mm
+        self.num_stitches = stitch_plan.num_stitches
+        self.num_trims = stitch_plan.num_trims
+        self.num_color_changes = stitch_plan.num_color_blocks - 1
+        self.num_stops = stitch_plan.num_stops
+        self.num_jumps = stitch_plan.num_jumps - 1
+        self.parse_stitch_plan(stitch_plan)
+        self.choose_zoom_and_pan()
+        self.set_current_stitch(0)
+        statusbar = self.GetTopLevelParent().statusbar
+        statusbar.SetStatusText(
+            _("Dimensions: {:.2f} x {:.2f}").format(
+                stitch_plan.dimensions_mm[0],
+                stitch_plan.dimensions_mm[1]
+            ),
+            1
+        )
+        self.loaded = True
+        self.go()
+        if hasattr(self.view_panel, 'info_panel') and self.view_panel.info_panel is not None:
+            self.view_panel.info_panel.update()
+
+    def set_page_specs(self, page_specs):
         self.SetBackgroundColour(page_specs['desk_color'])
         self.page_specs = page_specs
 
-    def set_background_color(self, color) -> None:
+    def set_background_color(self, color):
         self.background_color = color
         self._update_background_color()
 
-    def _update_background_color(self) -> None:
+    def _update_background_color(self):
         if not self.page_specs:
             self.SetBackgroundColour(self.background_color or "#FFFFFF")
         else:
@@ -241,18 +330,16 @@ class DrawingPanel(wx.Panel):
             else:
                 self.SetBackgroundColour(self.background_color or self.page_specs['page_color'])
 
-    def set_show_page(self, show_page) -> None:
+    def set_show_page(self, show_page):
         self.show_page = show_page
         self._update_background_color()
 
-    def choose_zoom_and_pan(self, event: Optional[wx.SizeEvent] = None) -> None:
+    def choose_zoom_and_pan(self, event=None):
         # ignore if EVT_SIZE fired before we load the stitch plan
         if not self.width and not self.height and event is not None:
             return
 
-        size: wx.Rect = self.GetClientSize()
-        panel_width = size.Width
-        panel_height = size.Height
+        panel_width, panel_height = self.GetClientSize()
 
         # add some padding to make stitches at the edge more visible
         width_ratio = panel_width / float(self.width + 10)
@@ -263,20 +350,42 @@ class DrawingPanel(wx.Panel):
         self.pan = ((panel_width - self.zoom * self.width) / 2.0,
                     (panel_height - self.zoom * self.height) / 2.0)
 
-    def color_to_pen(self, color: ThreadColor) -> wx.Pen:
+    def stop(self):
+        self.animating = False
+        self.timer.Stop()
+        self.control_panel.on_stop()
+
+    def go(self):
+        if not self.loaded:
+            return
+
+        if not self.animating:
+            try:
+                self.animating = True
+                self.last_frame_start = 0
+                self.timer.Start(int(self.target_frame_period * 1000))
+                self.animate()
+                self.control_panel.on_start()
+            except RuntimeError:
+                pass
+
+    def color_to_pen(self, color):
         line_width = global_settings['simulator_line_width'] * PIXELS_PER_MM * self.PIXEL_DENSITY
         background_color = self.GetBackgroundColour().GetAsString()
         return wx.Pen(list(map(int, color.visible_on_background(background_color).rgb)), int(line_width))
 
-    def update_pen_size(self) -> None:
+    def update_pen_size(self):
         line_width = global_settings['simulator_line_width'] * PIXELS_PER_MM * self.PIXEL_DENSITY
         for pen in self.pens:
             pen.SetWidth(int(line_width))
 
-    def parse_stitch_plan(self, stitch_plan: StitchPlan) -> None:
+    def parse_stitch_plan(self, stitch_plan):
         self.pens = []
         self.stitch_blocks = []
         self.jumps = []
+
+        # There is no 0th stitch, so add a place-holder.
+        self.commands = [None]
 
         for color_block in stitch_plan:
             pen = self.color_to_pen(color_block.color)
@@ -290,8 +399,17 @@ class DrawingPanel(wx.Panel):
                 stitch_block.append((self.PIXEL_DENSITY * (stitch.x - self.minx),
                                      self.PIXEL_DENSITY * (stitch.y - self.miny)))
 
-                if stitch.jump:
+                if stitch.trim:
+                    self.commands.append(TRIM)
+                elif stitch.jump:
+                    self.commands.append(JUMP)
                     jumps.append(stitch_index)
+                elif stitch.stop:
+                    self.commands.append(STOP)
+                elif stitch.color_change:
+                    self.commands.append(COLOR_CHANGE)
+                else:
+                    self.commands.append(STITCH)
 
                 if stitch.trim or stitch.stop or stitch.color_change:
                     self.pens.append(pen)
@@ -308,11 +426,47 @@ class DrawingPanel(wx.Panel):
                 self.stitch_blocks.append(stitch_block)
                 self.jumps.append(jumps)
 
-    def set_current_stitch(self, stitch: int) -> None:
+    def set_speed(self, speed):
+        self.speed = speed
+        global_settings['simulator_speed'] = speed
+
+    def forward(self):
+        self.direction = 1
+        self.start_if_not_at_end()
+
+    def reverse(self):
+        self.direction = -1
+        self.start_if_not_at_end()
+
+    def set_current_stitch(self, stitch):
         self.current_stitch = stitch
+        self.clamp_current_stitch()
+        try:
+            command = self.commands[int(self.current_stitch)]
+        except IndexError:
+            # no stitch plan loaded yet, do nothing for now
+            return
+        self.control_panel.on_current_stitch(int(self.current_stitch), command)
+        statusbar = self.GetTopLevelParent().statusbar
+        statusbar.SetStatusText(_("Command: %s") % COMMAND_NAMES[command], 2)
+        self.stop_if_at_end()
         self.Refresh()
 
-    def on_left_mouse_button_down(self, event: wx.MouseEvent) -> None:
+    def restart(self):
+        if self.direction == 1:
+            self.current_stitch = 1
+        elif self.direction == -1:
+            self.current_stitch = self.num_stitches
+
+        self.go()
+
+    def one_stitch_forward(self):
+        self.set_current_stitch(self.current_stitch + 1)
+
+    def one_stitch_backward(self):
+        self.set_current_stitch(self.current_stitch - 1)
+
+    def on_left_mouse_button_down(self, event):
         if self.loaded:
             self.CaptureMouse()
             self.drag_start = event.GetPosition()
@@ -321,14 +475,14 @@ class DrawingPanel(wx.Panel):
             self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self.on_drag_end)
             self.Bind(wx.EVT_LEFT_UP, self.on_drag_end)
 
-    def on_drag(self, event: wx.MouseEvent) -> None:
+    def on_drag(self, event):
         if self.HasCapture() and event.Dragging():
             delta = event.GetPosition()
-            offset = (delta.x - self.drag_start[0], delta.y - self.drag_start[1])
+            offset = (delta[0] - self.drag_start[0], delta[1] - self.drag_start[1])
             self.pan = (self.drag_original_pan[0] + offset[0], self.drag_original_pan[1] + offset[1])
             self.Refresh()
 
-    def on_drag_end(self, event: wx.MouseEvent) -> None:
+    def on_drag_end(self, event):
         if self.HasCapture():
             self.ReleaseMouse()
 
@@ -336,7 +490,7 @@ class DrawingPanel(wx.Panel):
         self.Unbind(wx.EVT_MOUSE_CAPTURE_LOST)
         self.Unbind(wx.EVT_LEFT_UP)
 
-    def on_mouse_wheel(self, event: wx.MouseEvent) -> None:
+    def on_mouse_wheel(self, event):
         if event.GetWheelRotation() > 0:
             zoom_delta = 1.03
         else:

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -3,54 +3,16 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 import wx
-import time
 
 from . import ControlPanel, DrawingPanel, ViewPanel
-from ...stitch_plan import StitchPlan
-from typing import List, Optional, cast
-from ...utils.settings import global_settings
-from ...i18n import _
-
-# L10N command label at bottom of simulator window
-COMMAND_NAMES = [_("STITCH"), _("JUMP"), _("TRIM"), _("STOP"), _("COLOR CHANGE")]
-
-# Constants corresponding to indices in the above array
-STITCH = 0
-JUMP = 1
-TRIM = 2
-STOP = 3
-COLOR_CHANGE = 4
 
 
 class SimulatorPanel(wx.Panel):
-    """
-    Panel for the Simulator, with a drawing panel, control panel, and view panel.
+    """"""
 
-    Owns animation control.
-    """
-
-    # render no faster than this many frames per second
-    TARGET_FPS = 30
-    TARGET_FRAME_PERIOD = 1.0 / TARGET_FPS
-
-    def __init__(self, parent, stitch_plan=None, background_color='white', target_duration=5, stitches_per_second=16, detach_callback=None) -> None:
+    def __init__(self, parent, stitch_plan=None, background_color='white', target_duration=5, stitches_per_second=16, detach_callback=None):
         """"""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
-
-        self.animating = False
-        self.timer = wx.Timer(self)
-        self.last_frame_start = 0.0
-        self.direction: float = 1
-        self.current_stitch: int = 0
-        # Set initial values as they may be accessed before a stitch plan is available
-        # for example through a focus action on the stitch box
-        self.num_stitches = 1
-        self.commands: List[int] = []
-
-        # desired simulation speed in stitches per second
-        self.speed: int = global_settings['simulator_speed']
-
-        self.Bind(wx.EVT_TIMER, self.animate)
 
         self.cp = ControlPanel(
             self,
@@ -62,10 +24,10 @@ class SimulatorPanel(wx.Panel):
 
         self.vp = ViewPanel(
             self,
-            detach_callback,
-            stitch_plan=stitch_plan,
+            detach_callback
         )
-        self.dp = DrawingPanel(self)
+        self.dp = DrawingPanel(self, stitch_plan=stitch_plan)
+        self.cp.set_drawing_panel(self.dp)
         self.vp.set_drawing_panel(self.dp)
         self.vp.set_background_color(wx.Colour(background_color))
         self.dp.set_background_color(wx.Colour(background_color))
@@ -100,7 +62,7 @@ class SimulatorPanel(wx.Panel):
             (wx.ACCEL_NORMAL, ord('_'), self.cp.animation_one_stitch_backward),
             (wx.ACCEL_NORMAL, wx.WXK_SUBTRACT, self.cp.animation_one_stitch_backward),
             (wx.ACCEL_NORMAL, wx.WXK_NUMPAD_SUBTRACT, self.cp.animation_one_stitch_backward),
-            (wx.ACCEL_NORMAL, ord('r'), self.restart),
+            (wx.ACCEL_NORMAL, ord('r'), self.cp.animation_restart),
             (wx.ACCEL_NORMAL, ord('p'), self.cp.play_or_pause),
             (wx.ACCEL_NORMAL, wx.WXK_SPACE, self.cp.play_or_pause),
             (wx.ACCEL_NORMAL, wx.WXK_PAGEDOWN, self.cp.animation_one_command_backward),
@@ -118,153 +80,19 @@ class SimulatorPanel(wx.Panel):
         self.accel_table = wx.AcceleratorTable(self.accel_entries)
         self.SetAcceleratorTable(self.accel_table)
 
-        # wait for layouts so that panel size is set
-        if stitch_plan:
-            wx.CallLater(50, self.dp.load, stitch_plan)
+    def go(self):
+        self.dp.go()
 
-    def load(self, stitch_plan: StitchPlan) -> None:
-        self.num_stitches = stitch_plan.num_stitches
+    def stop(self):
+        self.dp.stop()
+
+    def load(self, stitch_plan):
         self.dp.load(stitch_plan)
         self.cp.load(stitch_plan)
-        self.vp.load(stitch_plan)
 
-        # Build command list used to fill out the statusbar
-        # There is no 0th stitch, so add a place-holder.
-        self.commands = []
-        for color_block in stitch_plan:
-            for stitch in color_block:
-                if stitch.trim:
-                    self.commands.append(TRIM)
-                elif stitch.jump:
-                    self.commands.append(JUMP)
-                elif stitch.stop:
-                    self.commands.append(STOP)
-                elif stitch.color_change:
-                    self.commands.append(COLOR_CHANGE)
-                else:
-                    self.commands.append(STITCH)
-
-        statusbar = cast(wx.Frame, self.GetTopLevelParent()).GetStatusBar()
-        statusbar.SetStatusText(
-            _("Dimensions: {:.2f} x {:.2f}").format(
-                stitch_plan.dimensions_mm[0],
-                stitch_plan.dimensions_mm[1]
-            ),
-            1
-        )
-
-        self.go()
-
-    def clear(self) -> None:
+    def clear(self):
         self.dp.clear()
         self.cp.clear()
-        self.vp.load(None)
 
-    def set_page_specs(self, page_specs: dict) -> None:
+    def set_page_specs(self, page_specs):
         self.dp.set_page_specs(page_specs)
-
-    # Animation/Current Stitch-related methods
-    # Could probably be refactored into an "AnimationController" class in the future
-    # to better decouple the simulator elements from their panel...
-
-    def go(self) -> None:
-        if not self.animating:
-            try:
-                self.animating = True
-                self.last_frame_start = 0
-                self.timer.Start(int(self.TARGET_FRAME_PERIOD * 1000))
-                self.animate()
-                self.cp.on_start()
-            except RuntimeError:
-                pass
-
-    def stop(self) -> None:
-        self.animating = False
-        self.timer.Stop()
-        self.cp.on_stop()
-
-    def forward(self) -> None:
-        self.direction = 1
-        self.start_if_not_at_end()
-
-    def reverse(self) -> None:
-        self.direction = -1
-        self.start_if_not_at_end()
-
-    def restart(self, event: Optional[wx.Event] = None) -> None:
-        if self.direction == 1:
-            self.current_stitch = 1
-        elif self.direction == -1:
-            self.current_stitch = self.num_stitches
-
-        self.go()
-
-    def one_stitch_forward(self) -> None:
-        self.set_current_stitch(self.current_stitch + 1)
-
-    def one_stitch_backward(self) -> None:
-        self.set_current_stitch(self.current_stitch - 1)
-
-    def stop_if_at_end(self) -> None:
-        if self.direction == -1 and self.current_stitch == 1:
-            self.stop()
-        elif self.direction == 1 and self.current_stitch == self.num_stitches:
-            self.stop()
-
-    def start_if_not_at_end(self) -> None:
-        if self.direction == -1 and self.current_stitch > 1:
-            self.go()
-        elif self.direction == 1 and self.current_stitch < self.num_stitches:
-            self.go()
-
-    def animate(self, event: Optional[wx.Event] = None) -> None:
-        if not self.animating:
-            return
-
-        # Each frame, we need to advance forward some number of stitches to
-        # match the speed setting.  The tricky thing is that with bigger
-        # designs, it may take a long time to render a frame.  That might
-        # mean that we'll fall behind.  Even if we set our Timer to 30 FPS,
-        # we may only actually manage to render 20 FPS or fewer, and the
-        # duration of each frame may vary.
-        #
-        # To deal with that, we'll figure out how many stitches to advance
-        # based on how long it took to render the last frame.  We'll always
-        # be behind by one frame, but it should work out fine.
-
-        now = time.time()
-        if self.last_frame_start:
-            frame_time = now - self.last_frame_start
-        else:
-            frame_time = self.TARGET_FRAME_PERIOD
-        self.last_frame_start = now
-
-        stitch_increment = self.speed * frame_time
-        self.set_current_stitch(int(self.current_stitch + self.direction * stitch_increment))
-
-        self.stop_if_at_end()
-
-    def set_current_stitch(self, current_stitch: int) -> None:
-        # Clamp current stitch value
-        if current_stitch < 1:
-            current_stitch = 1
-        elif current_stitch > self.num_stitches:
-            current_stitch = self.num_stitches
-
-        self.current_stitch = current_stitch
-
-        self.dp.set_current_stitch(self.current_stitch)
-        self.cp.on_current_stitch(self.current_stitch)
-
-        # Todo: Should this maybe be in that top-level parent?
-        try:
-            command = self.commands[self.current_stitch-1]
-            statusbar = cast(wx.Frame, self.GetTopLevelParent()).GetStatusBar()
-            statusbar.SetStatusText(_("Command: %s") % COMMAND_NAMES[command], 2)
-        except IndexError:
-            # no stitch plan loaded yet, do nothing for now
-            pass
-
-    def set_speed(self, speed: int) -> None:
-        self.speed = speed
-        global_settings['simulator_speed'] = speed

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -2,15 +2,14 @@
 #
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
-import time
-from typing import List, Optional, cast
-
 import wx
+import time
 
-from ...i18n import _
-from ...stitch_plan import StitchPlan
-from ...utils.settings import global_settings
 from . import ControlPanel, DrawingPanel, ViewPanel
+from ...stitch_plan import StitchPlan
+from typing import List, Optional, cast
+from ...utils.settings import global_settings
+from ...i18n import _
 
 # L10N command label at bottom of simulator window
 COMMAND_NAMES = [_("STITCH"), _("JUMP"), _("TRIM"), _("STOP"), _("COLOR CHANGE")]
@@ -41,7 +40,7 @@ class SimulatorPanel(wx.Panel):
         self.animating = False
         self.timer = wx.Timer(self)
         self.last_frame_start = 0.0
-        self.direction: int = 1
+        self.direction: float = 1
         self.current_stitch: int = 0
         # Set initial values as they may be accessed before a stitch plan is available
         # for example through a focus action on the stitch box
@@ -238,13 +237,12 @@ class SimulatorPanel(wx.Panel):
             frame_time = now - self.last_frame_start
         else:
             frame_time = self.TARGET_FRAME_PERIOD
+        self.last_frame_start = now
 
-        stitch_increment = int(self.speed * frame_time)
-        if self.last_frame_start == 0 or stitch_increment > 0:
-            self.last_frame_start = now
-            self.set_current_stitch(self.current_stitch + self.direction * stitch_increment)
+        stitch_increment = self.speed * frame_time
+        self.set_current_stitch(int(self.current_stitch + self.direction * stitch_increment))
 
-            self.stop_if_at_end()
+        self.stop_if_at_end()
 
     def set_current_stitch(self, current_stitch: int) -> None:
         # Clamp current stitch value

--- a/lib/gui/simulator/view_panel.py
+++ b/lib/gui/simulator/view_panel.py
@@ -10,27 +10,22 @@ from ...i18n import _
 from . import SimulatorPreferenceDialog
 from . import DesignInfoDialog
 from ...utils.settings import global_settings
-from ...stitch_plan import StitchPlan
-from typing import Optional
 
 
 class ViewPanel(ScrolledPanel):
     """"""
 
     @debug.time
-    def __init__(self, parent, detach_callback, stitch_plan: Optional[StitchPlan] = None):
+    def __init__(self, parent, detach_callback):
         """"""
         self.parent = parent
         self.detach_callback = detach_callback
         ScrolledPanel.__init__(self, parent)
         self.SetupScrolling(scroll_y=True, scroll_x=False)
 
-        self.stitch_plan: Optional[StitchPlan] = stitch_plan
-
         self.button_style = wx.BU_EXACTFIT | wx.BU_NOTEXT
 
         self.control_panel = parent.cp
-        self.info_panel: Optional[DesignInfoDialog] = None
 
         self.npp_button_status = global_settings['npp_button_status']
         self.jump_button_status = global_settings['jump_button_status']
@@ -147,11 +142,6 @@ class ViewPanel(ScrolledPanel):
 
         self.SetSizerAndFit(outer_sizer)
 
-    def load(self, stitch_plan: Optional[StitchPlan]) -> None:
-        self.stitch_plan = stitch_plan
-        if self.info_panel is not None:
-            self.info_panel.set_stitch_plan(stitch_plan)
-
     def set_drawing_panel(self, drawing_panel):
         self.drawing_panel = drawing_panel
 
@@ -169,27 +159,26 @@ class ViewPanel(ScrolledPanel):
         self.toggle_npp(event)
 
     def toggle_npp(self, event):
-        global_settings['npp_button_status'] = self.btnNpp.GetValue()
         self.drawing_panel.Refresh()
+        global_settings['npp_button_status'] = self.btnNpp.GetValue()
 
     def on_cursor_button(self, event):
-        global_settings['display_crosshair'] = self.btnCursor.GetValue()
         self.drawing_panel.Refresh()
+        global_settings['display_crosshair'] = self.btnCursor.GetValue()
 
     def toggle_page(self, event):
         debug.log("toggle page")
         value = self.btnPage.GetValue()
         self.drawing_panel.set_show_page(value)
-        global_settings['toggle_page_button_status'] = value
         self.drawing_panel.Refresh()
+        global_settings['toggle_page_button_status'] = value
 
     def on_marker_button(self, marker_type, event):
         value = event.GetEventObject().GetValue()
         self.control_panel.slider.enable_marker_list(marker_type, value)
-        global_settings[f'{marker_type}_button_status'] = value
-        # Toggling jump toggles whether jump stitches are drawn by the drawing panel, too...
         if marker_type == 'jump':
             self.drawing_panel.Refresh()
+        global_settings[f'{marker_type}_button_status'] = value
 
     def on_settings_button(self, event):
         if event.GetEventObject().GetValue():
@@ -201,7 +190,7 @@ class ViewPanel(ScrolledPanel):
 
     def on_info_button(self, event):
         if event.GetEventObject().GetValue():
-            self.info_panel = DesignInfoDialog(self, title=_('Design Info'), stitch_plan=self.stitch_plan)
+            self.info_panel = DesignInfoDialog(self, title=_('Design Info'))
             self.info_panel.Bind(wx.EVT_CLOSE, self.info_panel_closed)
             self.info_panel.Show()
         else:


### PR DESCRIPTION
We observed all sorts of oddities with the simulator during the Hamburg meeting.
If that's ok for you, @capellancitizen , i'd like to undo the refactoring for now, move slowly towards the next release and spend more time on testing and bug fixing the simulator later?

I hope this doesn't interfere with your current work on the simulator too much. If you rather want to find fixes for the next release, I'm of course open to that idea as well.