### PR TITLE
Added multicolor-satin re-edit via settings

### DIFF
--- a/lib/gui/satin_multicolor/colorize_panel.py
+++ b/lib/gui/satin_multicolor/colorize_panel.py
@@ -16,6 +16,7 @@ class ColorizePanel(ScrolledPanel):
 
     def __init__(self, parent, panel):
         self.panel = panel
+        self.parent = parent
         ScrolledPanel.__init__(self, parent)
 
         self.colorize_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -126,10 +127,16 @@ class ColorizePanel(ScrolledPanel):
     def _add_color_event(self, event):
         self.add_color()
 
-    def add_color(self, color='black'):
+    def add_color(self, color='black', width=None, margin_right=None):
         color_panel = ColorPanel(self, color)
+        color_panel.colorpicker.Bind(wx.EVT_COLOURPICKER_CHANGED, self._update_colors)
+
         self.color_sizer.Add(color_panel, 0, wx.EXPAND | wx.ALL, 10)
 
+        if width:
+            color_panel.color_width.SetValue(width)
+        if margin_right:
+            color_panel.color_margin_right.SetValue(margin_right)
         if self.equististance.GetValue():
             color_panel.color_margin_right.Enable(False)
             color_panel.color_width.Enable(False)
@@ -215,10 +222,15 @@ class ColorizePanel(ScrolledPanel):
     def get_total_width(self):
         width = 0
         colors = self.color_sizer.GetChildren()
+
+        color_panel = None
         for color in colors:
             color_panel = color.GetWindow()
             width += color_panel.color_width.GetValue()
             width += color_panel.color_margin_right.GetValue()
+
+        if not color_panel:
+            return 0
         last_margin = color_panel.color_margin_right.GetValue()
         width -= last_margin
         return round(width, 2)
@@ -239,7 +251,7 @@ class ColorizePanel(ScrolledPanel):
             self.total_width.SetForegroundColour(wx.NullColour)
         self.panel.update_preview()
 
-    def _update_colors(self):
+    def _update_colors(self, event=None):
         equidistance = self.equististance.GetValue()
         num_colors = len(self.color_sizer.GetChildren())
         if equidistance:
@@ -252,6 +264,7 @@ class ColorizePanel(ScrolledPanel):
                 self._set_widget_width_value(monochrome_value, margin)
             self.monochrome_width.SetMax(max_width)
         self.Refresh()
+
         self._update()
 
     def _update_underlay(self, event):

--- a/lib/gui/satin_multicolor/main_panel.py
+++ b/lib/gui/satin_multicolor/main_panel.py
@@ -16,14 +16,18 @@ from ...stitch_plan import stitch_groups_to_stitch_plan
 from ...utils.threading import ExitThread, check_stop_flag
 from .. import PreviewRenderer, WarningPanel
 from . import ColorizePanel, HelpPanel
+from ...svg.tags import INKSCAPE_LABEL, INKSTITCH_SATIN_MULTICOLOR
+import json
+from ...utils import DotDict
 
 
 class MultiColorSatinPanel(wx.Panel):
 
     def __init__(self, parent, simulator, elements, metadata=None, background_color='white'):
         self.parent = parent
-        self.simulator = simulator
         self.elements = elements
+
+        self.simulator = simulator
         self.metadata = metadata or dict()
         self.background_color = background_color
         self.output_groups = []
@@ -60,11 +64,104 @@ class MultiColorSatinPanel(wx.Panel):
 
         self.notebook_sizer.Add(apply_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
 
-        self.colorize_panel.add_color(self.elements[0].color)
+        self.is_reedit = self.load_settings()
+        self.satin_elements = []
+        if not len(self.settings.colors):
+            self.settings.colors.append(
+                DotDict({
+                    "value": self.elements[0].color,
+                    "width": 100,
+                    "margin": 0
+                }))
+
+        self.apply_settings()
 
         self.SetSizerAndFit(self.notebook_sizer)
 
         self.Layout()
+
+    def create_group(self):
+        group = inkex.Group(attrib={
+            INKSCAPE_LABEL: _("Ink/Stitch Multicolor Satin"),
+        })
+        return group
+
+    def load_settings(self):
+        """Load the settings saved into the SVG group element"""
+        self.settings = DotDict({
+            "equidistance": True,
+            "monochrome_width": 100,
+            "colors": [],
+            "overflow_left": 0,
+            "overflow_right": 0,
+            "pull_compensation": 0,
+            "seed": "",
+            "adjust_underlay_per_color": False
+        })
+        self.reedit_group = None
+        self.reedit_layer = None
+        self.reedit_index = None
+        self.reedit_template_node = None
+
+        # TODO improve by verifying if multiple parents exist with satin config and if so throw error - we can only reedit one at a time
+        parent = self.elements[0].node.getparent()
+        if parent and INKSTITCH_SATIN_MULTICOLOR in parent.attrib:
+            try:
+                json_config = json.loads(
+                    parent.get(INKSTITCH_SATIN_MULTICOLOR))
+                self.settings.update(json_config)
+
+                self.settings.colors = []
+
+                for color_json in json_config["colors"]:
+                    self.settings.colors.append(DotDict(color_json))
+
+                self.reedit_group = parent
+                self.reedit_layer = parent.getparent()
+                if self.reedit_layer is not None:
+                    self.reedit_index = self.reedit_layer.index(parent)
+                self.reedit_template_node = copy(self.elements[0].node)
+                self.elements = [self.elements[0]]
+                return True
+            except (TypeError, ValueError):
+                return False
+        return False
+
+    def apply_settings(self):
+        self.colorize_panel.equististance.SetValue(self.settings.equidistance)
+        self.colorize_panel.monochrome_width.SetValue(self.settings.monochrome_width)
+        self.colorize_panel.overflow_left.SetValue(self.settings.overflow_left)
+        self.colorize_panel.overflow_right.SetValue(self.settings.overflow_right)
+        self.colorize_panel.pull_compensation.SetValue(self.settings.pull_compensation)
+        self.colorize_panel.adjust_underlay_per_color.SetValue(self.settings.adjust_underlay_per_color)
+        if self.settings.seed:
+            self.colorize_panel.seed.SetValue(self.settings.seed)
+        for color in self.settings.colors:
+            self.colorize_panel.add_color(color.value, color.width, color.margin_right)
+
+    def save_settings(self):
+        """Save the settings into the SVG group element."""
+
+        self.settings.equidistance = self.colorize_panel.equististance.GetValue()
+        self.settings.monochrome_width = self.colorize_panel.monochrome_width.GetValue()
+        self.settings.overflow_left = self.colorize_panel.overflow_left.GetValue()
+        self.settings.overflow_right = self.colorize_panel.overflow_right.GetValue()
+        self.settings.pull_compensation = self.colorize_panel.pull_compensation.GetValue()
+        self.settings.adjust_underlay_per_color = self.colorize_panel.adjust_underlay_per_color.GetValue()
+        self.settings.seed = self.colorize_panel.seed.GetValue()
+
+        colors = [
+            DotDict({
+                "value": c.GetWindow().colorpicker.GetColour().GetAsString(wx.C2S_HTML_SYNTAX),
+                "width": c.GetWindow().color_width.GetValue(),
+                "margin_right": c.GetWindow().color_margin_right.GetValue()
+            })
+            for c in self.colorize_panel.color_sizer.GetChildren()]
+
+        self.settings.colors = colors
+
+        for group in self.output_groups:
+            group.set(INKSTITCH_SATIN_MULTICOLOR, json.dumps(self.settings))
 
     def _hide_warning(self):
         self.warning_panel.clear()
@@ -89,9 +186,11 @@ class MultiColorSatinPanel(wx.Panel):
 
     def apply(self, event):
         self.update_satin_elements()
-        if not self.colorize_panel.keep_original.GetValue():
+        if not self.is_reedit and not self.colorize_panel.keep_original.GetValue():
             for element in self.elements:
                 element.node.delete()
+
+        self.save_settings()
         self.close()
 
     def render_stitch_plan(self):
@@ -129,26 +228,78 @@ class MultiColorSatinPanel(wx.Panel):
                 wx.CallAfter(self._show_warning, format_uncaught_exception())
         return stitch_groups
 
+    def _update_satin_column(self, new_satin, color, pull_compensation, seed, element, i, margin, previous_margin, current_position, width):
+        new_satin.style['stroke'] = color
+        new_satin.set('inkstitch:pull_compensation_mm', pull_compensation)
+        new_satin.set('inkstitch:random_seed', seed)
+
+        reverse_rails = self._get_new_reverse_rails_param(element, i)
+        if reverse_rails is not None:
+            new_satin.set('inkstitch:reverse_rails', reverse_rails)
+
+        if i % 2 == 0:
+            new_satin.set('inkstitch:swap_satin_rails', False)
+            new_satin.set('inkstitch:random_width_increase_percent', f'{ margin } 0')
+            new_satin.set('inkstitch:random_width_decrease_percent', f'0 { -previous_margin }')
+            new_satin.set('inkstitch:pull_compensation_percent', f'{ current_position + width - 100} { -current_position }')
+            new_satin.set('inkstitch:running_stitch_position', f'{100 - current_position - width / 2}')
+        else:
+            new_satin.set('inkstitch:swap_satin_rails', True)
+            new_satin.set('inkstitch:random_width_increase_percent', f'0 { margin }')
+            new_satin.set('inkstitch:random_width_decrease_percent', f'{ -previous_margin } 0')
+            new_satin.set('inkstitch:pull_compensation_percent', f'{ -current_position } { current_position + width - 100}')
+            new_satin.set('inkstitch:running_stitch_position', f'{current_position + width / 2}')
+
+        # underlay
+        if self.colorize_panel.adjust_underlay_per_color.GetValue():
+            if i % 2 == 0:
+                new_satin.set('inkstitch:center_walk_underlay_position', f'{ 100 - current_position - width / 2 }')
+                new_satin.set('inkstitch:contour_underlay_inset_percent', f'{ 100 - current_position - width } { current_position }')
+                new_satin.set('inkstitch:zigzag_underlay_inset_percent', f'{ 100 - current_position - width} { current_position }')
+            else:
+                new_satin.set('inkstitch:center_walk_underlay_position', f'{ current_position + width / 2 }')
+                new_satin.set('inkstitch:contour_underlay_inset_percent', f'{ current_position } { 100 - current_position - width }')
+                new_satin.set('inkstitch:zigzag_underlay_inset_percent', f'{ current_position } { 100 - current_position - width }')
+        elif i > 0:
+            new_satin.set('inkstitch:center_walk_underlay', False)
+            new_satin.set('inkstitch:contour_underlay', False)
+            new_satin.set('inkstitch:zigzag_underlay', False)
+
+        previous_margin = margin
+        current_position += width + margin
+        return current_position
+
     def update_satin_elements(self):
-        # empty old groups
-        for group in self.output_groups:
-            group.delete()
+        for out_group in self.output_groups:
+            if self.is_reedit and out_group is self.reedit_group:
+                for child in list(out_group):
+                    out_group.remove(child)
+            else:
+                out_group.delete()
+
         self.output_groups = []
+        self.satin_elements = []
 
         overflow_left = self.colorize_panel.overflow_left.GetValue()
         overflow_right = self.colorize_panel.overflow_right.GetValue()
         pull_compensation = self.colorize_panel.pull_compensation.GetValue()
         seed = self.colorize_panel.seed.GetValue()
 
-        self.satin_elements = []
         color_sizer = self.colorize_panel.color_sizer.GetChildren()
         num_colors = len(color_sizer)
         for element in self.elements:
+            if self.is_reedit:
+                group = self.reedit_group
+                layer = self.reedit_layer
+                index = self.reedit_index
+                template_node = self.reedit_template_node
+            else:
+                group = self.create_group()
+                layer = element.node.getparent()
+                index = layer.index(element.node)
+                template_node = element.node
+
             check_stop_flag()
-            layer = element.node.getparent()
-            index = layer.index(element.node)
-            group = inkex.Group()
-            group.label = _("Multicolor Satin Group")
             current_position = 0
             previous_margin = overflow_left
             for i, color_panel in enumerate(color_sizer):
@@ -160,50 +311,16 @@ class MultiColorSatinPanel(wx.Panel):
                     margin = panel.color_margin_right.GetValue()
                 width = panel.color_width.GetValue()
 
-                new_satin = copy(element.node)
-                new_satin.style['stroke'] = color
-                new_satin.set('inkstitch:pull_compensation_mm', pull_compensation)
-                new_satin.set('inkstitch:random_seed', seed)
-
-                reverse_rails = self._get_new_reverse_rails_param(element, i)
-                if reverse_rails is not None:
-                    new_satin.set('inkstitch:reverse_rails', reverse_rails)
-
-                if i % 2 == 0:
-                    new_satin.set('inkstitch:swap_satin_rails', False)
-                    new_satin.set('inkstitch:random_width_increase_percent', f'{ margin } 0')
-                    new_satin.set('inkstitch:random_width_decrease_percent', f'0 { -previous_margin }')
-                    new_satin.set('inkstitch:pull_compensation_percent', f'{ current_position + width - 100} { -current_position }')
-                    new_satin.set('inkstitch:running_stitch_position', f'{100 - current_position - width / 2}')
-                else:
-                    new_satin.set('inkstitch:swap_satin_rails', True)
-                    new_satin.set('inkstitch:random_width_increase_percent', f'0 { margin }')
-                    new_satin.set('inkstitch:random_width_decrease_percent', f'{ -previous_margin } 0')
-                    new_satin.set('inkstitch:pull_compensation_percent', f'{ -current_position } { current_position + width - 100}')
-                    new_satin.set('inkstitch:running_stitch_position', f'{current_position + width / 2}')
-
-                # underlay
-                if self.colorize_panel.adjust_underlay_per_color.GetValue():
-                    if i % 2 == 0:
-                        new_satin.set('inkstitch:center_walk_underlay_position', f'{ 100 - current_position - width / 2 }')
-                        new_satin.set('inkstitch:contour_underlay_inset_percent', f'{ 100 - current_position - width } { current_position }')
-                        new_satin.set('inkstitch:zigzag_underlay_inset_percent', f'{ 100 - current_position - width} { current_position }')
-                    else:
-                        new_satin.set('inkstitch:center_walk_underlay_position', f'{ current_position + width / 2 }')
-                        new_satin.set('inkstitch:contour_underlay_inset_percent', f'{ current_position } { 100 - current_position - width }')
-                        new_satin.set('inkstitch:zigzag_underlay_inset_percent', f'{ current_position } { 100 - current_position - width }')
-                elif i > 0:
-                    new_satin.set('inkstitch:center_walk_underlay', False)
-                    new_satin.set('inkstitch:contour_underlay', False)
-                    new_satin.set('inkstitch:zigzag_underlay', False)
-
+                new_satin = copy(template_node)
+                current_position = self._update_satin_column(
+                    new_satin, color, pull_compensation, seed, element, i, margin, previous_margin, current_position, width)
                 previous_margin = margin
-                current_position += width + margin
 
                 group.add(new_satin)
                 self.satin_elements.append(new_satin)
 
-            layer.insert(index + 1, group)
+            if not self.is_reedit and layer is not group:
+                layer.insert(index + 1, group)
             self.output_groups.append(group)
 
     def _get_new_reverse_rails_param(self, element, i):
@@ -219,3 +336,7 @@ class MultiColorSatinPanel(wx.Panel):
         self.simulator.stop()
         self.simulator.load(stitch_plan)
         self.simulator.go()
+
+    def on_change(self, attribute, event):
+        value = event.GetEventObject().GetValue()
+        self.settings[attribute] = value

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -47,6 +47,7 @@ SODIPODI_NODETYPES = inkex.addNS('nodetypes', 'sodipodi')
 
 INKSTITCH_LETTERING = inkex.addNS('lettering', 'inkstitch')
 INKSTITCH_TARTAN = inkex.addNS('tartan', 'inkstitch')
+INKSTITCH_SATIN_MULTICOLOR = inkex.addNS('satin-multicolor', 'inkstitch')
 
 EMBROIDERABLE_TAGS = (SVG_PATH_TAG, SVG_LINE_TAG, SVG_POLYLINE_TAG, SVG_POLYGON_TAG,
                       SVG_RECT_TAG, SVG_ELLIPSE_TAG, SVG_CIRCLE_TAG)


### PR DESCRIPTION
Similar to how lettering works, the multi color satin group now persist the saved settings in an svg attribute, allowing to load these settings on reedit

We're so happy you're interested in contributing to Ink/Stitch!  Before you contribute, **please have a look at our [contributor guidelines](https://github.com/inkstitch/inkstitch/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/inkstitch/inkstitch/blob/main/CODE_OF_CONDUCT.md)**.  Thanks!

**No AI-written contributions please!** We do not accept contributions written entirely or in large part using LLM-based tools such as Claude or Cursor.
