### PR TITLE
Update drawing_panel.py

### DIFF
--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -280,7 +280,7 @@ class DrawingPanel(wx.Panel):
             npp_brush = canvas.CreateBrush(wx.Brush(pen.GetColour()))
             canvas.SetBrush(npp_brush)
             for stitch in stitches:
-                canvas.DrawEllipse(stitch[0]-(npp_size // 2), stitch[1]-(npp_size // 2), npp_size, npp_size)
+                canvas.DrawEllipse(stitch[0]-(npp_size / 2), stitch[1]-(npp_size / 2), npp_size, npp_size)
 
     def clear(self):
         self.loaded = False

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -277,9 +277,10 @@ class DrawingPanel(wx.Panel):
     def draw_needle_penetration_points(self, canvas, pen, stitches):
         if self.view_panel.btnNpp.GetValue():
             npp_size = global_settings['simulator_npp_size'] * PIXELS_PER_MM * self.PIXEL_DENSITY
-            npp_pen = wx.Pen(pen.GetColour(), width=int(npp_size))
-            canvas.SetPen(npp_pen)
-            canvas.StrokeLineSegments(stitches, [(stitch[0] + 0.001, stitch[1]) for stitch in stitches])
+            npp_brush = canvas.CreateBrush(wx.Brush(pen.GetColour()))
+            canvas.SetBrush(npp_brush)
+            for stitch in stitches:
+                canvas.DrawEllipse(stitch[0]-(npp_size // 2), stitch[1]-(npp_size // 2), npp_size, npp_size)
 
     def clear(self):
         self.loaded = False


### PR DESCRIPTION
use real ellipse to draw the needle penetration point

Using StrokeLineSegments with segments of quasi null length is supposed to draw circles, but it fails to do so with some macos (at least it fails with mac M5 with macOS Tahoe). The needle penetration points can then be seen only if a large zoom is applied in the simulator windows

Using DrawEllipse solves the problem. It is said to be slower, but does not seem so much slower , but i'm not good at testing that.