### PR TITLE
Various type hinting improvements

### DIFF
--- a/lib/elements/clone.py
+++ b/lib/elements/clone.py
@@ -55,7 +55,7 @@ class Clone(EmbroideryElement):
            unit='deg',
            type='float')
     @cache
-    def clone_fill_angle(self) -> float:
+    def clone_fill_angle(self) -> float | None:
         return self.get_float_param('angle')
 
     @property

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -15,7 +15,6 @@ import numpy as np
 import shapely
 from inkex import BaseElement, Color, bezier, Path
 from shapely import Point as ShapelyPoint, Geometry
-from shapely.geometry.base import BaseGeometry
 from shapely.ops import nearest_points
 
 from ..commands import Command, find_commands
@@ -106,13 +105,14 @@ class EmbroideryElement(object):
     def get_param(self, param_id: str, default: TParam) -> str | TParam: ...
     @overload
     def get_param(self, param_id: str, default: None) -> Optional[str]: ...
+
     @cache
     def get_param(self, param_id: str, default: Optional[TParam]) -> str | Optional[TParam]:
         value = self.node.get(INKSTITCH_ATTRIBS[param_id], "").strip()
         return value or default
 
     @cache
-    def get_boolean_param(self, param_id: str, default: Optional[bool]=None) -> bool:
+    def get_boolean_param(self, param_id: str, default: Optional[bool] = None) -> bool:
         value = self.get_param(param_id, default)
 
         if isinstance(value, bool):
@@ -125,8 +125,9 @@ class EmbroideryElement(object):
     def get_float_param(self, param_id: str, default: float) -> float: ...
     @overload
     def get_float_param(self, param_id: str, default: None = None) -> Optional[float]: ...
+
     @cache
-    def get_float_param(self, param_id: str, default: Optional[float]=None) -> Optional[float]:
+    def get_float_param(self, param_id: str, default: Optional[float] = None) -> Optional[float]:
         value = None
         try:
             value_raw = self.get_param(param_id, default)
@@ -147,8 +148,9 @@ class EmbroideryElement(object):
     def get_int_param(self, param_id: str, default: int) -> int: ...
     @overload
     def get_int_param(self, param_id: str, default: None = None) -> Optional[int]: ...
+
     @cache
-    def get_int_param(self, param_id: str, default: Optional[int]=None) -> Optional[int]:
+    def get_int_param(self, param_id: str, default: Optional[int] = None) -> Optional[int]:
         try:
             value_raw = self.get_param(param_id, default)
             if value_raw is None:
@@ -166,7 +168,7 @@ class EmbroideryElement(object):
     # if a single number is given in the param, it will apply to both returned values.
     # Not cached the cache will crash if the default is a numpy array.
     # The property calling this will need to cache itself and can safely do so since it has no parameters
-    def get_split_float_param(self, param_id, default: tuple[float, float] | np.typing.NDArray[np.float64]=(0, 0)) -> np.typing.NDArray[np.float64]:
+    def get_split_float_param(self, param_id, default: tuple[float, float] | np.typing.NDArray[np.float64] = (0, 0)) -> np.typing.NDArray[np.float64]:
         default = np.array(default)
 
         raw = self.get_param(param_id, "")
@@ -190,7 +192,7 @@ class EmbroideryElement(object):
 
     # returns an array of multiple space separated int values
     @cache
-    def get_multiple_int_param(self, param_id: str, default: str="0"):
+    def get_multiple_int_param(self, param_id: str, default: str = "0"):
         try:
             value_parts_raw = self.get_param(param_id, default).split(" ")
             value_parts = [int(value) for value in value_parts_raw if value]
@@ -204,7 +206,7 @@ class EmbroideryElement(object):
 
     # returns an array of multiple space separated float values
     @cache
-    def get_multiple_float_param(self, param_id: str, default: str="0"):
+    def get_multiple_float_param(self, param_id: str, default: str = "0"):
         try:
             value_parts_raw = self.get_param(param_id, default).split(" ")
             value_parts = [float(value) for value in value_parts_raw if value]
@@ -216,7 +218,7 @@ class EmbroideryElement(object):
 
         return value_parts
 
-    def get_json_param(self, param_id: str, default: Optional[dict[TDictKey, TDictValue]]=None) -> dict[TDictKey, TDictValue]:
+    def get_json_param(self, param_id: str, default: Optional[dict[TDictKey, TDictValue]] = None) -> dict[TDictKey, TDictValue]:
         json_value = self.get_param(param_id, None)
         try:
             if json_value is not None:
@@ -835,7 +837,7 @@ class EmbroideryElement(object):
     def clip_shape(self):
         return get_clip_path(self.node)
 
-    def fatal(self, message: Optional[str], point_to_troubleshoot: bool=False):
+    def fatal(self, message: Optional[str], point_to_troubleshoot: bool = False):
         label = self.node.get(INKSCAPE_LABEL)
         node_id = self.node.get("id")
         if label:

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -8,12 +8,14 @@ import json
 import sys
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Callable, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar, Iterable, overload
 
 import inkex
 import numpy as np
-from inkex import BaseElement, Color, bezier
-from shapely import Point as ShapelyPoint
+import shapely
+from inkex import BaseElement, Color, bezier, Path
+from shapely import Point as ShapelyPoint, Geometry
+from shapely.geometry.base import BaseGeometry
 from shapely.ops import nearest_points
 
 from ..commands import Command, find_commands
@@ -33,6 +35,7 @@ from ..svg.tags import INKSCAPE_LABEL, INKSTITCH_ATTRIBS
 from ..utils import DotDict, Point, cache
 from ..utils.cache import (CacheKeyGenerator, get_stitch_plan_cache,
                            is_cache_disabled)
+from .validation import ValidationError, ValidationWarning
 
 
 class Param(object):
@@ -56,8 +59,14 @@ class Param(object):
         return "Param(%s)" % vars(self)
 
 
+TParam = TypeVar('TParam')
+TDictKey = TypeVar('TDictKey')
+TDictValue = TypeVar('TDictValue')
+
 # See https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 F = TypeVar('F', bound=Callable[..., Any])
+
+BasePath = list[tuple[float, float]]
 
 
 # Decorate a member function or property with information about
@@ -82,7 +91,7 @@ class EmbroideryElement(object):
         return self.node.get('id')
 
     @classmethod
-    def get_params(cls):
+    def get_params(cls) -> list[Param]:
         params = []
         for attr in dir(cls):
             prop = getattr(cls, attr)
@@ -93,43 +102,62 @@ class EmbroideryElement(object):
                     params.append(fget.param)
         return params
 
+    @overload
+    def get_param(self, param_id: str, default: TParam) -> str | TParam: ...
+    @overload
+    def get_param(self, param_id: str, default: None) -> Optional[str]: ...
     @cache
-    def get_param(self, param, default):
-        value = self.node.get(INKSTITCH_ATTRIBS[param], "").strip()
+    def get_param(self, param_id: str, default: Optional[TParam]) -> str | Optional[TParam]:
+        value = self.node.get(INKSTITCH_ATTRIBS[param_id], "").strip()
         return value or default
 
     @cache
-    def get_boolean_param(self, param, default=None):
-        value = self.get_param(param, default)
+    def get_boolean_param(self, param_id: str, default: Optional[bool]=None) -> bool:
+        value = self.get_param(param_id, default)
 
         if isinstance(value, bool):
             return value
         else:
-            return value and (value.lower() in ('yes', 'y', 'true', 't', '1'))
+            # have to wrap in bool() since falsy `value` would return None or an empty string
+            return bool(value and (value.lower() in ('yes', 'y', 'true', 't', '1')))
 
+    @overload
+    def get_float_param(self, param_id: str, default: float) -> float: ...
+    @overload
+    def get_float_param(self, param_id: str, default: None = None) -> Optional[float]: ...
     @cache
-    def get_float_param(self, param, default=None):
+    def get_float_param(self, param_id: str, default: Optional[float]=None) -> Optional[float]:
+        value = None
         try:
-            value = float(self.get_param(param, default))
+            value_raw = self.get_param(param_id, default)
+            if value_raw is not None:
+                value = float(value_raw)
         except (TypeError, ValueError):
             value = default
 
         if value is None:
             return value
 
-        if param.endswith('_mm'):
+        if param_id.endswith('_mm'):
             value = value * PIXELS_PER_MM
 
         return value
 
+    @overload
+    def get_int_param(self, param_id: str, default: int) -> int: ...
+    @overload
+    def get_int_param(self, param_id: str, default: None = None) -> Optional[int]: ...
     @cache
-    def get_int_param(self, param, default=None):
+    def get_int_param(self, param_id: str, default: Optional[int]=None) -> Optional[int]:
         try:
-            value = int(self.get_param(param, default))
+            value_raw = self.get_param(param_id, default)
+            if value_raw is None:
+                return default
+            value = int(value_raw)
         except (TypeError, ValueError):
             return default
 
-        if param.endswith('_mm'):
+        if param_id.endswith('_mm'):
             value = int(value * PIXELS_PER_MM)
 
         return value
@@ -137,11 +165,11 @@ class EmbroideryElement(object):
     # returns 2 float values as a numpy array
     # if a single number is given in the param, it will apply to both returned values.
     # Not cached the cache will crash if the default is a numpy array.
-    # The ppoperty calling this will need to cache itself and can safely do so since it has no parameters
-    def get_split_float_param(self, param, default=(0, 0)):
-        default = np.array(default)  # type coersion in case the default is a tuple
+    # The property calling this will need to cache itself and can safely do so since it has no parameters
+    def get_split_float_param(self, param_id, default: tuple[float, float] | np.typing.NDArray[np.float64]=(0, 0)) -> np.typing.NDArray[np.float64]:
+        default = np.array(default)
 
-        raw = self.get_param(param, "")
+        raw = self.get_param(param_id, "")
         parts = raw.split()
         try:
             if len(parts) == 0:
@@ -157,60 +185,63 @@ class EmbroideryElement(object):
             return default
 
     # not cached
-    def get_split_mm_param_as_px(self, param, default):
-        return self.get_split_float_param(param, default) * PIXELS_PER_MM
+    def get_split_mm_param_as_px(self, param_id: str, default):
+        return self.get_split_float_param(param_id, default) * PIXELS_PER_MM
 
     # returns an array of multiple space separated int values
     @cache
-    def get_multiple_int_param(self, param, default="0"):
-        params = self.get_param(param, default).split(" ")
+    def get_multiple_int_param(self, param_id: str, default: str="0"):
         try:
-            params = [int(param) for param in params if param]
+            value_parts_raw = self.get_param(param_id, default).split(" ")
+            value_parts = [int(value) for value in value_parts_raw if value]
         except (TypeError, ValueError):
-            params = [int(default)]
+            value_parts = [int(default)]
 
-        if param.endswith('_mm'):
-            params = [value * PIXELS_PER_MM for value in params]
+        if param_id.endswith('_mm'):
+            value_parts = [value * PIXELS_PER_MM for value in value_parts]
 
-        return params
+        return value_parts
 
     # returns an array of multiple space separated float values
     @cache
-    def get_multiple_float_param(self, param, default="0"):
-        params = self.get_param(param, default).split(" ")
+    def get_multiple_float_param(self, param_id: str, default: str="0"):
         try:
-            params = [float(param) for param in params if param]
+            value_parts_raw = self.get_param(param_id, default).split(" ")
+            value_parts = [float(value) for value in value_parts_raw if value]
         except (TypeError, ValueError):
-            params = [float(default)]
+            value_parts = [float(default)]
 
-        if param.endswith('_mm'):
-            params = [value * PIXELS_PER_MM for value in params]
+        if param_id.endswith('_mm'):
+            value_parts = [value * PIXELS_PER_MM for value in value_parts]
 
-        return params
+        return value_parts
 
-    def get_json_param(self, param, default=None):
-        json_value = self.get_param(param, None)
+    def get_json_param(self, param_id: str, default: Optional[dict[TDictKey, TDictValue]]=None) -> dict[TDictKey, TDictValue]:
+        json_value = self.get_param(param_id, None)
         try:
-            return json.loads(json_value, object_hook=DotDict)
+            if json_value is not None:
+                return json.loads(json_value, object_hook=DotDict)
         except (json.JSONDecodeError, TypeError):
-            if default is None:
-                return DotDict()
-            else:
-                return DotDict(default)
+            pass
 
-    def set_json_param(self, param, value):
+        if default is None:
+            return DotDict()
+        else:
+            return DotDict(default)
+
+    def set_json_param(self, param_id: str, value: Any):
         json_value = json.dumps(value)
-        self.set_param(param, json_value)
+        self.set_param(param_id, json_value)
 
-    def set_param(self, name, value):
+    def set_param(self, name: str, value: Any):
         # Sets a param on the node backing this element. Used by params dialog.
         # After calling, this element is invalid due to caching and must be re-created to use the new value.
-        param = INKSTITCH_ATTRIBS[name]
-        self.node.set(param, str(value))
+        param_id = INKSTITCH_ATTRIBS[name]
+        self.node.set(param_id, str(value))
 
-    def remove_param(self, name):
-        param = INKSTITCH_ATTRIBS[name]
-        del self.node.attrib[param]
+    def remove_param(self, name: str):
+        param_id = INKSTITCH_ATTRIBS[name]
+        del self.node.attrib[param_id]
 
     @cache
     def _get_specified_style(self):
@@ -224,19 +255,19 @@ class EmbroideryElement(object):
             style = None
         return style
 
-    def _get_color(self, node, color_location, default=None):
+    def _get_color(self, node: BaseElement, color_location: Any, default=None) -> Optional[Color]:
         try:
             color = node.get_computed_style(color_location)
             if isinstance(color, inkex.LinearGradient) and len(color.stops) == 1:
                 # Inkscape swatches set as a linear gradient with only one stop color
                 # Ink/Stitch should render the color correctly
-                color = self._get_color(color.stops[0], "stop-color", default)
+                return self._get_color(color.stops[0], "stop-color", default)
+            return color
         except (inkex.ColorError, ValueError):
             # A color error could show up, when an element has an unrecognized color name
             # A value error could show up, when for example when an element links to a non-existent gradient
             # TODO: This will also apply to currentcolor and alike which will not render
-            color = default
-        return color
+            return default
 
     @cache
     def get_inkstitch_metadata(self):
@@ -277,18 +308,18 @@ class EmbroideryElement(object):
         # vector completely cancels out the rotation, scale, and skew components.
         zero = (0, 0)
         zero = inkex.Transform.apply_to_point(node_transform, zero)
-        translate = Point(*zero)
+        translate = Point.from_vector2d(zero)
 
         # Next, see how the transform affects unit vectors in the X and Y axes.  We
         # need to subtract off the translation or it will affect the magnitude of
         # the resulting vector, which we don't want.
         unit_x = (1, 0)
         unit_x = inkex.Transform.apply_to_point(node_transform, unit_x)
-        sx = (Point(*unit_x) - translate).length()
+        sx = (Point.from_vector2d(unit_x) - translate).length()
 
         unit_y = (0, 1)
         unit_y = inkex.Transform.apply_to_point(node_transform, unit_y)
-        sy = (Point(*unit_y) - translate).length()
+        sy = (Point.from_vector2d(unit_y) - translate).length()
 
         # Take the average as a best guess.
         node_scale = (sx + sy) / 2.0
@@ -363,7 +394,7 @@ class EmbroideryElement(object):
            options=LOCK_DEFAULTS['start'],
            sort_index=204)
     def lock_start(self):
-        return self.get_param('lock_start', "half_stitch")
+        return self.get_param('lock_start', 'half_stitch')
 
     @property
     @param('lock_custom_start',
@@ -536,11 +567,11 @@ class EmbroideryElement(object):
 
     @property
     @cache
-    def paths(self):
+    def paths(self) -> list[BasePath]:
         return self.flatten(self.parse_path())
 
     @property
-    def shape(self):
+    def shape(self) -> Geometry:
         raise NotImplementedError("INTERNAL ERROR: %s must implement shape()", self.__class__)
 
     @property
@@ -596,10 +627,10 @@ class EmbroideryElement(object):
         # ignore multiple anchor lines
         return anchor_lines["stroke"][0].geoms[0]
 
-    def strip_control_points(self, subpath):
+    def strip_control_points(self, subpath: list[tuple[Any, tuple[float, float], Any]]) -> BasePath:
         return [point for control_before, point, control_after in subpath]
 
-    def flatten(self, path):
+    def flatten(self, path: Path) -> list[BasePath]:
         """approximate a path containing beziers with a series of points"""
 
         path = deepcopy(path)
@@ -691,8 +722,8 @@ class EmbroideryElement(object):
 
     def get_params_and_values(self):
         params = {}
-        for param in self.get_params():
-            params[param.name] = self.get_param(param.name, param.default)
+        for param_definition in self.get_params():
+            params[param_definition.name] = self.get_param(param_definition.name, param_definition.default)
 
         return params
 
@@ -721,7 +752,7 @@ class EmbroideryElement(object):
         return gradient
 
     def _get_tartan_key_data(self):
-        return (self.node.get('inkstitch:tartan', None))
+        return self.node.get('inkstitch:tartan', None)
 
     def get_cache_key_data(self, previous_stitch, next_element):
         return []
@@ -781,8 +812,8 @@ class EmbroideryElement(object):
         debug.log(f"ending {self.node.get('id')} {self.node.get(INKSCAPE_LABEL)}")
         return stitch_groups
 
-    def next_stitch(self, next_element):
-        next_stitch = None
+    def next_stitch(self, next_element: Optional[EmbroideryElement]) -> Optional[shapely.Point]:
+        next_stitch: Optional[shapely.Point] = None
         if next_element is not None and self.uses_next_element():
             # in fact we really only try an approximation to the next stitch
             if next_element.uses_previous_stitch():
@@ -792,7 +823,9 @@ class EmbroideryElement(object):
                     pass
             else:
                 try:
-                    next_stitch = nearest_points(next_element.first_stitch, self.shape)[1]
+                    next_first_stitch = next_element.first_stitch
+                    if next_first_stitch is not None:
+                        next_stitch = nearest_points(next_first_stitch, self.shape)[1]
                 except (ValueError, AttributeError):
                     pass
         return next_stitch
@@ -802,15 +835,18 @@ class EmbroideryElement(object):
     def clip_shape(self):
         return get_clip_path(self.node)
 
-    def fatal(self, message, point_to_troubleshoot=False):
+    def fatal(self, message: Optional[str], point_to_troubleshoot: bool=False):
         label = self.node.get(INKSCAPE_LABEL)
-        id = self.node.get("id")
+        node_id = self.node.get("id")
         if label:
-            name = "%s (%s)" % (label, id)
+            name = "%s (%s)" % (label, node_id)
         else:
-            name = id
+            name = node_id
 
-        error_msg = f"{name}: {message}"
+        error_msg = name
+        if message:
+            error_msg += f": {message}"
+
         if point_to_troubleshoot:
             error_msg += "\n\n%s" % _("Please run Extensions > Ink/Stitch > Troubleshoot > Troubleshoot objects. "
                                       "This will show you the exact location of the problem.")
@@ -832,7 +868,7 @@ class EmbroideryElement(object):
 
             raise InkstitchException(format_uncaught_exception())
 
-    def validation_errors(self):
+    def validation_errors(self) -> Iterable[ValidationError]:
         """Return a list of errors with this Element.
 
         Validation errors will prevent the Element from being stitched.
@@ -841,7 +877,7 @@ class EmbroideryElement(object):
         """
         return []
 
-    def validation_warnings(self):
+    def validation_warnings(self) -> Iterable[ValidationWarning]:
         """Return a list of warnings about this Element.
 
         Validation warnings don't prevent the Element from being stitched but
@@ -852,11 +888,7 @@ class EmbroideryElement(object):
         return []
 
     def is_valid(self):
-        # We have to iterate since it could be a generator.
-        for error in self.validation_errors():
-            return False
-
-        return True
+        return len(list(self.validation_errors())) == 0
 
     def validate(self):
         """Print an error message and exit if this Element is invalid."""

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -6,7 +6,7 @@
 import itertools
 from copy import deepcopy
 from itertools import chain
-from typing import List, Tuple, Optional, cast, Sequence, overload
+from typing import List, Tuple, Optional, Sequence, overload
 
 import numpy as np
 from inkex import Path, Vector2d
@@ -994,10 +994,11 @@ class SatinColumn(EmbroideryElement):
         return self._coordinates_to_satin(self.filtered_subpaths)
 
     @overload
-    def split(self, split_point: float | Point | Vector2d, cut_points: Optional[Sequence[Point | shgeo.Point]]=None): ...
+    def split(self, split_point: float | Point | Vector2d, cut_points: Optional[Sequence[Point | shgeo.Point]] = None): ...
     @overload
     def split(self, split_point: None, cut_points: Sequence[Point | shgeo.Point]): ...
-    def split(self, split_point: Optional[float | Point | Vector2d], cut_points: Optional[Sequence[Point | shgeo.Point]]=None):
+
+    def split(self, split_point: Optional[float | Point | Vector2d], cut_points: Optional[Sequence[Point | shgeo.Point]] = None):
         """Split a satin into two satins at the specified point
 
         split_point is a point on or near one of the rails, not at one of the
@@ -1241,7 +1242,8 @@ class SatinColumn(EmbroideryElement):
             return max(abs(d0 * normal), abs(d1 * normal))
 
     @debug.time
-    def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float]=(0, 0), offset_proportional: tuple[float, float]=(0, 0), use_random: bool=False,
+    def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float] = (0, 0),
+                             offset_proportional: tuple[float, float] = (0, 0), use_random: bool = False,
                              ) -> List[Tuple[Point, Point]]:
         # Take a section from each rail in turn, and plot out an equal number
         # of points on both rails.  Return the points plotted. The points will
@@ -1352,7 +1354,8 @@ class SatinColumn(EmbroideryElement):
 
         return pairs
 
-    def _connect_stitch_group_with_point(self, first_stitch_group: StitchGroup, start_point: Point | Vector2d, end_point: Optional[Point | Vector2d]= None) -> StitchGroup:
+    def _connect_stitch_group_with_point(self, first_stitch_group: StitchGroup, start_point: Point | Vector2d,
+                                         end_point: Optional[Point | Vector2d] = None) -> StitchGroup:
         start_stitch_group = StitchGroup(
             color=self.color,
             stitches=[Stitch(*start_point)]
@@ -1997,7 +2000,7 @@ class SatinColumn(EmbroideryElement):
             return ordered_stitch_groups
         return stitch_groups
 
-    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup]=None, next_element: Optional[EmbroideryElement]=None):
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup] = None, next_element: Optional[EmbroideryElement] = None):
         # Stitch a variable-width satin column, zig-zagging between two paths.
         # The algorithm will draw zigzags between each consecutive pair of
         # beziers.  The boundary points between beziers serve as "checkpoints",

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -10,11 +10,12 @@ from typing import List, Tuple, Optional, Sequence, overload
 
 import numpy as np
 from inkex import Path, Vector2d
-from shapely import affinity as shaffinity
+from shapely import affinity as shaffinity, LineString
 from shapely import geometry as shgeo
 from shapely import set_precision
 from shapely.ops import nearest_points, substring
 
+from lib.utils import AnyPointType
 from ..debug.debug import debug
 from ..i18n import _
 from ..metadata import InkStitchMetadata
@@ -1392,8 +1393,8 @@ class SatinColumn(EmbroideryElement):
             stitches=[Point(*end_point)]
         )
 
-    def _do_underlay_stitch_groups(self, top_layer, end_point):
-        stitch_groups = []
+    def _do_underlay_stitch_groups(self, top_layer: StitchGroup, end_point: Optional[Point]) -> list[StitchGroup]:
+        stitch_groups: list[StitchGroup] = []
         if self.center_walk_underlay:
             stitch_groups.extend(self.do_center_walk(end_point))
 
@@ -1405,16 +1406,16 @@ class SatinColumn(EmbroideryElement):
 
         return stitch_groups
 
-    def _to_stitch_group(self, linestring, tags, reverse=False):
+    def _to_stitch_group(self, linestring: LineString, tags, reverse: bool=False) -> StitchGroup:
         if reverse:
             linestring = linestring.reverse()
         return StitchGroup(
                 color=self.color,
                 tags=tags,
-                stitches=[Stitch(*coord) for coord in linestring.coords]
+                stitches=[Stitch.from_coordinates(coord) for coord in linestring.coords]
             )
 
-    def do_contour_underlay(self, top_layer, end_point):
+    def do_contour_underlay(self, top_layer: StitchGroup, end_point: Optional[Point]):
         # "contour walk" underlay: do stitches up one side and down the
         # other. if the two sides are far away, adding a running stitch to travel
         # in between avoids a long jump or a trim.
@@ -1457,7 +1458,7 @@ class SatinColumn(EmbroideryElement):
             second_side.reverse()
 
         if end_point:
-            stitch_groups = []
+            stitch_groups: list[StitchGroup] = []
             tags = ("satin_column", "satin_column_underlay", "satin_contour_underlay")
             first_linestring = shgeo.LineString(first_side)
             first_start, first_end = self._split_linestring_at_end_point(first_linestring, end_point)
@@ -1497,7 +1498,7 @@ class SatinColumn(EmbroideryElement):
             shortened_line = self._apply_push_comp(line, start, 0)
         return [Point(*point) for point in shortened_line.coords]
 
-    def do_center_walk(self, end_point):
+    def do_center_walk(self, end_point: Optional[Point]):
         # Center walk underlay is just a running stitch down and back on the
         # center line between the bezier curves.
         repeats = self.center_walk_underlay_repeats
@@ -1529,7 +1530,7 @@ class SatinColumn(EmbroideryElement):
                     stitch_group.stitches += stitch_group.stitches[:stitch_count]
         return stitch_groups
 
-    def do_zigzag_underlay(self, end_point):
+    def do_zigzag_underlay(self, end_point: Optional[Point]):
         # zigzag underlay, usually done at a much lower density than the
         # satin itself.  It looks like this:
         #
@@ -1586,19 +1587,17 @@ class SatinColumn(EmbroideryElement):
         stitch_group.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
         return stitch_group
 
-    def _do_top_layer_stitch_group(self):
+    def _do_top_layer_stitch_group(self) -> StitchGroup:
         if self.satin_method == 'e_stitch':
-            stitch_group = self.do_e_stitch()
+            return self.do_e_stitch()
         elif self.satin_method == 's_stitch':
-            stitch_group = self.do_s_stitch()
+            return self.do_s_stitch()
         elif self.satin_method == 'zigzag':
-            stitch_group = self.do_zigzag()
+            return self.do_zigzag()
         else:
-            stitch_group = self.do_satin()
+            return self.do_satin()
 
-        return stitch_group
-
-    def _split_linestring_at_end_point(self, linestring, end_point):
+    def _split_linestring_at_end_point(self, linestring: LineString, end_point: Point):
         split_line = set_precision(shgeo.LineString(self.find_cut_points(end_point)), 0.00001)
         if not split_line:
             start = shgeo.Point(linestring.coords[0])
@@ -1608,11 +1607,11 @@ class SatinColumn(EmbroideryElement):
                 return linestring, shgeo.Point(linestring.coords[-1])
         split_point = nearest_points(linestring, split_line)[0]
         project = linestring.project(split_point)
-        start = substring(linestring, 0, project)
-        end = substring(linestring, project, linestring.length)
-        return start, end
+        first_half = substring(linestring, 0, project)
+        second_half = substring(linestring, project, linestring.length)
+        return first_half, second_half
 
-    def _split_top_layer(self, stitch_group, end_point):
+    def _split_top_layer(self, stitch_group: StitchGroup, end_point: Point):
         top_layer = shgeo.LineString(stitch_group.stitches)
         start, end = self._split_linestring_at_end_point(top_layer, end_point)
         stitch_group2 = deepcopy(stitch_group)
@@ -1838,7 +1837,7 @@ class SatinColumn(EmbroideryElement):
             return self._get_split_points_staggered(*args, **kwargs), None
 
     def _get_split_points_default(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False, min_split_length=None,
-                                  seed=None, row_num=0, from_end=None):
+                                  seed=None):
         if not length:
             return ([], None)
         if min_split_length is None:
@@ -1864,8 +1863,7 @@ class SatinColumn(EmbroideryElement):
     def _get_split_points_simple(self, *args, **kwargs):
         return self._get_split_points_staggered(*args, **kwargs, _staggers=1)
 
-    def _get_split_points_staggered(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False, min_split_length=None,
-                                    seed=None, row_num=0, from_end=False, _staggers=None):
+    def _get_split_points_staggered(self, a, b, a_short, b_short, length, row_num=0, from_end=False, _staggers=None):
         if not length or a.distance(b) <= length:
             return []
 
@@ -1908,7 +1906,7 @@ class SatinColumn(EmbroideryElement):
 
         return shortened
 
-    def _get_offset_px(self, point, other_point, last_point, inset_index, max_stitch_length):
+    def _get_offset_px(self, point: Point, other_point: Point, last_point: Point, inset_index: int, max_stitch_length: float):
         if inset_index >= len(self.short_stitch_inset):
             inset_index = 0
 
@@ -1928,17 +1926,14 @@ class SatinColumn(EmbroideryElement):
 
         return offset_px, last_point, inset_index
 
-    def _get_inset_point(self, point1, point2, distance_fraction):
-        return point1 * (1 - distance_fraction) + point2 * distance_fraction
-
-    def add_running_stitches(self, start_stitch, end_stitch, stitch_group):
+    def add_running_stitches(self, start_stitch: Point, end_stitch: Point, stitch_group: StitchGroup) -> None:
         # add points in the distance of running stitch length
         if end_stitch.distance(start_stitch) > self.running_stitch_length:
             split_points = running_stitch.split_segment_even_dist(start_stitch, end_stitch, self.running_stitch_length)
             stitch_group.add_stitches(split_points)
             stitch_group.add_stitch(end_stitch)
 
-    def connect_and_add(self, stitch_group, next_stitch_group):
+    def connect_and_add(self, stitch_group: StitchGroup, next_stitch_group: StitchGroup) -> StitchGroup:
         if not next_stitch_group.stitches:
             return stitch_group
         if stitch_group.stitches:
@@ -1952,28 +1947,39 @@ class SatinColumn(EmbroideryElement):
             return None
         return shgeo.Point(self.line_string_rails[0].coords[0])
 
-    def start_point(self, last_stitch_group):
+    def start_point(self, last_stitch_group: Optional[StitchGroup]) -> Optional[Point]:
         # To cover possible tie ins are covered, it is best to start from the center line within the satin
         start_point = self._get_command_point('starting_point')
+
         if start_point is None and self.start_at_nearest_point and last_stitch_group is not None:
             last_point = shgeo.Point(*last_stitch_group.stitches[-1])
-            start_point = nearest_points(last_point, self.offset_center_line)[1]
+            nearest_point = nearest_points(last_point, self.offset_center_line)[1]
             # if starting from the centerline will produce a jump stitch and the actual distance to the last element doesn't exceed the minimum jump
             # stitch length, allow this satin to start from the outline
-            if last_point.distance(start_point) > self.min_jump_stitch_len and self.compensated_shape.distance(last_point) < self.min_jump_stitch_len:
-                start_point = nearest_points(self.compensated_shape, last_point)[0]
-            start_point = Point(*list(start_point.coords[0]))
-        return start_point
+            if last_point.distance(nearest_point) > self.min_jump_stitch_len and self.compensated_shape.distance(last_point) < self.min_jump_stitch_len:
+                nearest_point = nearest_points(self.compensated_shape, last_point)[0]
+            return Point(*list(nearest_point.coords[0]))
 
-    def end_point(self, next_stitch):
-        end_point = self._get_command_point('ending_point')
-        if end_point is None and self.end_at_nearest_point and next_stitch is not None:
-            end_point = nearest_points(next_stitch, self.compensated_shape)[1]
-            end_point = Point(*list(end_point.coords[0]))
+        return Point.from_other(start_point)
+
+    @overload
+    def end_point(self, next_stitch: shgeo.Point) -> Point: ...
+    @overload
+    def end_point(self, next_stitch: None) -> Optional[Point]: ...
+
+    def end_point(self, next_stitch: Optional[shgeo.Point]) -> Optional[Point]:
+        command_point = self._get_command_point('ending_point')
+        end_point: AnyPointType | None = command_point
+
+        if command_point is None and self.end_at_nearest_point and next_stitch is not None:
+            nearest_point = nearest_points(next_stitch, self.compensated_shape)[1]
+            end_point = Point(*list(nearest_point.coords[0]))
+
         # if we are already near to the end, we won't need to specify an ending point
         if end_point and shgeo.Point(self.offset_center_line.coords[-1]).distance(shgeo.Point(end_point)) < 5:
             end_point = None
-        return end_point
+
+        return Point.from_other(end_point)
 
     def uses_previous_stitch(self):
         if not self.start_at_nearest_point or self.get_command('starting_point'):
@@ -2000,7 +2006,7 @@ class SatinColumn(EmbroideryElement):
             return ordered_stitch_groups
         return stitch_groups
 
-    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup] = None, next_element: Optional[EmbroideryElement] = None):
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup] = None, next_element: Optional[EmbroideryElement] = None) -> list[StitchGroup]:
         # Stitch a variable-width satin column, zig-zagging between two paths.
         # The algorithm will draw zigzags between each consecutive pair of
         # beziers.  The boundary points between beziers serve as "checkpoints",
@@ -2008,7 +2014,7 @@ class SatinColumn(EmbroideryElement):
 
         start_point = self.start_point(last_stitch_group)
         end_point = self.end_point(self.next_stitch(next_element))
-        stitch_groups = []
+        stitch_groups: list[StitchGroup] = []
 
         # top layer
         top_layer_group = self._do_top_layer_stitch_group()

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -1406,7 +1406,7 @@ class SatinColumn(EmbroideryElement):
 
         return stitch_groups
 
-    def _to_stitch_group(self, linestring: LineString, tags, reverse: bool=False) -> StitchGroup:
+    def _to_stitch_group(self, linestring: LineString, tags, reverse: bool = False) -> StitchGroup:
         if reverse:
             linestring = linestring.reverse()
         return StitchGroup(
@@ -1956,7 +1956,8 @@ class SatinColumn(EmbroideryElement):
             nearest_point = nearest_points(last_point, self.offset_center_line)[1]
             # if starting from the centerline will produce a jump stitch and the actual distance to the last element doesn't exceed the minimum jump
             # stitch length, allow this satin to start from the outline
-            if last_point.distance(nearest_point) > self.min_jump_stitch_len and self.compensated_shape.distance(last_point) < self.min_jump_stitch_len:
+            if (last_point.distance(nearest_point) > self.min_jump_stitch_len
+                    and self.compensated_shape.distance(last_point) < self.min_jump_stitch_len):
                 nearest_point = nearest_points(self.compensated_shape, last_point)[0]
             return Point(*list(nearest_point.coords[0]))
 
@@ -2006,7 +2007,8 @@ class SatinColumn(EmbroideryElement):
             return ordered_stitch_groups
         return stitch_groups
 
-    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup] = None, next_element: Optional[EmbroideryElement] = None) -> list[StitchGroup]:
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup] = None,
+                         next_element: Optional[EmbroideryElement] = None) -> list[StitchGroup]:
         # Stitch a variable-width satin column, zig-zagging between two paths.
         # The algorithm will draw zigzags between each consecutive pair of
         # beziers.  The boundary points between beziers serve as "checkpoints",

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -6,10 +6,10 @@
 import itertools
 from copy import deepcopy
 from itertools import chain
-from typing import List, Tuple
+from typing import List, Tuple, Optional, cast, Sequence, overload
 
 import numpy as np
-from inkex import Path
+from inkex import Path, Vector2d
 from shapely import affinity as shaffinity
 from shapely import geometry as shgeo
 from shapely import set_precision
@@ -28,6 +28,9 @@ from ..utils.threading import check_stop_flag
 from .element import PIXELS_PER_MM, EmbroideryElement, param
 from .utils.stroke_to_satin import convert_path_to_satin, set_first_node
 from .validation import ValidationError, ValidationWarning
+
+
+ListOfPairs = list[tuple[Point, Point]]
 
 
 class NotStitchableError(ValidationError):
@@ -188,7 +191,7 @@ class SatinColumn(EmbroideryElement):
            unit="mm",
            sort_index=94)
     def max_stitch_length_px(self):
-        return self.get_float_param("max_stitch_length_mm") or None
+        return self.get_float_param("max_stitch_length_mm")
 
     @property
     @param('random_split_jitter_percent',
@@ -215,9 +218,10 @@ class SatinColumn(EmbroideryElement):
            select_items=[('split_method', 'default')],
            default='', type='float', unit='mm', sort_index=97)
     def min_random_split_length_px(self):
-        if self.max_stitch_length_px is None:
+        max_stitch_length_px = self.max_stitch_length_px
+        if max_stitch_length_px is None:
             return None
-        return min(self.max_stitch_length_px, self.get_float_param('min_random_split_length_mm', self.max_stitch_length_px))
+        return min(max_stitch_length_px, self.get_float_param('min_random_split_length_mm', max_stitch_length_px))
 
     @property
     @param('split_staggers',
@@ -335,7 +339,7 @@ class SatinColumn(EmbroideryElement):
     def reverse_rails(self):
         return self.get_param('reverse_rails', 'automatic')
 
-    def _get_rails_to_reverse(self):
+    def _get_rails_to_reverse(self) -> tuple[bool, bool]:
         choice = self.reverse_rails
 
         if choice == 'first':
@@ -708,7 +712,7 @@ class SatinColumn(EmbroideryElement):
 
     @property
     @cache
-    def line_string_rails(self):
+    def line_string_rails(self) -> tuple[shgeo.LineString, ...]:
         """The rails, as LineStrings."""
         paths = [set_precision(shgeo.LineString(rail), 0.00001) for rail in self.rails]
 
@@ -748,7 +752,7 @@ class SatinColumn(EmbroideryElement):
 
     @cache
     def _synthesize_rungs(self):
-        # self.rails may contain additoinal nodes through flattening
+        # self.rails may contain additional nodes through flattening
         # at this point we know that we only have two paths, both paths are rails
         # so we can access the original nodes by parsing and filtering the original path
         paths = Path(self.parse_path()).break_apart()
@@ -989,7 +993,11 @@ class SatinColumn(EmbroideryElement):
 
         return self._coordinates_to_satin(self.filtered_subpaths)
 
-    def split(self, split_point, cut_points=None):
+    @overload
+    def split(self, split_point: float | Point | Vector2d, cut_points: Optional[Sequence[Point | shgeo.Point]]=None): ...
+    @overload
+    def split(self, split_point: None, cut_points: Sequence[Point | shgeo.Point]): ...
+    def split(self, split_point: Optional[float | Point | Vector2d], cut_points: Optional[Sequence[Point | shgeo.Point]]=None):
         """Split a satin into two satins at the specified point
 
         split_point is a point on or near one of the rails, not at one of the
@@ -1008,25 +1016,23 @@ class SatinColumn(EmbroideryElement):
         """
 
         if cut_points is None:
+            if split_point is None:
+                raise ValueError("split_point cannot be None when cut_points is None")
             cut_points = self.find_cut_points(split_point)
-        path_lists = self._cut_rails(cut_points)
 
         # prevent error when split points lies at the start or end of the satin column
-        cleaned_path_lists = path_lists
-        for i, path_list in enumerate(path_lists):
-            if None in path_list:
-                cleaned_path_lists[i] = None
-                continue
-            for path in path_list:
-                if shgeo.LineString(path).length < self.zigzag_spacing:
-                    cleaned_path_lists[i] = None
-        path_lists = cleaned_path_lists
+        path_lists: list[Optional[list[shgeo.LineString]]] = []
+        for path_list in self._cut_rails(cut_points):
+            if any(path is None or shgeo.LineString(path).length < self.zigzag_spacing for path in path_list):
+                path_lists.append(None)
+            else:
+                path_lists.append(path_list)
 
         self._assign_rungs_to_split_rails(path_lists)
         self._add_rungs_if_necessary(path_lists)
         return [self._path_list_to_satins(path_list) for path_list in path_lists]
 
-    def find_cut_points(self, split_point):
+    def find_cut_points(self, split_point: float | Point | Vector2d):
         """Find the points on each satin corresponding to the split point.
 
         split_point is a point that is near but not necessarily touching one
@@ -1042,7 +1048,7 @@ class SatinColumn(EmbroideryElement):
         """
 
         # like in do_satin()
-        points = list(chain.from_iterable(self.plot_points_on_rails(self.zigzag_spacing)))
+        points: list[Point] = list(chain.from_iterable(self.plot_points_on_rails(self.zigzag_spacing)))
 
         if isinstance(split_point, float):
             index_of_closest_stitch = int(round(len(points) * split_point))
@@ -1059,19 +1065,19 @@ class SatinColumn(EmbroideryElement):
             return (points[index_of_closest_stitch - 1],
                     points[index_of_closest_stitch])
 
-    def _cut_rails(self, cut_points):
+    def _cut_rails(self, cut_points) -> tuple[list[shgeo.LineString], list[shgeo.LineString]]:
         """Cut the rails of this satin at the specified points.
 
         cut_points is a list of two elements, corresponding to the cut points
         for each rail in order.
 
-        Returns: A list of two elements, corresponding two the two new sets of
+        Returns: A list of two elements, corresponding to the two new sets of
           rails.  Each element is a list of two rails of type LineString.
         """
 
         rails = [shgeo.LineString(rail) for rail in self.rails]
 
-        path_lists = [[], []]
+        path_lists: tuple[list[shgeo.LineString], list[shgeo.LineString]] = ([], [])
 
         rails_to_reverse = self._get_rails_to_reverse()
 
@@ -1092,7 +1098,7 @@ class SatinColumn(EmbroideryElement):
             path_lists[0].append(after)
 
         if rails_to_reverse[0]:
-            path_lists = [path_lists[1], path_lists[0]]
+            path_lists = (path_lists[1], path_lists[0])
 
         return path_lists
 
@@ -1212,7 +1218,7 @@ class SatinColumn(EmbroideryElement):
 
         return stitches
 
-    def _stitch_distance(self, pos0, pos1, previous_pos0, previous_pos1):
+    def _stitch_distance(self, pos0: Point, pos1: Point, previous_pos0: Point, previous_pos1: Point) -> float:
         """Return the distance from one stitch to the next."""
 
         previous_stitch = previous_pos1 - previous_pos0
@@ -1235,7 +1241,7 @@ class SatinColumn(EmbroideryElement):
             return max(abs(d0 * normal), abs(d1 * normal))
 
     @debug.time
-    def plot_points_on_rails(self, spacing, offset_px=(0, 0), offset_proportional=(0, 0), use_random=False,
+    def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float]=(0, 0), offset_proportional: tuple[float, float]=(0, 0), use_random: bool=False,
                              ) -> List[Tuple[Point, Point]]:
         # Take a section from each rail in turn, and plot out an equal number
         # of points on both rails.  Return the points plotted. The points will
@@ -1346,7 +1352,7 @@ class SatinColumn(EmbroideryElement):
 
         return pairs
 
-    def _connect_stitch_group_with_point(self, first_stitch_group, start_point, end_point=None):
+    def _connect_stitch_group_with_point(self, first_stitch_group: StitchGroup, start_point: Point | Vector2d, end_point: Optional[Point | Vector2d]= None) -> StitchGroup:
         start_stitch_group = StitchGroup(
             color=self.color,
             stitches=[Stitch(*start_point)]
@@ -1366,7 +1372,7 @@ class SatinColumn(EmbroideryElement):
             end = connector.project(nearest_points(split_line, connector)[1])
 
         start_path = substring(connector, start, end)
-        stitches = [Stitch(*coord) for coord in start_path.coords]
+        stitches = [Stitch.from_coordinates(coord) for coord in start_path.coords]
         stitch_group = StitchGroup(
             color=self.color,
             stitches=stitches
@@ -1978,13 +1984,11 @@ class SatinColumn(EmbroideryElement):
         else:
             return True
 
-    def _get_command_point(self, command):
-        point = self.get_command(command)
-        if point is not None:
-            point = point.target_point
-        return point
+    def _get_command_point(self, command_id: str) -> Optional[Vector2d]:
+        command = self.get_command(command_id)
+        return command.target_point if command is not None else None
 
-    def _sort_stitch_groups(self, stitch_groups, end_point):
+    def _sort_stitch_groups(self, stitch_groups: list[StitchGroup], end_point):
         if end_point:
             ordered_stitch_groups = []
             ordered_stitch_groups.extend(stitch_groups[::2])
@@ -1993,7 +1997,7 @@ class SatinColumn(EmbroideryElement):
             return ordered_stitch_groups
         return stitch_groups
 
-    def to_stitch_groups(self, last_stitch_group=None, next_element=None):
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup]=None, next_element: Optional[EmbroideryElement]=None):
         # Stitch a variable-width satin column, zig-zagging between two paths.
         # The algorithm will draw zigzags between each consecutive pair of
         # beziers.  The boundary points between beziers serve as "checkpoints",
@@ -2042,7 +2046,7 @@ class SatinColumn(EmbroideryElement):
 
 
 class SatinProcessor:
-    def __init__(self, satin, offset_px, offset_proportional, use_random):
+    def __init__(self, satin: 'SatinColumn', offset_px: tuple[float, float], offset_proportional: tuple[float, float], use_random: bool):
         self.satin = satin
         self.use_random = use_random
         self.offset_px = offset_px
@@ -2055,7 +2059,7 @@ class SatinProcessor:
             self.offset_range = (satin.random_width_increase + satin.random_width_decrease)
             self.cycle = 0
 
-    def process_points(self, pos0, pos1):
+    def process_points(self, pos0: Point, pos1: Point) -> tuple[Point, Point]:
         if self.use_random:
             roll = prng.uniform_floats(self.seed, self.cycle)
             self.cycle += 1

--- a/lib/elements/utils/stroke_to_satin.py
+++ b/lib/elements/utils/stroke_to_satin.py
@@ -5,6 +5,7 @@
 
 import sys
 from math import acos, degrees
+from typing import cast
 
 from inkex import errormsg
 from numpy import convolve, diff, int32, setdiff1d, sign, zeros
@@ -12,6 +13,7 @@ from shapely import geometry as shgeo
 from shapely.affinity import rotate, scale
 from shapely.ops import substring
 
+from ..element import BasePath
 from ...i18n import _
 from ...svg import PIXELS_PER_MM
 from ...utils import Point, roll_linear_ring
@@ -22,7 +24,7 @@ class SelfIntersectionError(Exception):
     pass
 
 
-def convert_path_to_satin(path, stroke_width, style_args, rungs_at_nodes=False):
+def convert_path_to_satin(path: BasePath, stroke_width, style_args, rungs_at_nodes=False):
     path = remove_duplicate_points(fix_loop(path))
 
     if len(path) < 2:
@@ -39,7 +41,7 @@ def convert_path_to_satin(path, stroke_width, style_args, rungs_at_nodes=False):
     return None
 
 
-def convert_path_to_satins(path, stroke_width, style_args, rungs_at_nodes=False, depth=0):
+def convert_path_to_satins(path: BasePath, stroke_width, style_args, rungs_at_nodes=False, depth=0):
     try:
         rails, rungs = path_to_satin(path, stroke_width, style_args, rungs_at_nodes)
         yield (rails, rungs)
@@ -59,14 +61,14 @@ def convert_path_to_satins(path, stroke_width, style_args, rungs_at_nodes=False,
                 yield section
 
 
-def split_path(path):
+def split_path(path: BasePath) -> tuple[BasePath, BasePath]:
     linestring = shgeo.LineString(path)
-    halves = [
+    halves = (
         list(substring(linestring, 0, 0.5, normalized=True).coords),
         list(substring(linestring, 0.5, 1, normalized=True).coords),
-    ]
-
-    return halves
+    )
+    # without the cast each item is list[tuple[float, ...]] but we know that it is a BasePath since input is BasePath
+    return cast(tuple[BasePath, BasePath], halves)
 
 
 def fix_loop(path):

--- a/lib/extensions/auto_run.py
+++ b/lib/extensions/auto_run.py
@@ -46,10 +46,9 @@ class AutoRun(CommandsExtension):
         return self.get_command_point("autoroute_end")
 
     def get_command_point(self, command_type: str) -> Optional[Vector2d]:
-        command = None
         for stroke in self.elements:
             command = stroke.get_command(command_type)
-            # return the first occurence directly
+            # return the first occurrence directly
             if command:
                 return command.target_point
         return None

--- a/lib/extensions/break_apart.py
+++ b/lib/extensions/break_apart.py
@@ -4,10 +4,9 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from copy import copy
-from typing import List, Tuple, Union
+from typing import List, Sequence
 
 from inkex import Path, errormsg
-from mypyc.ir.ops import Sequence
 from shapely import make_valid
 from shapely.geometry import LinearRing, MultiPolygon, Polygon
 from shapely.ops import polygonize, unary_union

--- a/lib/extensions/break_apart.py
+++ b/lib/extensions/break_apart.py
@@ -7,6 +7,7 @@ from copy import copy
 from typing import List, Tuple, Union
 
 from inkex import Path, errormsg
+from mypyc.ir.ops import Sequence
 from shapely import make_valid
 from shapely.geometry import LinearRing, MultiPolygon, Polygon
 from shapely.ops import polygonize, unary_union
@@ -69,7 +70,7 @@ class BreakApart(InkstitchExtension):
             if recombined_polygons:
                 self.polygons_to_nodes(recombined_polygons, element)
 
-    def break_apart_paths(self, paths: List[List[Union[List[float], Tuple[float, float]]]]) -> List[Polygon]:
+    def break_apart_paths(self, paths: Sequence[Sequence[Sequence[float]]]) -> List[Polygon]:
         polygons = []
         for path in paths:
             if len(path) < 3:

--- a/lib/extensions/cut_satin.py
+++ b/lib/extensions/cut_satin.py
@@ -79,21 +79,21 @@ class CutSatin(InkstitchExtension):
             return new_satins
         return satin_elements
 
-    def _get_cut_points(self, satin: SatinColumn, cut_lines: list[LineString]) -> list[tuple[Point, Point]]:
+    def _get_cut_points(self, satin: SatinColumn, cut_lines: list[LineString]) -> list[list[Point]]:
         """Cut lines must intersect each rail once
         This filters cut lines and returns the cut points"""
         rails = satin.line_string_rails
-        filtered_cut_points = []
+        filtered_cut_points: list[list[Point]] = []
         for cut_line in cut_lines:
-            cut_points = []
+            cut_points: list[Point] = []
             cut_point1 = rails[0].intersection(cut_line)
-            if cut_point1.geom_type == "Point":
+            if isinstance(cut_point1, Point):
                 cut_points.append(cut_point1)
             cut_point2 = rails[1].intersection(cut_line)
-            if cut_point2.geom_type == "Point":
+            if isinstance(cut_point2, Point):
                 cut_points.append(cut_point2)
             if len(cut_points) > 0:
-                filtered_cut_points.append(tuple(cut_points))
+                filtered_cut_points.append(cut_points)
         return filtered_cut_points
 
     def _select_elements(self) -> tuple[list[LineString], list[inkex.BaseElement], list[SatinColumn]]:

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -123,6 +123,12 @@ class Stitch(Point):
         if base_stitch is not None:
             self.add_tags(base_stitch.tags)
 
+    @classmethod
+    def from_coordinates(cls, coords: tuple[float, ...]):
+        if len(coords) < 2:
+            raise ValueError("Coordinates must have at least 2 elements")
+        return cls(coords[0], coords[1])
+
     def __new__(cls: Type[Stitch], *args, **kwargs) -> Stitch:
         instance = super().__new__(cls)
 

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -80,7 +80,7 @@ class Stitch(Point):
 
     def __init__(
         self,
-        x: Union[Stitch, float, Point],
+        x: Union[Stitch, float, Point, shgeo.Point],
         y: Optional[float] = None,
         color: Optional[Any] = None,
         jump: bool = False,

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -26,7 +26,7 @@ class StitchGroup:
     """
 
     color: Optional[Color] = None
-    stitches: list[Stitch] = []
+    stitches: list[Stitch]
     min_jump_stitch_length: bool = False
     trim_after: bool = False
     stop_after: bool = False
@@ -54,6 +54,7 @@ class StitchGroup:
         self.lock_stitches = lock_stitches or (None, None)
         self.force_lock_stitches = force_lock_stitches
         self.min_jump_stitch_length = min_jump_stitch_length
+        self.stitches = []
 
         if stitches:
             self.add_stitches(stitches)

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -2,8 +2,16 @@
 #
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+from typing import Optional, Literal, Sequence
 
+from inkex import Color
+from shapely import geometry as shgeo
+
+from .lock_stitch import LockStitch
 from .stitch import Stitch
+from ..utils import Point
+
+LockStitches = tuple[LockStitch | None, LockStitch | None]
 
 
 class StitchGroup:
@@ -17,16 +25,23 @@ class StitchGroup:
     between them by the stitch plan generation code.
     """
 
+    color: Optional[Color] = None
+    stitches: list[Stitch] = []
+    min_jump_stitch_length: bool = False
+    trim_after: bool = False
+    stop_after: bool = False
+    lock_stitches: LockStitches = (None, None)
+
     def __init__(
         self,
-        color=None,
-        stitches=None,
-        min_jump_stitch_length=False,
-        trim_after=False,
-        stop_after=False,
-        lock_stitches=(None, None),
-        force_lock_stitches=False,
-        tags=None
+        color: Optional[Color] = None,
+        stitches: Optional[list[Stitch]] = None,
+        min_jump_stitch_length: bool = False,
+        trim_after: bool = False,
+        stop_after: bool = False,
+        lock_stitches: Optional[tuple[LockStitch | None, LockStitch | None]] = None,
+        force_lock_stitches: bool = False,
+        tags: Optional[Sequence[str]] = None
     ):
         # DANGER: if you add new attributes, you MUST also set their default
         # values in __new__() below.  Otherwise, cached stitch plans can be
@@ -36,10 +51,9 @@ class StitchGroup:
         self.color = color
         self.trim_after = trim_after
         self.stop_after = stop_after
-        self.lock_stitches = lock_stitches
+        self.lock_stitches = lock_stitches or (None, None)
         self.force_lock_stitches = force_lock_stitches
         self.min_jump_stitch_length = min_jump_stitch_length
-        self.stitches = []
 
         if stitches:
             self.add_stitches(stitches)
@@ -53,7 +67,7 @@ class StitchGroup:
         # Set default values for any new attributes here (see note in __init__() above)
         # instance.foo = None
 
-        instance.lock_stitches = None
+        instance.lock_stitches = (None, None)
 
         return instance
 
@@ -72,34 +86,37 @@ class StitchGroup:
         for stitch in self.stitches:
             stitch.min_stitch_length = min_stitch_length
 
-    def add_stitches(self, stitches, tags=None):
+    def add_stitches(self, stitches: Sequence[Stitch | Point | shgeo.Point], tags: Optional[Sequence[str]] = None):
         for stitch in stitches:
             self.add_stitch(stitch, tags=tags)
 
-    def add_stitch(self, stitch, tags=None):
-        if not isinstance(stitch, Stitch):
-            # probably a Point
+    def add_stitch(self, stitch: Stitch | Point | shgeo.Point, tags: Optional[Sequence[str]] = None):
+        if isinstance(stitch, (Point, shgeo.Point)):
             stitch = Stitch(stitch, tags=tags)
+        elif not isinstance(stitch, Stitch):
+            raise TypeError("Expected a Stitch or Point object, got %s" % type(stitch))
+
         self.stitches.append(stitch)
 
     def reverse(self):
         return StitchGroup(self.color, self.stitches[::-1])
 
-    def add_tags(self, tags):
+    def add_tags(self, tags: Sequence[str]) -> None:
         for stitch in self.stitches:
             stitch.add_tags(tags)
 
-    def add_tag(self, tag):
+    def add_tag(self, tag: str) -> None:
         for stitch in self.stitches:
             stitch.add_tag(tag)
 
-    def get_lock_stitches(self, pos, disable_ties=False):
-        if len(self.stitches) < 2:
-            return []
+    def get_lock_stitches(self, pos: Literal['start'] | Literal['end'], disable_ties: bool = False) -> Optional[LockStitches]:
+        if disable_ties or len(self.stitches) < 2:
+            return None
 
         lock_pos = 0 if pos == "start" else 1
-        if disable_ties or self.lock_stitches[lock_pos] is None:
-            return
+        lock_stitches = self.lock_stitches[lock_pos]
+        if lock_stitches is None:
+            return None
 
-        stitches = self.lock_stitches[lock_pos].stitches(self.stitches, pos)
+        stitches = lock_stitches.stitches(self.stitches, pos)
         return stitches

--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import inkex
 import networkx as nx
-from click.types import OptionHelpExtra
 from inkex.units import convert_unit
 from shapely import geometry as shgeo
 from shapely import set_precision
@@ -48,7 +47,8 @@ class SatinSegment(object):
     reverse: bool
     original_satin: SatinColumn
 
-    def __init__(self, satin: SatinColumn, start: SatinSegmentPortionInput=0.0, end: SatinSegmentPortionInput=1.0, reverse: bool=False, original_satin: Optional[SatinColumn]=None):
+    def __init__(self, satin: SatinColumn, start: SatinSegmentPortionInput = 0.0, end: SatinSegmentPortionInput = 1.0,
+                 reverse: bool = False, original_satin: Optional[SatinColumn] = None):
         """Initialize a SatinEdge.
 
         Arguments:
@@ -325,7 +325,8 @@ class RunningStitch(object):
         return RunningStitch(new_path, self.original_element)
 
 
-def auto_satin(elements: list[SatinColumn], preserve_order: bool = False, starting_point: Optional[InkstitchPoint] = None, ending_point: Optional[InkstitchPoint] = None, trim: bool = False, keep_originals: bool = False, parent=None, index=None):
+def auto_satin(elements: list[SatinColumn], preserve_order: bool = False, starting_point: Optional[InkstitchPoint] = None,
+               ending_point: Optional[InkstitchPoint] = None, trim: bool = False, keep_originals: bool = False, parent=None, index=None):
     """Find an optimal order to stitch a list of SatinColumns.
 
     Add running stitch and jump stitches as necessary to construct a stitch

--- a/lib/stitches/auto_satin.py
+++ b/lib/stitches/auto_satin.py
@@ -5,9 +5,11 @@
 
 import math
 from itertools import chain
+from typing import Optional
 
 import inkex
 import networkx as nx
+from click.types import OptionHelpExtra
 from inkex.units import convert_unit
 from shapely import geometry as shgeo
 from shapely import set_precision
@@ -30,18 +32,23 @@ from .utils.autoroute import (add_elements_to_group, add_jumps,
                               preserve_original_groups,
                               remove_original_elements)
 
+# start/end can be a tuple/Point falling somewhere on the satin column, OR a floating point specifying a normalized
+# projection of a distance along the satin (0.0 to 1.0 inclusive).
+SatinSegmentPortionInput = tuple[float, float] | InkstitchPoint | float | int
+
 
 class SatinSegment(object):
-    """A portion of SatinColumn.
+    """A portion of a SatinColumn."""
 
-    Attributes:
-        satin -- the SatinColumn instance
-        start -- how far along the satin this graph edge starts (a float from 0.0 to 1.0)
-        end -- how far along the satin this graph edge ends (a float from 0.0 to 1.0)
-        reverse -- if True, reverse the direction of the satin
-    """
+    satin: SatinColumn
+    # How far along the satin this graph edge starts (from 0.0 to 1.0)
+    start: float
+    # How far along the satin this graph edge ends (from 0.0 to 1.0)
+    end: float
+    reverse: bool
+    original_satin: SatinColumn
 
-    def __init__(self, satin, start=0.0, end=1.0, reverse=False, original_satin=None):
+    def __init__(self, satin: SatinColumn, start: SatinSegmentPortionInput=0.0, end: SatinSegmentPortionInput=1.0, reverse: bool=False, original_satin: Optional[SatinColumn]=None):
         """Initialize a SatinEdge.
 
         Arguments:
@@ -58,20 +65,21 @@ class SatinSegment(object):
         self.reverse = reverse
 
         # start and end are stored as normalized projections
-        self.start = self._parse_init_param(start)
-        self.end = self._parse_init_param(end)
+        self.start = self._parse_portion_input(start)
+        self.end = self._parse_portion_input(end)
 
         if self.start > self.end:
             self.end, self.start = self.start, self.end
             self.reverse = True
 
-    def _parse_init_param(self, param):
-        if isinstance(param, (float, int)):
-            return param
-        elif isinstance(param, (tuple, InkstitchPoint, ShapelyPoint)):
-            return self.satin.center.project(ShapelyPoint(param), normalized=True)
+    def _parse_portion_input(self, portion: SatinSegmentPortionInput) -> float | int:
+        if isinstance(portion, (float, int)):
+            return portion
+        elif isinstance(portion, (tuple, InkstitchPoint, ShapelyPoint)):
+            return self.satin.center_line.project(ShapelyPoint(portion), normalized=True)
+        raise ValueError("Unrecognized portion type %s" % type(portion))
 
-    def to_satin(self):
+    def to_satin(self) -> Optional[SatinColumn]:
         satin = self.satin
 
         # get cut points before actually cutting the satin to avoid
@@ -89,7 +97,7 @@ class SatinSegment(object):
 
         # the cut operation can lead to a NoneType element
         if satin is None:
-            return
+            return None
 
         if self.reverse:
             satin = satin.reverse()
@@ -109,11 +117,11 @@ class SatinSegment(object):
     def to_running_stitch(self):
         return RunningStitch(self.center_line, self.original_satin)
 
-    def break_up(self, segment_size):
+    def break_up(self, segment_size: float) -> list['SatinSegment']:
         """Break this SatinSegment up into SatinSegments of the specified size."""
 
         num_segments = int(math.ceil(self.center_line.length / segment_size))
-        segments = []
+        segments: list[SatinSegment] = []
         for i in range(num_segments):
             segments.append(SatinSegment(self.satin,
                                          float(i) / num_segments,
@@ -317,7 +325,7 @@ class RunningStitch(object):
         return RunningStitch(new_path, self.original_element)
 
 
-def auto_satin(elements, preserve_order=False, starting_point=None, ending_point=None, trim=False, keep_originals=False, parent=None, index=None):
+def auto_satin(elements: list[SatinColumn], preserve_order: bool = False, starting_point: Optional[InkstitchPoint] = None, ending_point: Optional[InkstitchPoint] = None, trim: bool = False, keep_originals: bool = False, parent=None, index=None):
     """Find an optimal order to stitch a list of SatinColumns.
 
     Add running stitch and jump stitches as necessary to construct a stitch
@@ -388,7 +396,7 @@ def auto_satin(elements, preserve_order=False, starting_point=None, ending_point
     path = find_path(graph, starting_node, ending_node)
     operations = path_to_operations(graph, path)
     operations = collapse_sequential_segments(operations)
-    new_elements, trims, original_parents = operations_to_elements_and_trims(operations, preserve_order)
+    new_elements, trims, original_parents = operations_to_elements_and_trims(operations)
 
     if not keep_originals:
         remove_original_elements(elements)
@@ -436,7 +444,7 @@ def _route_single_satin(elements, starting_point, keep_originals):
         remove_original_elements([satin], True)
 
 
-def convert_stroke_width(element):
+def convert_stroke_width(element: SatinColumn) -> float:
     document_unit = element.node.getroottree().getroot().document_unit
     stroke_width = convert_unit(element.stroke_width, document_unit)
     return stroke_width
@@ -540,7 +548,7 @@ def collapse_sequential_segments(old_operations):
     return new_operations
 
 
-def operations_to_elements_and_trims(operations, preserve_order):
+def operations_to_elements_and_trims(operations):
     """Convert a list of operations to Elements and locations of trims.
 
     Returns:
@@ -614,13 +622,13 @@ def name_elements(new_elements, preserve_order):
             index += 1
 
 
-def _ensure_even_repeats(element):
+def _ensure_even_repeats(element: SatinColumn):
     # center underlay can have an odd number of repeats, this would cause jumps in auto route satin
     # so let's set it to an even number of repeats, but not lower than 2
     center_walk_underlay_repeats = element.get_int_param('center_walk_underlay_repeats', 2)
     if center_walk_underlay_repeats % 2 == 1:
         repeats = max(center_walk_underlay_repeats - 1, 2)
-        element.node.set(INKSTITCH_ATTRIBS['center_walk_underlay_repeats'], repeats)
+        element.node.set(INKSTITCH_ATTRIBS['center_walk_underlay_repeats'], str(repeats))
 
 
 def add_trims(elements, trim_indices):

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -316,7 +316,7 @@ def stitch_curve_evenly(
     """
     if len(points) < 2:
         return [], stitch_length_pos
-    dist_left = [0] * len(points)
+    dist_left = [0.0] * len(points)
     for j in reversed(range(0, len(points) - 1)):
         dist_left[j] = dist_left[j + 1] + points[j].distance(points[j + 1])
 

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -40,14 +40,14 @@ def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_
     return [line.interpolate(x, normalized=True) for x in splits]
 
 
-def split_segment_even_dist(a, b, max_length: float, jitter_sigma: float = 0.0, random_seed=None) -> typing.List[shgeo.Point]:
+def split_segment_even_dist(a: Point, b: Point, max_length: float, jitter_sigma: float = 0.0, random_seed=None) -> typing.List[shgeo.Point]:
     """Split a segment into even parts with maximum length."""
     distance = shgeo.Point(a).distance(shgeo.Point(b))
     segments = math.ceil(distance / max_length)
     return split_segment_even_n(a, b, segments, jitter_sigma, random_seed)
 
 
-def split_segment_random_phase(a, b, length: float, length_sigma: float, random_seed: str) -> typing.List[shgeo.Point]:
+def split_segment_random_phase(a: Point, b: Point, length: float, length_sigma: float, random_seed: str) -> typing.List[shgeo.Point]:
     """Split a segment with randomized phase and length variation."""
     line = shgeo.LineString([a, b])
     progress = length * prng.uniform_floats(random_seed, "phase")[0]
@@ -64,8 +64,8 @@ def split_segment_random_phase(a, b, length: float, length_sigma: float, random_
 
 
 def split_segment_stagger_phase(
-    a,
-    b,
+    a: Point,
+    b: Point,
     segment_length: float,
     num_staggers: int,
     this_segment_num: int,

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -299,6 +299,7 @@ class Point:
     def __mul__(self, other: 'Point') -> float: ...
     @overload
     def __mul__(self, other: int | float) -> 'Point': ...
+
     def __mul__(self, other: 'Point | int | float'):
         if isinstance(other, Point):
             # dot product

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -261,7 +261,7 @@ def remove_duplicate_points(path):
 
 
 CoordinateType = typing.Union[float, numpy.float64]
-AnyPointType: TypeAlias = Vector2d | tuple[CoordinateType, CoordinateType] | 'Point'
+AnyPointType: TypeAlias = 'Vector2d | tuple[CoordinateType, CoordinateType] | Point'
 
 
 class Point:

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -6,7 +6,7 @@
 import math
 import typing
 from itertools import groupby
-from typing import Iterable, Iterator, overload
+from typing import Iterable, Iterator, overload, NoReturn, TypeAlias
 
 import numpy
 from inkex import Vector2d
@@ -260,14 +260,15 @@ def remove_duplicate_points(path):
     return [point for point, repeats in groupby(path)]
 
 
-COORDINATE_TYPE = typing.Union[float, numpy.float64]
+CoordinateType = typing.Union[float, numpy.float64]
+AnyPointType: TypeAlias = Vector2d | tuple[CoordinateType, CoordinateType] | 'Point'
 
 
 class Point:
     x: float
     y: float
 
-    def __init__(self, x: COORDINATE_TYPE, y: COORDINATE_TYPE):
+    def __init__(self, x: CoordinateType, y: CoordinateType):
         self.x = float(x)
         self.y = float(y)
 
@@ -276,12 +277,38 @@ class Point:
         return cls(point.x, point.y)
 
     @classmethod
-    def from_tuple(cls, point: tuple[COORDINATE_TYPE, COORDINATE_TYPE]):
+    def from_tuple(cls, point: tuple[CoordinateType, CoordinateType]):
         return cls(point[0], point[1])
 
     @classmethod
     def from_vector2d(cls, vec: Vector2d):
         return cls(vec.x, vec.y)
+
+    @overload
+    @classmethod
+    def from_other(cls, other: None) -> None: ...
+    @overload
+    @classmethod
+    def from_other(cls, other: AnyPointType) -> 'Point': ...
+    @overload
+    @classmethod
+    def from_other(cls, other: object) -> NoReturn: ...
+
+    @classmethod
+    def from_other(cls, other: object):
+        """
+        When working with different point types, method return types get messy and end up as a union between the
+        different types. Instead, we can just return Point.from_other to normalize them into our Point type.
+        """
+        if other is None:
+            return None
+        if isinstance(other, Point):
+            return Point(other.x, other.y)
+        if isinstance(other, tuple) and len(other) == 2 and isinstance(other[0], float) and isinstance(other[1], float):
+            return Point.from_tuple(typing.cast(tuple[CoordinateType, CoordinateType], other))
+        if isinstance(other, Vector2d):
+            return Point.from_vector2d(other)
+        raise ValueError(f"Cannot convert {type(other)} to Point")
 
     def __json__(self):
         return vars(self)
@@ -388,5 +415,5 @@ def line_string_to_point_list(line_string) -> list[Point]:
     return [Point(*point) for point in line_string.coords]
 
 
-def coordinate_list_to_point_list(coordinate_list: Iterable[tuple[COORDINATE_TYPE, COORDINATE_TYPE]]) -> list[Point]:
+def coordinate_list_to_point_list(coordinate_list: Iterable[tuple[CoordinateType, CoordinateType]]) -> list[Point]:
     return [Point.from_tuple(coords) for coords in coordinate_list]

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -6,8 +6,10 @@
 import math
 import typing
 from itertools import groupby
+from typing import Iterable, Iterator, overload
 
 import numpy
+from inkex import Vector2d
 from shapely.geometry import (GeometryCollection, LinearRing, LineString,
                               MultiLineString, MultiPoint, MultiPolygon, Polygon)
 from shapely.geometry.base import BaseGeometry
@@ -258,8 +260,14 @@ def remove_duplicate_points(path):
     return [point for point, repeats in groupby(path)]
 
 
+COORDINATE_TYPE = typing.Union[float, numpy.float64]
+
+
 class Point:
-    def __init__(self, x: typing.Union[float, numpy.float64], y: typing.Union[float, numpy.float64]):
+    x: float
+    y: float
+
+    def __init__(self, x: COORDINATE_TYPE, y: COORDINATE_TYPE):
         self.x = float(x)
         self.y = float(y)
 
@@ -268,22 +276,30 @@ class Point:
         return cls(point.x, point.y)
 
     @classmethod
-    def from_tuple(cls, point):
+    def from_tuple(cls, point: tuple[COORDINATE_TYPE, COORDINATE_TYPE]):
         return cls(point[0], point[1])
+
+    @classmethod
+    def from_vector2d(cls, vec: Vector2d):
+        return cls(vec.x, vec.y)
 
     def __json__(self):
         return vars(self)
 
-    def __add__(self, other):
+    def __add__(self, other: 'Point'):
         return self.__class__(self.x + other.x, self.y + other.y)
 
-    def __sub__(self, other):
+    def __sub__(self, other: 'Point'):
         return self.__class__(self.x - other.x, self.y - other.y)
 
     def mul(self, scalar):
         return self.__class__(self.x * scalar, self.y * scalar)
 
-    def __mul__(self, other):
+    @overload
+    def __mul__(self, other: 'Point') -> float: ...
+    @overload
+    def __mul__(self, other: int | float) -> 'Point': ...
+    def __mul__(self, other: 'Point | int | float'):
         if isinstance(other, Point):
             # dot product
             return self.x * other.x + self.y * other.y
@@ -295,52 +311,54 @@ class Point:
     def __neg__(self):
         return self * -1
 
-    def __rmul__(self, other):
+    def __rmul__(self, other: int | float):
         if isinstance(other, (int, float)):
             return self.__mul__(other)
         else:
             raise ValueError("cannot multiply %s by %s" % (type(self), type(other)))
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: int | float):
         if isinstance(other, (int, float)):
             return self * (1.0 / other)
         else:
             raise ValueError("cannot divide %s by %s" % (type(self), type(other)))
 
-    def __eq__(self, other):
-        return self.x == other.x and self.y == other.y
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Point):
+            return self.x == other.x and self.y == other.y
+        return False
 
     def __repr__(self):
         return "%s(%s,%s)" % (type(self), self.x, self.y)
 
-    def length(self):
+    def length(self) -> float:
         return (self.x ** 2 + self.y ** 2) ** 0.5
 
-    def distance(self, other):
+    def distance(self, other: 'Point') -> float:
         return (other - self).length()
 
-    def unit(self):
+    def unit(self) -> 'Point':
         length = self.length()
         if length == 0:
             return self.__class__(0, 0)
         return self.__class__(self.x / length, self.y / length)
 
-    def angle(self):
+    def angle(self) -> float:
         return math.atan2(self.y, self.x)
 
-    def rotate_left(self):
+    def rotate_left(self) -> 'Point':
         return self.__class__(-self.y, self.x)
 
-    def rotate(self, angle):
+    def rotate(self, angle: float) -> 'Point':
         return self.__class__(self.x * math.cos(angle) - self.y * math.sin(angle), self.y * math.cos(angle) + self.x * math.sin(angle))
 
-    def scale(self, x_scale, y_scale):
+    def scale(self, x_scale: float, y_scale: float) -> 'Point':
         return self.__class__(self.x * x_scale, self.y * y_scale)
 
-    def as_int(self):
+    def as_int(self) -> 'Point':
         return self.__class__(int(round(self.x)), int(round(self.y)))
 
-    def as_tuple(self):
+    def as_tuple(self) -> tuple[float, float]:
         return (self.x, self.y)
 
     def __getitem__(self, item):
@@ -352,10 +370,22 @@ class Point:
     def __str__(self):
         return "({0:.3f}, {1:.3f})".format(self.x, self.y)
 
+    def clone(self) -> 'Point':
+        return self.__class__(self.x, self.y)
 
-def line_string_to_point_list(line_string):
+    def __iter__(self) -> Iterator[float]:
+        """
+        We pass Point objects into shapely classes in many places, which works at runtime with just
+        __len__ and __getitem__ since python uses that as a fallback when the class doesn't have __iter__.
+        But mypy doesn't recognize that as a valid iterable, so we implement __iter__ to make mypy happy.
+        """
+        yield self.x
+        yield self.y
+
+
+def line_string_to_point_list(line_string) -> list[Point]:
     return [Point(*point) for point in line_string.coords]
 
 
-def coordinate_list_to_point_list(coordinate_list):
+def coordinate_list_to_point_list(coordinate_list: Iterable[tuple[COORDINATE_TYPE, COORDINATE_TYPE]]) -> list[Point]:
     return [Point.from_tuple(coords) for coords in coordinate_list]

--- a/lib/utils/smoothing.py
+++ b/lib/utils/smoothing.py
@@ -1,4 +1,5 @@
 import numpy as np
+from shapely.coords import CoordinateSequence
 
 from ..stitches.running_stitch import stitch_curve_evenly
 from .geometry import Point, coordinate_list_to_point_list
@@ -21,7 +22,7 @@ def _remove_duplicate_coordinates(coords_array):
     return coords_array[keepers]
 
 
-def smooth_path(path, smoothness=1.0, iterations=5):
+def smooth_path(path, smoothness: float=1.0, iterations: int=5):
     """Smooth a path of coordinates.
 
     Arguments:
@@ -44,10 +45,10 @@ def smooth_path(path, smoothness=1.0, iterations=5):
     #
     # Fortunately, we can convert the path to segments that are mostly the same
     # length by using the running stitch algorithm.
-    points, _ = stitch_curve_evenly(points, [smoothness * 5], smoothness * 2)
-    points = np.array(points)
+    curve_points, _ = stitch_curve_evenly(points, [smoothness * 5], smoothness * 2)
+    points_np = np.array(curve_points)
     for _ in range(iterations):
-        ll = points.repeat(2, axis=0)
+        ll = points_np.repeat(2, axis=0)
         r = np.empty_like(ll)
         if len(r) == 0:
             continue
@@ -55,10 +56,10 @@ def smooth_path(path, smoothness=1.0, iterations=5):
         r[2::2] = ll[1:-1:2]
         r[1:-1:2] = ll[2::2]
         r[-1] = ll[-1]
-        points = ll * 0.75 + r * 0.25
+        points_np = ll * 0.75 + r * 0.25
 
     # we want to keep the old start and end points
     start = [Point(* path[0])]
     end = [Point(* path[-1])]
 
-    return start + [Point(*coord) for coord in points] + end
+    return start + [Point(*coord) for coord in points_np] + end

--- a/lib/utils/smoothing.py
+++ b/lib/utils/smoothing.py
@@ -1,5 +1,4 @@
 import numpy as np
-from shapely.coords import CoordinateSequence
 
 from ..stitches.running_stitch import stitch_curve_evenly
 from .geometry import Point, coordinate_list_to_point_list
@@ -22,7 +21,7 @@ def _remove_duplicate_coordinates(coords_array):
     return coords_array[keepers]
 
 
-def smooth_path(path, smoothness: float=1.0, iterations: int=5):
+def smooth_path(path, smoothness: float = 1.0, iterations: int = 5):
     """Smooth a path of coordinates.
 
     Arguments:


### PR DESCRIPTION
Unnecessary background context: I'm working on a feature I want to add to SatinColumn which automatically removes identical satin columns when two objects share an edge. 
I'm finding it really hard to understand what's going on in SatinColumn, in part because type hinting is mostly missing and there is a ton of trying to figure out if something is a list or a Point or a shapely Point or a Vector2d or whatever since they're all just called "point" or "path" or etc. 
SatinColumn (in addition to the other embroidery elements) also has a ton of responsibilities with a ton of scattered helpers throughout the class, and I'd like to split those responsibilities out into submodules to make it easier to understand. 

Anyway, seems like the first step here is to start doing some more type hinting. My initial goal was to type hint all of SatinColumn, but I arbitrarily picked a stopping point before that because I keep going down rabbit holes of trying to type helpers in the base class/utility classes which makes me type other stuff and etc so there are already a lot of changes despite not typing the whole surface. There is still a lot which has no types.

Some notes on the changes:
- `@param` now has proper type-safety and doesn't return `str | Any | <whatever the type you used as default was>` anymore! feels like a big win since that kind of clobbered a bunch of other types.
- The changes are not _entirely_ just adding type hints; for example, in a few cases mypy was angry that things could be None where we didn't think they would be None before / were kind of implicitly handling the potential for it to be None. mypy won't allow that so I had to more explicitly handle None. Some other cases exist where we did things like reassign a `str` to be an `int` but mypy wouldn't later recognize that it was always an `int` now, so I needed a separate variable for it. 
- As I was going, pycharm also complained about some shadowed identifiers (in particular with `@param` being shadowed by a local variable called `param`), so I did some minor renames as well.

I'm also happy to split out the changes into separate PRs if the diff is too large - there were just a few things where typing one function meant you had to type like 10 others.