### PR TITLE
cleanup: do not clear selection

### DIFF
--- a/lib/extensions/cleanup.py
+++ b/lib/extensions/cleanup.py
@@ -35,7 +35,6 @@ class Cleanup(InkstitchExtension):
         self.rm_groups = self.options.rm_groups
         self.dry_run = self.options.dry_run
 
-        self.svg.selection.clear()
         self.get_elements()
 
         self.elements_to_remove = set()

--- a/templates/cleanup.xml
+++ b/templates/cleanup.xml
@@ -23,7 +23,8 @@
                 gui-description="Only display labels and ids of affected elements and groups without removing them.">true</param>
         </page>
         <page name="info" gui-text="Help">
-            <label>Use this extension to remove small objects from the document.</label>
+            <label>Use this extension to remove small objects from the selection.
+                   With no selection, small element from the entire document will be removed.</label>
             <spacer />
             <label>More information on our website</label>
             <label appearance="url">https://inkstitch.org/docs/troubleshoot/#cleanup-document</label>


### PR DESCRIPTION
The cleanup document extension was designed to cleanup the entire document only. Therefore it removes active selections.
But sometimes it'd be helpful to be able to actually use a selection and there is no really any harm into allowing it.

So this changes the behavior into:
* active selection: remove elements smaller than given threshold values
* no selection: remove tiny elements from the entire document