### PR TITLE
Guided fill: remove small stitches before applying bean stitches

### DIFF
--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -13,6 +13,7 @@ from lib.utils import prng
 
 from ..debug.debug import debug
 from ..stitch_plan import Stitch
+from ..svg import PIXELS_PER_MM
 from ..utils.geometry import Point as InkstitchPoint
 from ..utils.geometry import (ensure_geometry_collection,
                               ensure_multi_line_string, ensure_multi_point,
@@ -24,6 +25,7 @@ from .tatami_fill import (build_fill_stitch_graph, build_travel_graph,
                           collapse_sequential_outline_edges, find_stitch_path,
                           graph_make_valid, tatami_fill, travel)
 from .utils.connect_geometries import connect_offset_lines
+from .utils.stitches import filter_small_stitches
 
 
 def guided_fill(fill, shape, guideline, anchor_line, starting_point, ending_point):
@@ -60,6 +62,12 @@ def guided_fill(fill, shape, guideline, anchor_line, starting_point, ending_poin
         stitches = path_to_stitches(fill, shape, path, travel_graph, guided_graph)
 
         if any(fill.bean_stitch_repeats):
+            # remove small stitches before applying any bean stitches
+            # otherwise the back stitch may not end up at the correct position
+            metadata = fill.get_inkstitch_metadata()
+            min_stitch_length = fill.min_stitch_length or metadata.get('min_stitch_len_mm') * PIXELS_PER_MM
+            stitches = filter_small_stitches(stitches, min_stitch_length)
+
             # add bean stitches, but ignore travel stitches
             stitches = bean_stitch(stitches, fill.bean_stitch_repeats, ['travel', 'fill_row_start'])
         result.append(stitches)

--- a/lib/stitches/tatami_fill.py
+++ b/lib/stitches/tatami_fill.py
@@ -908,7 +908,7 @@ def travel(shape, travel_graph, edge, running_stitch_length, running_stitch_tole
     stitches = [Stitch(point) for point in points]
 
     for stitch in stitches:
-        stitch.add_tag('tatami_fill_travel')
+        stitch.add_tag('travel')
 
     # The path's first stitch will start at the end of a row of stitches.  We
     # don't want to double that last stitch, so we'd like to skip it.

--- a/lib/stitches/utils/stitches.py
+++ b/lib/stitches/utils/stitches.py
@@ -6,6 +6,8 @@
 import numpy as np
 from shapely.geometry import LineString, Point
 
+from ...stitch_plan import Stitch
+
 
 def apply_stitches(
         line: LineString,
@@ -47,3 +49,22 @@ def apply_stitches(
         points = np.insert(points, indices, extra_points, axis=0)
 
     return LineString(points)
+
+
+def filter_small_stitches(stitches: list[Stitch], min_stitch_len: float = 0.1) -> list[Stitch]:
+    if not stitches:
+        return stitches
+
+    if min_stitch_len is None:
+        min_stitch_len = 0.1
+
+    filtered_stitches = [stitches[0]]
+    for stitch in stitches[1:]:
+        length = (stitch - filtered_stitches[-1]).length()
+        if length <= min_stitch_len:
+            # duplicate stitch, skip this one
+            continue
+
+        filtered_stitches.append(stitch)
+
+    return filtered_stitches


### PR DESCRIPTION
Guided fill: fixes the bad points when bean stitch is applied
The issue is minimum stitch length deletes the original stitches, leaving the bean stitch repeats in the wild.

Fixes #4404