### PR TITLE
Preserve element label when converting stroke to satin

### DIFF
--- a/lib/extensions/stroke_to_satin.py
+++ b/lib/extensions/stroke_to_satin.py
@@ -4,11 +4,12 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from itertools import chain
+from typing import List
 
 import inkex
 from shapely import geometry as shgeo
 
-from ..elements import SatinColumn, Stroke
+from ..elements import SatinColumn, Stroke, EmbroideryElement
 from ..elements.utils.stroke_to_satin import (convert_path_to_satin,
                                               set_first_node)
 from ..i18n import _
@@ -19,6 +20,17 @@ from .base import InkstitchExtension
 
 class StrokeToSatin(InkstitchExtension):
     """Convert a line to a satin column of the same width."""
+
+    @staticmethod
+    def _get_target_path_label(element: EmbroideryElement, paths: List[Stroke], i: int) -> str:
+        if element.node.label is None:
+            return None
+
+        if len(paths) == 1:
+            return element.node.label
+
+        return f"{element.node.label} ({i + 1})"
+
 
     def effect(self):
         if not self.get_elements():
@@ -43,7 +55,7 @@ class StrokeToSatin(InkstitchExtension):
             if element.is_closed_path:
                 set_first_node(paths, element.stroke_width)
 
-            for path in paths:
+            for i, path in enumerate(paths):
                 satin_paths = convert_path_to_satin(path, element.stroke_width, style_args)
 
                 if satin_paths is not None:
@@ -54,6 +66,8 @@ class StrokeToSatin(InkstitchExtension):
                     path_element.set('id', self.uniqueId("path"))
                     path_element.set('transform', correction_transform)
                     path_element.set('style', path_style)
+                    path_element.label = self._get_target_path_label(element, paths, i)
+
                     parent.insert(index, path_element)
 
             element.node.delete()

--- a/lib/extensions/stroke_to_satin.py
+++ b/lib/extensions/stroke_to_satin.py
@@ -31,7 +31,6 @@ class StrokeToSatin(InkstitchExtension):
 
         return f"{element.node.label} ({i + 1})"
 
-
     def effect(self):
         if not self.get_elements():
             return

--- a/lib/extensions/stroke_to_satin.py
+++ b/lib/extensions/stroke_to_satin.py
@@ -4,7 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from itertools import chain
-from typing import List
+from typing import Optional
 
 import inkex
 from shapely import geometry as shgeo
@@ -22,11 +22,11 @@ class StrokeToSatin(InkstitchExtension):
     """Convert a line to a satin column of the same width."""
 
     @staticmethod
-    def _get_target_path_label(element: EmbroideryElement, paths: List[Stroke], i: int) -> str:
+    def _get_target_path_label(element: EmbroideryElement, i: int, has_multiple_paths: bool) -> Optional[str]:
         if element.node.label is None:
             return None
 
-        if len(paths) == 1:
+        if not has_multiple_paths:
             return element.node.label
 
         return f"{element.node.label} ({i + 1})"
@@ -66,7 +66,7 @@ class StrokeToSatin(InkstitchExtension):
                     path_element.set('id', self.uniqueId("path"))
                     path_element.set('transform', correction_transform)
                     path_element.set('style', path_style)
-                    path_element.label = self._get_target_path_label(element, paths, i)
+                    path_element.label = self._get_target_path_label(element, i, has_multiple_paths=len(paths) > 1)
 
                     parent.insert(index, path_element)
 


### PR DESCRIPTION
# Background

I label all of my inkscape elements. When I run "Stroke to Satin", these labels are lost.

# Change

Instead of skipping label assignment on the element (which seems to fall back to the unique ID we generate), preserve the original element's label. If the original path results in multiple paths for the satin column, just add `(i + 1)` to the end of each. 

Example: 

<img width="235" height="739" alt="image" src="https://github.com/user-attachments/assets/9a4e7504-922d-4ab9-a4b4-f7be57f64156" />

I duplicated the bottom group of running stitches, selected the whole group, and hit stroke to satin to get the top group. You can see that "L eye", "R eye", and "head top" all turned into multiple paths and ended up with the (1), (2), etc

I could also be convinced to make groups when a given element would turn into multiple paths, but this preserves the flat tree behavior from before.

# Testing

Tested manually in inkscape. Doesn't look like there is UT coverage for StrokeToSatin so I didn't create any UTs.