### PR TITLE
Redwork element style

### DIFF
--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -128,7 +128,7 @@ class Redwork(InkstitchExtension):
         node = elements[0].node
 
         transform = get_correction_transform(self.svg.selection.rendering_order()[-1], False)
-        style = node.style
+        style = node.specified_style()
         # Fix up the stroke width
         stroke_width = elements[0].stroke_width
         style["stroke-width"] = self.svg.viewport_to_unit(stroke_width)

--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -132,6 +132,8 @@ class Redwork(InkstitchExtension):
         # Fix up the stroke width
         stroke_width = elements[0].stroke_width
         style["stroke-width"] = self.svg.viewport_to_unit(stroke_width)
+        # Set fill explicitly to none as input elements may have both (stroke and fill)
+        style["fill"] = None
 
         # insert lines grouped by underpath and top layer
         visited_lines = []


### PR DESCRIPTION
Fixes two style issues for the redwork extension:
1. Style attributes from a parent group got lost when a redwork element was moved out of the original group
2. when an element carries both, a stroke and a fill, redwork will break up the path and the fill ends up being broken.
  Since the user selected the element for redwork, we assume, that they wanted the stroke only and remove the fill color (fixes #4421)