### PR TITLE
Security: XML External Entity (XXE) Injection in lxml etree.parse

### DIFF
--- a/lib/extensions/lettering_remove_kerning.py
+++ b/lib/extensions/lettering_remove_kerning.py
@@ -26,8 +26,9 @@ class LetteringRemoveKerning(InkstitchExtension):
         for path in paths:
             if not os.path.isfile(path):
                 continue
+            parser = etree.XMLParser(resolve_entities=False, no_network=True, load_dtd=False)
             with open(path, 'r+', encoding="utf-8") as fontfile:
-                svg = etree.parse(fontfile)
+                svg = etree.parse(fontfile, parser)
                 xpath = ".//svg:font[1]"
                 kerning = svg.xpath(xpath, namespaces=NSS)
                 if kerning:


### PR DESCRIPTION
## Summary

Security: XML External Entity (XXE) Injection in lxml etree.parse

## Problem

**Severity**: `High` | **File**: `lib/extensions/lettering_remove_kerning.py:L26`

The `lettering_remove_kerning.py` extension uses `lxml.etree.parse` to parse SVG files provided by the user. `lxml` by default is vulnerable to XML External Entity (XXE) attacks, which can allow an attacker to read arbitrary files from the local system, cause denial of service, or in some cases, perform SSRF.

## Solution

Disable DTD processing and external entity resolution when parsing untrusted SVG files. Use a custom parser configuration like: `parser = etree.XMLParser(resolve_entities=False, no_network=True, load_dtd=False)` and pass it to `etree.parse(fontfile, parser)`.

## Changes

- `lib/extensions/lettering_remove_kerning.py` (modified)