### PR TITLE
Guided stitch position method

### DIFF
--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -408,7 +408,7 @@ class FillStitch(EmbroideryElement):
            select_items=[('fill_method', 'guided_fill')],
            sort_index=25)
     def stitch_position_method(self):
-        return self.get_param('stitch_position_method', 'flexible_stagger')
+        return self.get_param('stitch_position_method', 'flexible')
 
     @property
     @param('staggers',

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -400,8 +400,8 @@ class FillStitch(EmbroideryElement):
     @property
     @param('stitch_position_method',
            _('Stitch position method'),
-           tooltip=_('Flexible: adapts stitch lenghts accordingly to the tolerance value while keeping stitch length consistent on each curve segment.'
-                     'Flexible (stagger): adapts stitch length accordingly to the tolerance value while also optimizing for stagger.'),
+           tooltip=_('Flexible: adapts stitch lenghts accordingly to the tolerance value while keeping stitch length consistent on each curve '
+                     'segment.\nFlexible (stagger): adapts stitch length accordingly to the tolerance value while also optimizing for stagger.'),
            type='combo',
            default=0,
            options=stitch_position_options,

--- a/lib/elements/fill_stitch.py
+++ b/lib/elements/fill_stitch.py
@@ -392,13 +392,31 @@ class FillStitch(EmbroideryElement):
         end_row_spacing = self.get_float_param("end_row_spacing_mm")
         return max(end_row_spacing, 0) if end_row_spacing else None
 
+    stitch_position_options = [
+        ParamOption('flexible', _("Flexible")),
+        ParamOption('flexible_stagger', _("Flexible (stagger)")),
+    ]
+
+    @property
+    @param('stitch_position_method',
+           _('Stitch position method'),
+           tooltip=_('Flexible: adapts stitch lenghts accordingly to the tolerance value while keeping stitch length consistent on each curve segment.'
+                     'Flexible (stagger): adapts stitch length accordingly to the tolerance value while also optimizing for stagger.'),
+           type='combo',
+           default=0,
+           options=stitch_position_options,
+           select_items=[('fill_method', 'guided_fill')],
+           sort_index=25)
+    def stitch_position_method(self):
+        return self.get_param('stitch_position_method', 'flexible_stagger')
+
     @property
     @param('staggers',
            _('Stagger rows this many times before repeating'),
            tooltip=_('Length of the cycle by which successive stitch rows are staggered. '
                      'Fractional values are allowed and can have less visible diagonals than integer values.'),
            type='int',
-           sort_index=25,
+           sort_index=26,
            select_items=[('fill_method', 'tatami_fill'),
                          ('fill_method', 'guided_fill'),
                          ('fill_method', 'linear_gradient_fill'),

--- a/lib/stitches/guided_fill.py
+++ b/lib/stitches/guided_fill.py
@@ -193,6 +193,11 @@ def _apply_stagger(fill, linestring, guide_line, i, min_stitch_length) -> LineSt
     first_point = get_point(linestring, 0)
     points = [InkstitchPoint(*coord) for coord in substring(linestring, start, linestring.length).coords]
 
+    # adapt to length will split curve sections more evenly, which we want to flexible stitch length optimization
+    # however, if we want to optimize for staggering, we want to stay closer to the original stitch positions while still adding extra points
+    # to stay within the tolerance value
+    adapt_to_length = fill.stitch_position_method == 'flexible'
+
     return LineString(
         [first_point] +
         running_stitch(
@@ -203,7 +208,7 @@ def _apply_stagger(fill, linestring, guide_line, i, min_stitch_length) -> LineSt
             fill.random_stitch_length_jitter,
             prng.join_args(fill.random_seed, i),
             min_stitch_length,
-            False)
+            adapt_to_length)
     )
 
 

--- a/lib/svg/tags.py
+++ b/lib/svg/tags.py
@@ -100,6 +100,7 @@ inkstitch_attribs = [
     'row_spacing_mm',
     'end_row_spacing_mm',
     'skip_last',
+    'stitch_position_method',
     'staggers',
     'underlay_underpath',
     'underpath',


### PR DESCRIPTION
Ok, stitch positions on guided fill have changed much.
This sets back to the old behavior and adds the new one optionally.
Stitch position method:
- flexible (old behavior, default), adapts stitch lengths according to the tolerance value with a consistant stitch length on each curve segment
- flexible (stagger), adapts stitch lengths according to the tolerance value while also preserve staggers as good as possible

Depending on density and wildness of the guide line, the user can choose which methods fits the use case best.