### PR TITLE
Fix several jump to stroke issues

### DIFF
--- a/lib/elements/clone.py
+++ b/lib/elements/clone.py
@@ -107,6 +107,14 @@ class Clone(EmbroideryElement):
             return stitch_groups
 
     @property
+    # TODO: insert type annotation
+    def color(self):  # type: ignore[no-untyped-def]
+        first, last = self.first_and_last_element()
+        if first:
+            return first.color
+        return 'black'
+
+    @property
     def first_stitch(self) -> Optional[ShapelyPoint]:
         first, last = self.first_and_last_element()
         if first:

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -632,6 +632,9 @@ class EmbroideryElement(object):
     def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup], next_element: Optional[EmbroideryElement] = None) -> List[StitchGroup]:
         raise NotImplementedError("%s must implement to_stitch_groups()" % self.__class__.__name__)
 
+    def color(self):
+        raise NotImplementedError("%s must implement color()" % self.__class__.__name__)
+
     @debug.time
     def _load_cached_stitch_groups(self, previous_stitch, next_element):
         if is_cache_disabled():

--- a/lib/elements/image.py
+++ b/lib/elements/image.py
@@ -68,6 +68,10 @@ class ImageObject(EmbroideryElement):
             shape = MultiPolygon([paths])
         return shape
 
+    @property
+    def color(self):
+        return "black"
+
     def center(self):
         parent = self.node.getparent()
         assert parent is not None, "This should be part of a tree and therefore have a parent"

--- a/lib/elements/marker.py
+++ b/lib/elements/marker.py
@@ -29,6 +29,11 @@ class MarkerObject(EmbroideryElement):
         repr_point = next(inkex.Path(self.parse_path()).end_points)
         yield MarkerWarning(repr_point)
 
+    @property
+    def color(self):
+        # We will not sitch this element, but we need to implement a color definition.
+        return 'black'
+
     def to_stitch_groups(self, last_stitch_group, next_element=None):
         return []
 

--- a/lib/elements/text.py
+++ b/lib/elements/text.py
@@ -30,6 +30,12 @@ class TextObject(EmbroideryElement):
 
         return point
 
+    @property
+    def color(self):
+        # We are not able to sitch this element, but we need to implement a color definition.
+        # So let's simply define a black color
+        return 'black'
+
     def validation_warnings(self):
         yield TextTypeWarning(self.pointer())
 

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -119,7 +119,8 @@ class JumpToStroke(InkstitchExtension):
     def _split_stroke_elements_with_subpaths(self) -> None:
         elements = []
         for element in self.elements:
-            if isinstance(element, Stroke) and len(element.paths) > 1:
+            if (isinstance(element, Stroke) and element.node.TAG == "path" and
+                    not element.node.get('sodipodi:type') and not element.node.get('inkscape:path-effect') and len(element.paths) > 1):
                 if element.get_param('stroke_method', None) in ['ripple_stitch']:
                     elements.append(element)
                     continue

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -154,7 +154,7 @@ class JumpToStroke(InkstitchExtension):
                 element2.node.get_id() not in self.svg.selection.ids):
             return True
         if (self.options.merge and
-                element1.node.TAG == "path" and
+                (element1.node.TAG == "path" and not element1.node.get('sodipodi:type') and not element1.node.get('inkscape:path-effect')) and
                 element1.get_param('stroke_method', None) == element2.get_param('stroke_method', None) and
                 not element1.get_param('stroke_method', '') == 'ripple_stitch'):
             return True

--- a/lib/extensions/jump_to_stroke.py
+++ b/lib/extensions/jump_to_stroke.py
@@ -4,9 +4,11 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from inkex import Boolean, DirectedLineSegment, Path, PathElement, Transform
+from inkex.paths import Line
 
-from ..elements import Stroke
+from ..elements import Clone, Stroke
 from ..i18n import _
+from ..stitch_plan import StitchGroup
 from ..svg import PIXELS_PER_MM, generate_unique_id, get_correction_transform
 from ..svg.tags import INKSTITCH_ATTRIBS, SVG_GROUP_TAG
 from .base import InkstitchExtension
@@ -32,7 +34,7 @@ class JumpToStroke(InkstitchExtension):
         self.arg_parser.add_argument("-l", "--stitch-length", type=float, default=2.5, dest="running_stitch_length_mm")
         self.arg_parser.add_argument("-t", "--tolerance", type=float, default=2.0, dest="running_stitch_tolerance_mm")
 
-    def effect(self):
+    def effect(self) -> None:
         self._set_selection()
         self.get_elements()
         self.metadata = self.get_inkstitch_metadata()
@@ -47,16 +49,18 @@ class JumpToStroke(InkstitchExtension):
         last_element = None
         last_stitch_group = None
         next_elements = [None]
+        original_stitch_groups = None
         if len(self.elements) > 1:
             next_elements = self.elements[1:] + next_elements
         for element, next_element in zip(self.elements, next_elements):
             layer, group = self._get_element_layer_and_group(element)
             stitch_groups = element.embroider(last_stitch_group, next_element)
-            multiple = not self.options.merge_subpaths and stitch_groups
+            multiple = not self.options.merge_subpaths and len(stitch_groups) > 1
 
             if multiple:
                 ending_point = stitch_groups[0].stitches[0]
-                stitch_groups = [stitch_groups[-1]]
+                original_stitch_groups = stitch_groups
+                stitch_groups = [stitch_groups[0]]
 
             if (not stitch_groups or
                     last_element is None or
@@ -69,30 +73,37 @@ class JumpToStroke(InkstitchExtension):
                 last_group = group
                 last_element = element
                 if stitch_groups:
-                    last_stitch_group = stitch_groups[-1]
+                    last_stitch_group = self._get_last_stitch_group(multiple, stitch_groups[-1], original_stitch_groups)
                 continue
 
             for stitch_group in stitch_groups:
                 if last_stitch_group is None or stitch_group.color != last_stitch_group.color:
                     last_layer = layer
                     last_group = group
-                    last_stitch_group = stitch_group
+                    last_stitch_group = self._get_last_stitch_group(multiple, stitch_group, original_stitch_groups)
                     continue
                 start = last_stitch_group.stitches[-1]
                 if multiple:
                     end = ending_point
                 else:
                     end = stitch_group.stitches[0]
+                last_stitch_group = self._get_last_stitch_group(multiple, stitch_group, original_stitch_groups)
                 self.generate_stroke(last_element, element, start, end)
-                last_stitch_group = stitch_group
 
             last_group = group
             last_layer = layer
             last_element = element
 
-    def _set_selection(self):
+    def _set_selection(self) -> None:
         if not self.svg.selection:
             self.svg.selection.clear()
+
+    def _get_last_stitch_group(self, multiple, stitch_group, original_stitch_groups) -> StitchGroup:
+        if multiple:
+            last_stitch_group = original_stitch_groups[-1]
+        else:
+            last_stitch_group = stitch_group
+        return last_stitch_group
 
     def _get_element_layer_and_group(self, element):
         layer = None
@@ -105,7 +116,7 @@ class JumpToStroke(InkstitchExtension):
                 break
         return layer, group
 
-    def _split_stroke_elements_with_subpaths(self):
+    def _split_stroke_elements_with_subpaths(self) -> None:
         elements = []
         for element in self.elements:
             if isinstance(element, Stroke) and len(element.paths) > 1:
@@ -114,10 +125,11 @@ class JumpToStroke(InkstitchExtension):
                     continue
                 node = element.node
                 parent = node.getparent()
+                assert parent is not None, "This should be part of a tree and therefore have a parent"
                 index = parent.index(node)
                 paths = node.get_path().break_apart()
 
-                block_ids = []
+                block_ids: list[str] = []
                 for path in paths:
                     subpath_element = node.copy()
                     subpath_id = generate_unique_id(node, f'{node.get_id()}_', block_ids)
@@ -131,8 +143,11 @@ class JumpToStroke(InkstitchExtension):
                 elements.append(element)
         self.elements = elements
 
-    def _is_mergable(self, element1, element2):
-        if not (isinstance(element1, Stroke)):
+    def _is_mergable(self, element1, element2) -> bool:
+        if not isinstance(element1, Stroke):
+            return False
+        if isinstance(element2, Clone):
+            # we do not want to try any merging with clones
             return False
         if (self.options.merge_subpaths and
                 element1.node.get_id() not in self.svg.selection.ids and
@@ -145,10 +160,27 @@ class JumpToStroke(InkstitchExtension):
             return True
         return False
 
-    def generate_stroke(self, last_element, element, start, end):
+    def _prepare_path(self, element, path) -> Path:
+        if element.is_closed_path:
+            # remove zoneclose segment
+            path.pop()
+            # close path manually if not already
+            end_points = list(path.end_points)
+            if end_points[0] != end_points[-1]:
+                path.append(Line(*end_points[0]))
+        return path
+
+    def generate_stroke(self, last_element, element, start, end) -> None:
         node = element.node
         parent = node.getparent()
         index = parent.index(node)
+        if index == 0:
+            # if the indx is 0 we are at the start of a group
+            # include the running stitch into the parent group
+            # this also helps to prevent cloned group originals to carry an additional stroke
+            group_parent = parent.getparent()
+            index = group_parent.index(parent)
+            parent = group_parent
 
         # do not add a running stitch if the distance is smaller than min_jump setting
         # when the extension didn't define a value, use the actual min. jump stitch length
@@ -167,17 +199,37 @@ class JumpToStroke(InkstitchExtension):
             return
 
         path = Path([(start.x, start.y), (end.x, end.y)])
+
+        merged = self._merge_paths(last_element, element, path)
+        if merged:
+            return
+
+        # add simple stroke to connect elements
+        path.transform(Transform(get_correction_transform(parent, True)), True)
+        color = element.color
+        style = f'stroke:{color};stroke-width:{self.svg.viewport_to_unit("1px")};fill:none;'
+
+        run = PathElement(d=str(path), style=style)
+        run.label = _('Running Stitch')
+        run.set(INKSTITCH_ATTRIBS['running_stitch_length_mm'], self.options.running_stitch_length_mm)
+        run.set(INKSTITCH_ATTRIBS['running_stitch_tolerance_mm'], self.options.running_stitch_tolerance_mm)
+        parent.insert(index, run)
+
+    def _merge_paths(self, last_element, element, path) -> bool:
         # option: merge line with paths
         merged = False
+        node = element.node
         if self._is_mergable(last_element, element):
             path.transform(Transform(get_correction_transform(last_element.node, True)), True)
-            path = last_element.node.get_path() + path[1:]
+            last_element_path = self._prepare_path(last_element, last_element.node.get_path())
+            path = last_element_path + path[1:]
             last_element.node.set('d', str(path))
-            path.transform(-Transform(get_correction_transform(last_element.node)), True)
+            path.transform(-Transform(get_correction_transform(last_element.node, True)), True)
             merged = True
         if self._is_mergable(element, last_element):
-            path.transform(Transform(get_correction_transform(node)), True)
-            path = path + node.get_path()[1:]
+            element_path = self._prepare_path(element, node.get_path())
+            path.transform(Transform(get_correction_transform(node, True)), True)
+            path = path + element_path[1:]
             node.set('d', str(path))
             if merged:
                 # remove last element (since it is merged)
@@ -186,21 +238,8 @@ class JumpToStroke(InkstitchExtension):
                 # remove parent group if empty
                 if len(last_parent) == 0:
                     last_parent.delete()
-            return
-
-        if merged:
-            return
-
-        # add simple stroke to connect elements
-        path.transform(Transform(get_correction_transform(node)), True)
-        color = element.color
-        style = f'stroke:{color};stroke-width:{self.svg.viewport_to_unit("1px")};fill:none;'
-
-        line = PathElement(d=str(path), style=style)
-        line.label = _('Running Stitch')
-        line.set(INKSTITCH_ATTRIBS['running_stitch_length_mm'], self.options.running_stitch_length_mm)
-        line.set(INKSTITCH_ATTRIBS['running_stitch_tolerance_mm'], self.options.running_stitch_tolerance_mm)
-        parent.insert(index, line)
+            merged = True
+        return merged
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* add color information for clones (and every element type which doesn't have one)
   grouped clones would throw an error otherwise
* fix issue with closed paths missing the last element when merged
* restrict merging for objects and paths with path-effects