### PR TITLE
Update INX to run the extension inside a uv venv if one is detected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ manual:
 
 .PHONY: inx
 inx: version locales
+	# If additional python runtimes are added to this Makefile,
+	# They will need their own cases added to lib/inx/utils.py
 	$(PYTHON_EXECUTABLE) bin/generate-inx-files;
 
 .PHONY: messages.po

--- a/inkstitch_uv.bat
+++ b/inkstitch_uv.bat
@@ -1,0 +1,3 @@
+@echo off
+set SCRIPT_DIR=%~dp0
+uv --project "%SCRIPT_DIR%" run python "%SCRIPT_DIR%inkstitch.py" %*

--- a/inkstitch_uv.sh
+++ b/inkstitch_uv.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+uv --project "$SCRIPT_DIR" run python "$SCRIPT_DIR/inkstitch.py" $@

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -33,8 +33,16 @@ def build_environment():
         else:
             env.globals["command_tag"] = '<command location="inx">../bin/inkstitch</command>'
             env.globals["icon_path"] = '../bin/icons/'
+    elif "UV" in os.environ:
+        # user is running inkstitch.py directly as a developer in a venv managed by UV
+        if sys.platform == "win32":
+            env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.bat</command>'
+            env.globals["icon_path"] = '../icons/'
+        else: 
+            env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.sh</command>'
+            env.globals["icon_path"] = '../icons/'
     else:
-        # user is running inkstitch.py directly as a developer
+        # user is running inkstitch.py directly as a developer with dependencies installed systemwide
         env.globals["command_tag"] = '<command location="inx" interpreter="python">../inkstitch.py</command>'
         env.globals["icon_path"] = '../icons/'
     return env

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -38,7 +38,7 @@ def build_environment():
         if sys.platform == "win32":
             env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.bat</command>'
             env.globals["icon_path"] = '../icons/'
-        else: 
+        else:
             env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.sh</command>'
             env.globals["icon_path"] = '../icons/'
     else:

--- a/lib/inx/utils.py
+++ b/lib/inx/utils.py
@@ -34,7 +34,7 @@ def build_environment():
             env.globals["command_tag"] = '<command location="inx">../bin/inkstitch</command>'
             env.globals["icon_path"] = '../bin/icons/'
     elif "UV" in os.environ:
-        # user is running inkstitch.py directly as a developer in a venv managed by UV
+        # User is running inkstitch.py directly as a developer in a venv managed by UV/
         if sys.platform == "win32":
             env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.bat</command>'
             env.globals["icon_path"] = '../icons/'
@@ -42,7 +42,8 @@ def build_environment():
             env.globals["command_tag"] = '<command location="inx">../inkstitch_uv.sh</command>'
             env.globals["icon_path"] = '../icons/'
     else:
-        # user is running inkstitch.py directly as a developer with dependencies installed systemwide
+        # User is running inkstitch.py directly as a developer with dependencies installed systemwide.
+        # If other python runtimes are added to the Makefile, they will need their own cases added here.
         env.globals["command_tag"] = '<command location="inx" interpreter="python">../inkstitch.py</command>'
         env.globals["icon_path"] = '../icons/'
     return env


### PR DESCRIPTION
#4428 changed where dependencies get installed by creating a venv if uv is available
(allowing installation on distros with locked python packages),
which broke local development as launching from the INX still looks in the old location.

To fix this, `make inx` now detects if it is being run in a uv venv, and if so,
launches the extension through `inkstitch_uv.sh|bat`,
which uses the venv instead of the systemwide python environment.

Operation without uv is unchanged.

Inspired by #3791.

