### PR TITLE
guided fill: keep curve peaks

### DIFF
--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -31,12 +31,15 @@ from .utils.stitches import filter_small_stitches
 def guided_fill(fill, shape, guideline, anchor_line, starting_point, ending_point):
     guide_line = prepare_guide_line(guideline, shape, fill.guided_fill_strategy)
 
+    metadata = fill.get_inkstitch_metadata()
+    min_stitch_length = fill.min_stitch_length or metadata.get('min_stitch_len_mm') * PIXELS_PER_MM
+
     segments = intersect_region_with_grating_guideline(fill, shape, guide_line)
 
     if fill.guided_fill_strategy > 0 and segments:
         segments = connect_offset_lines(shape, segments, fill.row_spacing, fill.skip_last, fill.max_stitch_length)
 
-    segments = _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line)
+    segments = _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line, min_stitch_length)
 
     if not segments:
         return fallback(fill, shape, guideline, starting_point, ending_point)
@@ -64,8 +67,6 @@ def guided_fill(fill, shape, guideline, anchor_line, starting_point, ending_poin
         if any(fill.bean_stitch_repeats):
             # remove small stitches before applying any bean stitches
             # otherwise the back stitch may not end up at the correct position
-            metadata = fill.get_inkstitch_metadata()
-            min_stitch_length = fill.min_stitch_length or metadata.get('min_stitch_len_mm') * PIXELS_PER_MM
             stitches = filter_small_stitches(stitches, min_stitch_length)
 
             # add bean stitches, but ignore travel stitches
@@ -85,7 +86,7 @@ def fallback(fill, shape, guideline, starting_point, ending_point,):
     )]
 
 
-def _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line) -> list[list[tuple[float, ...]]]:
+def _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line, min_stitch_length) -> list[list[tuple[float, ...]]]:
 
     # sort segments so that they are well prepared for staggering
     segments = _sort_segments(shape, segments, fill.guided_fill_strategy, guide_line)
@@ -107,7 +108,7 @@ def _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line) ->
             # users have the option to use an anchor line to help defining the start and end of the linestrings
             # for the stitch positioning task
             if anchor_line is not None:
-                linestring, rolled = _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i)
+                linestring, rolled = _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i, min_stitch_length)
             if not rolled:
                 # we assume that all lines which possibly ends within the shape are actually rings (even when not recognized as such)
                 # take exterior of the shape, ignoring the holes. we connected everything to the exterior, so this should work
@@ -115,9 +116,11 @@ def _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line) ->
                 diff = linestring.difference(Polygon(shape.exterior))
                 if not diff.is_empty:
                     outside_point = take_only_line_strings(diff).geoms[0].interpolate(0.5, True)
-                    linestring = _apply_stagger(fill, LineString(roll_linear_ring(linestring, linestring.project(outside_point))), guide_line, i)
+                    linestring = _apply_stagger(
+                        fill, LineString(roll_linear_ring(linestring, linestring.project(outside_point))), guide_line, i, min_stitch_length
+                    )
         else:
-            linestring = _apply_stagger(fill, linestring, guide_line, i)
+            linestring = _apply_stagger(fill, linestring, guide_line, i, min_stitch_length)
 
         debug.log_line_string(linestring, "row", "blue")
 
@@ -135,7 +138,7 @@ def _stagger_and_cut_segments(fill, shape, segments, guide_line, anchor_line) ->
     return new_segments
 
 
-def _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i) -> tuple[LineString, bool]:
+def _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i, min_stitch_length) -> tuple[LineString, bool]:
     rolled = False
 
     # get intersection points
@@ -151,7 +154,7 @@ def _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i) -> t
 
     if len(intersection.geoms) == 1:
         # there is only one intersection, we can simply apply stitches
-        linestring = _apply_stagger(fill, linestring, guide_line, i)
+        linestring = _apply_stagger(fill, linestring, guide_line, i, min_stitch_length)
     else:
         # more than one intersection
         # split the segment into multiple paths and apply stitches individually
@@ -162,13 +165,13 @@ def _get_anchored_stitch_line(fill, linestring, guide_line, anchor_line, i) -> t
         linestring_coords: list[Point] = []
         for start, end in zip(projections[:-1], projections[1:]):
             line = substring(linestring, start, end)
-            stitched_line = _apply_stagger(fill, line, guide_line, i)
+            stitched_line = _apply_stagger(fill, line, guide_line, i, min_stitch_length)
             linestring_coords.extend(get_coordinates(stitched_line).tolist())
         linestring = LineString(linestring_coords)
     return linestring, rolled
 
 
-def _apply_stagger(fill, linestring, guide_line, i) -> LineString:
+def _apply_stagger(fill, linestring, guide_line, i, min_stitch_length) -> LineString:
     # we stagger by using a substring of the original line
     # then we reappend the first point (just in case we actually need it)
     num_staggers = fill.staggers
@@ -199,6 +202,7 @@ def _apply_stagger(fill, linestring, guide_line, i) -> LineString:
             fill.enable_random_stitch_length,
             fill.random_stitch_length_jitter,
             prng.join_args(fill.random_seed, i),
+            min_stitch_length,
             False)
     )
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -245,14 +245,18 @@ def take_stitch(
     return points[-1], None
 
 
-def stitch_curve_evenly_strict(
+def stitch_curve_evenly_strict(  # noqa C901
     points: typing.Sequence[Point],
     stitch_length: typing.List[float],
     tolerance: float,
+    min_stitch_length: float,
     stitch_length_pos: int = 0,
-    stitch_distance_passed: float = 0
+    stitch_distance_passed: float = 0,
 ) -> typing.Tuple[typing.List[Point], int, float]:
     """Split a curve into even-length stitches while handling curves correctly.
+
+    Adapts stitch lengths to the distance that already has been passed,
+    to keep a consistant stitch positioning when stitching rows of lines (with staggers).
 
     Includes end point but not start point.
     """
@@ -269,9 +273,18 @@ def stitch_curve_evenly_strict(
             stitch_len = max(0.1, stitch_len)
 
         stitch, newidx = take_stitch(last, points, i, stitch_len, tolerance)
-        i = newidx
         if stitch is not None:
-            stitches.append(stitch)
+            if not stitches or (stitches and stitch.distance(stitches[-1]) >= min_stitch_length):
+                if stitches and i is not None:
+                    distance_to_last_stitch = stitch.distance(stitches[-1])
+                    if distance_to_last_stitch > stitch_length[stitch_length_pos] + 0.001 and distance_to_last_stitch >= 2 * min_stitch_length:
+                        # we exceeded the maximum length and are able to split split the stitch in half
+                        # but we want don't want to simply split the stitch, but also to keep the original path in mind
+                        split_stitch, _ = take_stitch(last, points, i, distance_to_last_stitch / 2, tolerance)
+                        if split_stitch:
+                            stitches.append(split_stitch)
+                # skip when minimum stitch length isn't met
+                stitches.append(stitch)
             stitch_distance_passed += last.distance(stitch)
             # when we use this for fill stitch type such as guided fill where rows of lines are visibile,
             # we do not want to break the stitch pattern through shortcoming stitches
@@ -281,7 +294,13 @@ def stitch_curve_evenly_strict(
                 stitch_length_pos += 1
                 if stitch_length_pos >= len(stitch_length):
                     stitch_length_pos = 0
+            i = newidx
             last = stitch
+    distance_to_last_point = last.distance(points[-1])
+    if stitches and distance_to_last_point < min_stitch_length:
+        stitches.pop()
+    stitches.append(points[-1])
+    stitch_distance_passed += distance_to_last_point
     return stitches, stitch_length_pos, stitch_distance_passed
 
 
@@ -406,7 +425,7 @@ def path_to_curves(points: typing.List[Point], min_len: float):
     return curves
 
 
-def even_running_stitch(points, stitch_length, tolerance, adapt_to_length=True):
+def even_running_stitch(points, stitch_length, tolerance, min_stitch_length=0.1, adapt_to_length=True):
     """Turn a continuous path into a running stitch with even length.
 
     Creates stitches as close to even length as possible (including first and
@@ -429,7 +448,7 @@ def even_running_stitch(points, stitch_length, tolerance, adapt_to_length=True):
             )
         else:
             stitched_curve, last_stitch_length_pos, stitch_distance_passed = stitch_curve_evenly_strict(
-                curve, stitch_length, tolerance, last_stitch_length_pos, stitch_distance_passed
+                curve, stitch_length, tolerance, min_stitch_length, last_stitch_length_pos, stitch_distance_passed
             )
         stitches.extend(stitched_curve)
     return stitches
@@ -460,12 +479,12 @@ def random_running_stitch(points, stitch_length, tolerance, stitch_length_sigma,
     return stitches
 
 
-def running_stitch(points, stitch_length, tolerance, is_random, stitch_length_sigma, random_seed, adapt_to_length=True):
+def running_stitch(points, stitch_length, tolerance, is_random, stitch_length_sigma, random_seed, min_stitch_length=0.1, adapt_to_length=True):
     """Create a running stitch with a choice of algorithm."""
     if is_random:
         return random_running_stitch(points, stitch_length, tolerance, stitch_length_sigma, random_seed)
     else:
-        return even_running_stitch(points, stitch_length, tolerance, adapt_to_length)
+        return even_running_stitch(points, stitch_length, tolerance, min_stitch_length, adapt_to_length)
 
 
 def bean_stitch(stitches, repeats, tags_to_ignore=None):


### PR DESCRIPTION
Fixes #4476

Sends the minimum stitch length value to the stitch positioning algo, so they can be avoided in the first place.
For guided fill we still want to keep track of the distance passed, so we do not lose the stitch pattern when dividing the path into curves.

When we run the normal removal of stitches when the minimum stitch length isn't satisfied, we usually will remove the second stitch. When we want to keep the "peaks", we will need to make sure, that the previous stitch not below this value.