### PR TITLE
[SPLIT] Debug script: runtime python interpreter fallback

### DIFF
--- a/DEBUG_template.toml
+++ b/DEBUG_template.toml
@@ -5,17 +5,30 @@
 # prefer_pip_inkex = false
 
 [LOGGING]
+### Specifies where log files are written in developer mode.
+### Options: "script" (SCRIPTDIR),
+###          "document" "doc" (active SVG folder),
+###          "user" "usr" (user log directory),
+###          "temp" "tmp" (system temp)
+###          "abs_path" (absolute path to a folder)
+###           "" (default - disables logging)
+### Note: For regular users (development_mode = false), file logging is
+### completely DISABLED unless override via INKSTITCH_LOG_DIR env variable.
+# log_location = "script"
+
 ### logging configuration file, default: none - use implicit DEBUG logging to inkstitch.log
 ### we may have multiple configurations: LOGGING.toml, LOGGING1.toml, LOGGING2.toml, etc.
 # log_config_file = "LOGGING.toml"
 
-### disable globally logging: default: false - using logging.disable()
-### reenable logging.disable(0)
+### Disable all logging globally using logging.disable().
+### Note: This does NOT suppress warnings (e.g., from the 'warnings' module).
+### To re-enable logging, call: logging.disable(0)
 # disable_logging = true
 
 [DEBUG]
-### simulate frozen mode, overwrite running_as_frozen in inkstitch.py, default: false
-# force_frozen = true
+### Enable developer mode (enables debug tools, profiling, and file logging).
+### Default: false
+# development_mode = true
 
 ### select one active debug_type, default: "none"
 # debug_type = "vscode"

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -173,7 +173,6 @@ else:
     from lib.i18n import _      # Gettext translation function
     from lib.utils import restore_stderr, save_stderr  # Suppress GTK/C-level warning noise
 
-
     save_stderr()  # Suppress GTK warning noise
     try:
         extension.run(args=remaining_args)
@@ -194,4 +193,3 @@ else:
         restore_stderr()
 
     sys.exit(0)
-

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -3,153 +3,150 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-import os
+# only Python 3.11+ is officially supported
 import sys
-from pathlib import Path  # to work with paths as objects
-from argparse import ArgumentParser  # to parse arguments and remove --extension
-
-if sys.version_info >= (3, 11):
-    import tomllib      # built-in in Python 3.11+
-else:
-    import tomli as tomllib
+if sys.version_info < (3, 11):  # noqa: UP036
+    print("ERROR: Python 3.11 or later is required.", file=sys.stderr)
+    sys.exit(1)
 
 import logging
+import os
+import tomllib
+from argparse import ArgumentParser
+from pathlib import Path
 
-import lib.debug.utils as debug_utils
+
 import lib.debug.logging as debug_logging
+import lib.debug.utils as debug_utils
 from lib.debug.utils import safe_get    # mimic get method of dict with default value
+
+# --------------------------------------------------------------------------------------------
+
+if len(sys.argv) < 2:
+    from textwrap import dedent
+    # No CLI arguments provided - script was likely executed directly by double-clicking
+    msg = dedent("""
+        No arguments given, exiting!
+        Ink/Stitch is an Inkscape extension.
+        Please enter arguments or run Ink/Stitch through the Inkscape extensions menu.
+    """).strip()
+
+    try:
+        import wx
+        app = wx.App()
+        wx.MessageBox(msg, "Ink/Stitch", wx.OK | wx.ICON_ERROR)
+    except ImportError:
+        print(msg, file=sys.stderr)
+
+    sys.exit(1)
+
 
 # --------------------------------------------------------------------------------------------
 
 SCRIPTDIR = Path(__file__).parent.absolute()
 
-logger = logging.getLogger("inkstitch")   # create module logger with name 'inkstitch'
+# Create main 'inkstitch' logger
+logger = logging.getLogger("inkstitch")
 
-# TODO --- temporary --- catch old DEBUG.ini file and inform user to reformat it to DEBUG.toml
-old_debug_ini = SCRIPTDIR / "DEBUG.ini"
-if old_debug_ini.exists():
-    print("ERROR: old DEBUG.ini exists, please reformat it to DEBUG.toml and remove DEBUG.ini file", file=sys.stderr)
-    sys.exit(1)
-# --- end of temporary ---
-
+# Load DEBUG.toml if present; fallback to defaults
 debug_toml = SCRIPTDIR / "DEBUG.toml"
 if debug_toml.exists():
     with debug_toml.open("rb") as f:
-        ini = tomllib.load(f)  # read DEBUG.toml file if exists, otherwise use default values in ini object
+        ini = tomllib.load(f)
 else:
     ini = {}
 # --------------------------------------------------------------------------------------------
-
-running_as_frozen = getattr(sys, 'frozen', None) is not None  # check if running from pyinstaller bundle
-
-running_from_readonly_filesystem = not debug_utils.can_write_to_directory(SCRIPTDIR)
-
-# override runnig_as_frozen if read-only filesystem is detected
-if running_from_readonly_filesystem:
-    running_as_frozen = True
+development_mode = safe_get(ini, "DEBUG", "development_mode", default=False)
+log_location = ""
+if development_mode:
+    log_location = safe_get(ini, "LOGGING", "log_location", default="")
 
 
-if not running_as_frozen:  # override running_as_frozen from DEBUG.toml - for testing
-    if safe_get(ini, "DEBUG", "force_frozen", default=False):
-        running_as_frozen = True
+# running_as_frozen = getattr(sys, 'frozen', None) is not None  # check if running from pyinstaller bundle
+# running_from_readonly_filesystem = not debug_utils.can_write_to_directory(SCRIPTDIR)
 
-if len(sys.argv) < 2:
-    # no arguments - prevent accidentally running this script
-    msg = "No arguments given, exiting!"  # without gettext localization see _()
-    msg += "\n\n"
-    msg += "Ink/Stitch is an Inkscape extension."
-    msg += "\n\n"
-    msg += "Please enter arguments or run Ink/Stitch through the Inkscape extensions menu."
-    if running_as_frozen:  # we show dialog only when running from pyinstaller bundle - using wx
-        try:
-            import wx
-            app = wx.App()
-            dlg = wx.MessageDialog(None, msg, "Inkstitch", wx.OK | wx.ICON_ERROR)
-            dlg.ShowModal()
-            dlg.Destroy()
-        except ImportError:
-            print(msg, file=sys.stderr)
-    else:
-        print(msg, file=sys.stderr)
-    sys.exit(1)
 
-# activate logging - must be done before any logging is done
-debug_logging.activate_logging(running_as_frozen, ini, SCRIPTDIR)
+# Initialize logging before any log calls
+LOGDIR = debug_logging.activate_logging(
+    development_mode,
+    log_location,
+    ini,
+    SCRIPTDIR
+)
 # --------------------------------------------------------------------------------------------
 
-# check if running from inkscape, given by environment variable
-if os.environ.get('INKSTITCH_OFFLINE_SCRIPT', '').lower() in ['true', '1', 'yes', 'y']:
-    running_from_inkscape = False
-else:
-    running_from_inkscape = True
+# Prevent recursive script creation in CLI/BASH mode
+YES_VALUES = {"true", "1", "yes", "y"}
+running_from_inkscape = os.environ.get("INKSTITCH_OFFLINE_SCRIPT", "").lower() not in YES_VALUES
 
-# initialize debug and profiler type
-debug_active = bool((gettrace := getattr(sys, 'gettrace')) and gettrace())  # check if debugger is active on startup
+# -------------------------------------------------------------------------------------------
+# Initialize debug and profiling modes
+debug_active = sys.gettrace() is not None     # check if debugger is active on startup
 debug_type = 'none'
 profiler_type = 'none'
 
-if not running_as_frozen:  # debugging/profiling only in development mode
-    # specify debugger type
-    #   but if script was already started from debugger then don't read debug type from ini file or cmd line
+if development_mode:
+    # Fallback to INI settings if no debugger is attached
     if not debug_active:
-        debug_type = debug_utils.resolve_debug_type(
-            ini)  # read debug type from ini file or cmd line
+        debug_type = debug_utils.resolve_debug_type(ini)
 
-    profiler_type = debug_utils.resolve_profiler_type(
-        ini)  # read profile type from ini file or cmd line
+    # Resolve profiler type from INI file or CLI arguments
+    profiler_type = debug_utils.resolve_profiler_type(ini)
 
     if running_from_inkscape:
-        # process creation of the Bash script - should be done before sys.path is modified, see below in prefer_pip_inkex
-        if safe_get(
-                ini, "DEBUG", "create_bash_script",
-                default=False):  # create script only if enabled in DEBUG.toml
+        # Generate offline script before sys.path modifications (see inkex below)
+        if safe_get(ini, "DEBUG", "create_bash_script", default=False):
             debug_utils.write_offline_debug_script(SCRIPTDIR, ini)
 
-        # disable debugger when running from inkscape
-        disable_from_inkscape = safe_get(ini,
-                                         "DEBUG",
-                                         "disable_from_inkscape",
-                                         default=False)
-        if disable_from_inkscape:
-            debug_type = 'none'  # do not start debugger when running from inkscape
+        # Optionally disable debugger when running inside Inkscape
+        if safe_get(ini, "DEBUG", "disable_from_inkscape", default=False):
+            debug_type = "none"
 
-    # prefer pip installed inkex over inkscape bundled inkex, pip version is bundled with Inkstitch
-    # - must be be done before importing inkex
+    # Prioritize pip-installed inkex over Inkscape's bundled version
+    # WARNING: Must be executed before importing inkex
+    prefer_pip_inkex = safe_get(ini, "LIBRARY", "prefer_pip_inkex", default=True)
 
-    prefer_pip_inkex = safe_get(ini,
-                                "LIBRARY",
-                                "prefer_pip_inkex",
-                                default=True)
-    if prefer_pip_inkex and 'PYTHONPATH' in os.environ:
+    if prefer_pip_inkex and "PYTHONPATH" in os.environ:
         debug_utils.assert_inkex_not_imported_before_path_setup()
         debug_utils.reorder_sys_path()
 
-# enabling of debug depends on value of debug_type in DEBUG.toml file
-if debug_type != 'none':
+if debug_type != "none":
     from lib.debug.debugger import init_debugger
+
     init_debugger(debug_type, ini)
-    # check if debugger is really activated
-    debug_active = bool((gettrace := getattr(sys, 'gettrace')) and gettrace())
+    debug_active = sys.gettrace() is not None
 
-# activate logging for svg
-# we need to import only after possible modification of sys.path, we disable here flake8 E402
-from lib.debug.debug import debug  # noqa: E402  # import global variable debug - don't import whole module
-debug.enable()  # perhaps it would be better to find a more relevant name; in fact, it's about logging and svg creation.
 
-# log startup info
-debug_logging.startup_info(logger, SCRIPTDIR, running_as_frozen, running_from_inkscape, debug_active, debug_type, profiler_type)
+# Enable debug logging (must be imported after sys.path setup)
+from lib.debug.debug import debug as debug_logger  # noqa: E402
+
+debug_logger.enable()
+
+debug_logging.startup_info(
+    logger,
+    SCRIPTDIR,
+    LOGDIR,
+    development_mode,
+    log_location,
+    running_from_inkscape,
+    debug_active,
+    debug_type,
+    profiler_type,
+)
 
 # --------------------------------------------------------------------------------------------
 
-# pop '--extension' from arguments and generate extension class name from extension name
-#   example:  --extension=params will instantiate Params() class from lib.extensions.
+# Extract '--extension' argument and dynamically load the corresponding extension class
+# NOTE: Must be imported after sys.path setup
+from lib import extensions  # noqa: E402
 
-# we need to import only after possible modification of sys.path, we disable here flake8 E402
-from lib import extensions  # noqa: E402  # import all supported extensions of institch
 
-# TODO: if we run this earlier the warnings ignore filter for releases will not work properly
-if running_as_frozen and not debug_logging.frozen_debug_active():
+# WARN: Do not move up; running earlier breaks release warning suppression.
+logging_active = development_mode or LOGDIR is not None
+if not logging_active:
     debug_logging.disable_warnings()
+
+# --------------------------------------------------------------------------------------------
 
 parser = ArgumentParser()
 parser.add_argument("--extension")
@@ -160,37 +157,34 @@ extension_name = my_args.extension
 # example: foo_bar_baz -> FooBarBaz
 extension_class_name = extension_name.title().replace("_", "")
 
-extension_class = getattr(extensions, extension_class_name)
-extension = extension_class()  # create instance of extension class - call __init__ method
+extension = getattr(extensions, extension_class_name)()
 
-# extension run(), we differentiate between debug and normal mode
-# - in debug or profile mode we debug or profile extension.run() method
-# - in normal mode we run extension.run() in try/except block to catch all exceptions and hide GTK spam
-if debug_active or profiler_type != "none":  # if debug or profile mode
-    if profiler_type == 'none':             # only debugging
-        extension.run(args=remaining_args)
-    else:                                  # do profiling
-        debug_utils.profile(profiler_type, SCRIPTDIR, ini, extension, remaining_args)
+# Execute extension in debug/profile mode vs. normal mode
+if profiler_type != "none":
+    debug_utils.profile(profiler_type, SCRIPTDIR, ini, extension, remaining_args)
+elif debug_active:
+    extension.run(args=remaining_args)
+else:
+    # Normal execution: catch exceptions and suppress GTK output
 
-else:   # if not debug nor profile mode
+    from inkex import errormsg  # Display UI error popups in Inkscape
+    from lxml.etree import XMLSyntaxError  # Catch malformed or non-standard SVG input
     from lib.exceptions import InkstitchException, format_uncaught_exception
-    from inkex import errormsg  # to show error message in inkscape
-    from lxml.etree import XMLSyntaxError  # to catch XMLSyntaxError from inkex
-    from lib.i18n import _      # see gettext translation function _()
-    from lib.utils import restore_stderr, save_stderr  # to hide GTK spam
+    from lib.i18n import _      # Gettext translation function
+    from lib.utils import restore_stderr, save_stderr  # Suppress GTK/C-level warning noise
 
-    save_stderr()  # hide GTK spam
-    exception = None
+
+    save_stderr()  # Suppress GTK warning noise
     try:
         extension.run(args=remaining_args)
     except (SystemExit, KeyboardInterrupt):
         raise
     except XMLSyntaxError:
-        msg = _("Ink/Stitch cannot read your SVG file. "
-                "This is often the case when you use a file which has been created with Adobe Illustrator.")
-        msg += "\n\n"
-        msg += _("Try to import the file into Inkscape through 'File > Import...' (Ctrl+I)")
-        errormsg(msg)
+        errormsg(
+            _("Ink/Stitch cannot read your SVG file. "
+              "This is often the case when you use a file which has been created with Adobe Illustrator.\n\n"
+              "Try to import the file into Inkscape through 'File > Import...' (Ctrl+I)")
+        )
     except InkstitchException as exc:
         errormsg(str(exc))
     except Exception:
@@ -200,3 +194,4 @@ else:   # if not debug nor profile mode
         restore_stderr()
 
     sys.exit(0)
+

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -41,6 +41,12 @@ else:
 # --------------------------------------------------------------------------------------------
 
 running_as_frozen = getattr(sys, 'frozen', None) is not None  # check if running from pyinstaller bundle
+running_from_readonly_filesystem = not os.access(SCRIPTDIR, os.W_OK)  # check if running from read-only filesystem
+
+# override runnig_as_frozen if read-only filesystem is detected
+if running_from_readonly_filesystem:
+    running_as_frozen = True
+
 
 if not running_as_frozen:  # override running_as_frozen from DEBUG.toml - for testing
     if safe_get(ini, "DEBUG", "force_frozen", default=False):

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -55,6 +55,44 @@ def _can_write_to_directory(path: Path) -> bool:
         return False
 
 
+def _modules_referencing_module(target_module: object) -> list[tuple[str, str]]:
+    refs: list[tuple[str, str]] = []
+    for module_name, module in sys.modules.items():
+        module_dict = getattr(module, '__dict__', None)
+        if not isinstance(module_dict, dict):
+            continue
+
+        for attr_name, attr_value in module_dict.items():
+            if attr_value is target_module:
+                refs.append((module_name, attr_name))
+                break
+
+    return sorted(refs)
+
+
+def _assert_inkex_not_imported_before_path_setup() -> None:
+    inkex_module = sys.modules.get('inkex')
+    if inkex_module is None:
+        return
+
+    inkex_file = getattr(inkex_module, '__file__', '<unknown>')
+    refs = _modules_referencing_module(inkex_module)
+    refs_msg = ', '.join([f"{module}.{attr}" for module, attr in refs[:10]])
+    if len(refs) > 10:
+        refs_msg += ', ...'
+
+    print(
+        "ERROR: 'inkex' was imported before sys.path setup. "
+        "This can select the wrong inkex installation when multiple versions are available.\n"
+        f"Loaded inkex module: {inkex_file}\n"
+        f"First modules referencing inkex: {refs_msg or '<none>'}\n"
+        "Fix: delay imports that depend on inkex until after reorder_sys_path().",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# ------------------------------------------------------------
+
 running_from_readonly_filesystem = not _can_write_to_directory(SCRIPTDIR)
 
 # override runnig_as_frozen if read-only filesystem is detected
@@ -105,24 +143,36 @@ if not running_as_frozen:  # debugging/profiling only in development mode
     # specify debugger type
     #   but if script was already started from debugger then don't read debug type from ini file or cmd line
     if not debug_active:
-        debug_type = debug_utils.resolve_debug_type(ini)  # read debug type from ini file or cmd line
+        debug_type = debug_utils.resolve_debug_type(
+            ini)  # read debug type from ini file or cmd line
 
-    profiler_type = debug_utils.resolve_profiler_type(ini)  # read profile type from ini file or cmd line
+    profiler_type = debug_utils.resolve_profiler_type(
+        ini)  # read profile type from ini file or cmd line
 
     if running_from_inkscape:
         # process creation of the Bash script - should be done before sys.path is modified, see below in prefer_pip_inkex
-        if safe_get(ini, "DEBUG", "create_bash_script", default=False):  # create script only if enabled in DEBUG.toml
+        if safe_get(
+                ini, "DEBUG", "create_bash_script",
+                default=False):  # create script only if enabled in DEBUG.toml
             debug_utils.write_offline_debug_script(SCRIPTDIR, ini)
 
         # disable debugger when running from inkscape
-        disable_from_inkscape = safe_get(ini, "DEBUG", "disable_from_inkscape", default=False)
+        disable_from_inkscape = safe_get(ini,
+                                         "DEBUG",
+                                         "disable_from_inkscape",
+                                         default=False)
         if disable_from_inkscape:
             debug_type = 'none'  # do not start debugger when running from inkscape
 
     # prefer pip installed inkex over inkscape bundled inkex, pip version is bundled with Inkstitch
     # - must be be done before importing inkex
-    prefer_pip_inkex = safe_get(ini, "LIBRARY", "prefer_pip_inkex", default=True)
+
+    prefer_pip_inkex = safe_get(ini,
+                                "LIBRARY",
+                                "prefer_pip_inkex",
+                                default=True)
     if prefer_pip_inkex and 'PYTHONPATH' in os.environ:
+        _assert_inkex_not_imported_before_path_setup()
         debug_utils.reorder_sys_path()
 
 # enabling of debug depends on value of debug_type in DEBUG.toml file

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -5,7 +5,6 @@
 
 import os
 import sys
-import tempfile
 from pathlib import Path  # to work with paths as objects
 from argparse import ArgumentParser  # to parse arguments and remove --extension
 
@@ -43,57 +42,7 @@ else:
 
 running_as_frozen = getattr(sys, 'frozen', None) is not None  # check if running from pyinstaller bundle
 
-
-def _can_write_to_directory(path: Path) -> bool:
-    """Return True only if creating and deleting a temp file in the directory succeeds."""
-    try:
-        fd, probe_path = tempfile.mkstemp(prefix=".inkstitch-write-test-", dir=path)
-        os.close(fd)
-        os.unlink(probe_path)
-        return True
-    except OSError:
-        return False
-
-
-def _modules_referencing_module(target_module: object) -> list[tuple[str, str]]:
-    refs: list[tuple[str, str]] = []
-    for module_name, module in sys.modules.items():
-        module_dict = getattr(module, '__dict__', None)
-        if not isinstance(module_dict, dict):
-            continue
-
-        for attr_name, attr_value in module_dict.items():
-            if attr_value is target_module:
-                refs.append((module_name, attr_name))
-                break
-
-    return sorted(refs)
-
-
-def _assert_inkex_not_imported_before_path_setup() -> None:
-    inkex_module = sys.modules.get('inkex')
-    if inkex_module is None:
-        return
-
-    inkex_file = getattr(inkex_module, '__file__', '<unknown>')
-    refs = _modules_referencing_module(inkex_module)
-    refs_msg = ', '.join([f"{module}.{attr}" for module, attr in refs[:10]])
-    if len(refs) > 10:
-        refs_msg += ', ...'
-
-    print(
-        "ERROR: 'inkex' was imported before sys.path setup. "
-        "This can select the wrong inkex installation when multiple versions are available.\n"
-        f"Loaded inkex module: {inkex_file}\n"
-        f"First modules referencing inkex: {refs_msg or '<none>'}\n"
-        "Fix: delay imports that depend on inkex until after reorder_sys_path().",
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
-# ------------------------------------------------------------
-
-running_from_readonly_filesystem = not _can_write_to_directory(SCRIPTDIR)
+running_from_readonly_filesystem = not debug_utils.can_write_to_directory(SCRIPTDIR)
 
 # override runnig_as_frozen if read-only filesystem is detected
 if running_from_readonly_filesystem:
@@ -172,7 +121,7 @@ if not running_as_frozen:  # debugging/profiling only in development mode
                                 "prefer_pip_inkex",
                                 default=True)
     if prefer_pip_inkex and 'PYTHONPATH' in os.environ:
-        _assert_inkex_not_imported_before_path_setup()
+        debug_utils.assert_inkex_not_imported_before_path_setup()
         debug_utils.reorder_sys_path()
 
 # enabling of debug depends on value of debug_type in DEBUG.toml file

--- a/inkstitch.py
+++ b/inkstitch.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import tempfile
 from pathlib import Path  # to work with paths as objects
 from argparse import ArgumentParser  # to parse arguments and remove --extension
 
@@ -41,7 +42,20 @@ else:
 # --------------------------------------------------------------------------------------------
 
 running_as_frozen = getattr(sys, 'frozen', None) is not None  # check if running from pyinstaller bundle
-running_from_readonly_filesystem = not os.access(SCRIPTDIR, os.W_OK)  # check if running from read-only filesystem
+
+
+def _can_write_to_directory(path: Path) -> bool:
+    """Return True only if creating and deleting a temp file in the directory succeeds."""
+    try:
+        fd, probe_path = tempfile.mkstemp(prefix=".inkstitch-write-test-", dir=path)
+        os.close(fd)
+        os.unlink(probe_path)
+        return True
+    except OSError:
+        return False
+
+
+running_from_readonly_filesystem = not _can_write_to_directory(SCRIPTDIR)
 
 # override runnig_as_frozen if read-only filesystem is detected
 if running_from_readonly_filesystem:

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -7,7 +7,7 @@ import os
 import sys
 from copy import deepcopy
 from random import random
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import inkex
 from shapely import geometry as shgeo
@@ -225,7 +225,7 @@ def point_command_symbols_up(node: inkex.BaseElement) -> None:
             point_upwards(use)
 
 
-def find_commands(node: inkex.BaseElement) -> List[Command]:
+def find_commands(node: inkex.BaseElement) -> list[Command]:
     """Find the symbols this node is connected to and return them as Commands"""
 
     # find all paths that have this object as a connection

--- a/lib/debug/debug.py
+++ b/lib/debug/debug.py
@@ -6,8 +6,9 @@
 import atexit  # to save svg file on exit
 import time    # to measure time of code block, use time.monotonic() instead of time.time()
 import traceback
+from collections.abc import Callable
 from datetime import datetime
-from typing import TypeVar, Callable, Any, cast
+from typing import TypeVar, Any, cast
 
 from contextlib import contextmanager  # to measure time of with block
 from pathlib import Path  # to work with paths as objects

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -82,6 +82,7 @@ from . import utils as debug_utils
 
 logger = logging.getLogger('inkstitch')
 
+
 def disable_warnings():
     warnings.simplefilter('ignore')  # ignore all warnings
 
@@ -105,6 +106,7 @@ def resolve_log_dir(development_mode: bool, log_location: str, SCRIPTDIR: Path) 
         return None
 
     return log_dir
+
 
 # Resolve log directory based on development mode, log location, and environment variables
 # Returns directory path, may not exist or is writable
@@ -131,7 +133,7 @@ def _resolve_log_dir(development_mode: bool, log_location: str, SCRIPTDIR: Path)
             return SCRIPTDIR
 
         case "document" | "doc":
-            if doc_env := os.environ.get("DOCUMENT_PATH"): # full name eg: .../x.svg
+            if doc_env := os.environ.get("DOCUMENT_PATH"):  # full name eg: .../x.svg
                 doc_path = Path(doc_env).expanduser().resolve()
                 return doc_path.parent if doc_path.is_file() else doc_path
             print("DEBUG: DOCUMENT_PATH environment variable not set. Disabling logging.", file=sys.stderr)
@@ -149,10 +151,11 @@ def _resolve_log_dir(development_mode: bool, log_location: str, SCRIPTDIR: Path)
             print(f"DEBUG: Unrecognized log_location '{log_location}'. Disabling logging.", file=sys.stderr)
             return None
 
+
 # --------------------------------------------------------------------------------------------
 # activate_logging - configure logging for inkstitch application
 def activate_logging(development_mode: bool, log_location: str,
-                     ini: dict, SCRIPTDIR: Path) -> Path:
+                     ini: dict, SCRIPTDIR: Path) -> Path | None:
     # Resolve logging directory
     LOGDIR = resolve_log_dir(development_mode, log_location, SCRIPTDIR)
 
@@ -177,15 +180,16 @@ def activate_logging(development_mode: bool, log_location: str,
 
 VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
 
+
 def activate_for_production(ini: dict, LOGDIR: Path):
     loglevel = os.environ.get('INKSTITCH_LOGLEVEL')
-    docpath = os.environ.get('DOCUMENT_PATH') # full path to input SVG file or None
+    docpath = os.environ.get('DOCUMENT_PATH')  # full path to input SVG file or None
 
     if not loglevel or loglevel.upper() not in VALID_LOG_LEVELS:
         loglevel = "WARNING"  # default log level for production mode
 
     if docpath:
-        doc_name = Path(docpath).name
+        doc_name = Path(Path(docpath).name)
     else:
         doc_name = Path("unknown_document")
 
@@ -202,7 +206,7 @@ def activate_for_production(ini: dict, LOGDIR: Path):
 
     # After this operation, logging will be activated, so we can use the logger.
     logging.config.dictConfig(config)  # configure root logger from dict
-    logging.captureWarnings(True) # capture all warnings to log file with level WARNING
+    logging.captureWarnings(True)  # capture all warnings to log file with level WARNING
 
 
 # in development mode we want to use configuration from some LOGGING.toml file
@@ -285,7 +289,7 @@ def expand_variables(cfg: dict, vars: dict):
     return cfg
 
 
-def startup_info(logger: logging.Logger, SCRIPTDIR: Path, LOGDIR: Path,
+def startup_info(logger: logging.Logger, SCRIPTDIR: Path, LOGDIR: Path | None,
                  development_mode: bool,
                  log_location: str,
                  running_from_inkscape: bool,
@@ -298,7 +302,6 @@ def startup_info(logger: logging.Logger, SCRIPTDIR: Path, LOGDIR: Path,
     logger.info(f"Development mode: {development_mode}")
     logger.info(f"Script directory: {SCRIPTDIR}")
     logger.info(f"Log directory: {LOGDIR}")
-
 
     # log Python version, platform, command line arguments, sys.path
     import sys

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -70,7 +70,7 @@ import os
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
 
 if sys.version_info >= (3, 11):
     import tomllib      # built-in in Python 3.11+
@@ -141,7 +141,7 @@ def disable_warnings():
 # in development mode we want to use configuration from some LOGGING.toml file
 def activate_for_development(ini: dict, SCRIPTDIR: Path):
     logging_config_file = safe_get(ini, "LOGGING", "log_config_file", default=None)
-    vars: Dict[str, Any] = {'SCRIPTDIR': SCRIPTDIR}        # dynamic data for logging configuration
+    vars: dict[str, Any] = {'SCRIPTDIR': SCRIPTDIR}        # dynamic data for logging configuration
 
     if logging_config_file is not None:
         logging_config_file = Path(logging_config_file)

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -66,82 +66,149 @@
 #
 
 # --------------------------------------------------------------------------------------------
+import logging           # to configure logging
+import logging.config    # to configure logging from dict
 import os
 import sys
+import tomllib           # built-in in Python 3.11+
+import warnings          # to control python warnings
+
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-if sys.version_info >= (3, 11):
-    import tomllib      # built-in in Python 3.11+
-else:
-    import tomli as tomllib
-
-import warnings          # to control python warnings
-import logging           # to configure logging
-import logging.config    # to configure logging from dict
-
 from .utils import safe_get     # mimic get method of dict with default value
+from . import utils as debug_utils
 
 logger = logging.getLogger('inkstitch')
-
-
-# --------------------------------------------------------------------------------------------
-# activate_logging - configure logging for inkstitch application
-def activate_logging(running_as_frozen: bool, ini: dict, SCRIPTDIR: Path):
-    if running_as_frozen:                          # in release mode
-        activate_for_frozen()
-    else:                                          # in development
-        activate_for_development(ini, SCRIPTDIR)
-
-
-# Configure logging in frozen (release) mode of application:
-# in release mode normally we want to ignore all warnings and logging, but we can enable it by setting environment variables
-#  - INKSTITCH_LOGLEVEL - logging level:
-#       'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
-#  - PYTHONWARNINGS, -W - warnings action controlled by python
-#       actions: 'error', 'ignore', 'always', 'default', 'module', 'once'
-def activate_for_frozen():
-    if frozen_debug_active():
-        loglevel = os.environ.get('INKSTITCH_LOGLEVEL')  # read log level from environment variable or None
-        docpath = os.environ.get('DOCUMENT_PATH')  # read document path from environment variable (set by inkscape) or None
-
-        # The end user enabled logging and warnings are redirected to the input_svg.inkstitch.log file.
-
-        vars = {
-            'loglevel': loglevel.upper(),
-            'logfilename': Path(docpath).with_suffix('.inkstitch.log')  # log file is created in document path
-        }
-        config = expand_variables(frozen_config, vars)
-
-        # dictConfig has access to top level variables, dict contains: ext://__main__.var
-        #   - restriction: variable must be last token in string - very limited functionality, avoid using it
-
-        # After this operation, logging will be activated, so we can use the logger.
-        logging.config.dictConfig(config)  # configure root logger from dict
-
-        logging.captureWarnings(True)                           # capture all warnings to log file with level WARNING
-    else:
-        logging.disable()                # globally disable all logging of all loggers
-        disable_warnings()
-
-
-def frozen_debug_active():
-    loglevel = os.environ.get('INKSTITCH_LOGLEVEL')  # read log level from environment variable or None
-    docpath = os.environ.get('DOCUMENT_PATH')  # read document path from environment variable (set by inkscape) or None
-    if docpath is not None and loglevel is not None and loglevel.upper() in ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']:
-        return True
-    return False
-
 
 def disable_warnings():
     warnings.simplefilter('ignore')  # ignore all warnings
 
 
+def resolve_log_dir(development_mode: bool, log_location: str, SCRIPTDIR: Path) -> Path | None:
+    log_dir = _resolve_log_dir(development_mode, log_location, SCRIPTDIR)
+    if log_dir is None:
+        return None
+
+    # Try to create the directory if it does not exist
+    if not log_dir.exists():
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except (OSError, PermissionError) as e:
+            print(f"DEBUG: Failed to create log directory '{log_dir}': {e}", file=sys.stderr)
+            return None
+
+    # Check if directory is writable
+    if not debug_utils.can_write_to_directory(log_dir):
+        print(f"DEBUG: Log directory is not writable: '{log_dir}'", file=sys.stderr)
+        return None
+
+    return log_dir
+
+# Resolve log directory based on development mode, log location, and environment variables
+# Returns directory path, may not exist or is writable
+#         None if logging is disabled (regular user mode)
+
+def _resolve_log_dir(development_mode: bool, log_location: str, SCRIPTDIR: Path) -> Path | None:
+    # Master override via environment variable (works for dev and regular users)
+    if env_path := os.environ.get("INKSTITCH_LOG_DIR"):
+        raw_path = Path(env_path).expanduser().resolve()
+        return raw_path.parent if raw_path.is_file() else raw_path
+
+    # Regular user mode without ENV -> no file logging
+    if not development_mode:
+        return None
+
+    # Handle absolute paths directly
+    raw_path = Path(log_location).expanduser()
+    if raw_path.is_absolute():
+        return raw_path.parent if raw_path.is_file() else raw_path
+
+    # Handle keywords
+    match log_location.lower():
+        case "script":
+            return SCRIPTDIR
+
+        case "document" | "doc":
+            if doc_env := os.environ.get("DOCUMENT_PATH"): # full name eg: .../x.svg
+                doc_path = Path(doc_env).expanduser().resolve()
+                return doc_path.parent if doc_path.is_file() else doc_path
+            print("DEBUG: DOCUMENT_PATH environment variable not set. Disabling logging.", file=sys.stderr)
+            return None
+
+        case "user" | "usr":
+            from lib.utils.paths import get_user_dir  # this loads inkex
+            return Path(get_user_dir())
+
+        case "temp" | "tmp":
+            import tempfile
+            return Path(tempfile.gettempdir()) / "inkstitch_logs"
+
+        case _:
+            print(f"DEBUG: Unrecognized log_location '{log_location}'. Disabling logging.", file=sys.stderr)
+            return None
+
+# --------------------------------------------------------------------------------------------
+# activate_logging - configure logging for inkstitch application
+def activate_logging(development_mode: bool, log_location: str,
+                     ini: dict, SCRIPTDIR: Path) -> Path:
+    # Resolve logging directory
+    LOGDIR = resolve_log_dir(development_mode, log_location, SCRIPTDIR)
+
+    if LOGDIR is None:
+        logging.disable()                # globally disable all logging of all loggers
+        disable_warnings()
+    elif development_mode:
+        activate_for_development(ini, LOGDIR)
+    else:
+        activate_for_production(ini, LOGDIR)
+
+    return LOGDIR  # return the directory where logs are written
+
+
+# Configure logging in frozen (release) mode of application:
+# in release mode normally we want to ignore all warnings and logging,
+# but we can enable it by setting environment variables
+#  - INKSTITCH_LOGLEVEL - logging level:
+#       'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+#  - PYTHONWARNINGS, -W - warnings action controlled by python
+#       actions: 'error', 'ignore', 'always', 'default', 'module', 'once'
+
+VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+def activate_for_production(ini: dict, LOGDIR: Path):
+    loglevel = os.environ.get('INKSTITCH_LOGLEVEL')
+    docpath = os.environ.get('DOCUMENT_PATH') # full path to input SVG file or None
+
+    if not loglevel or loglevel.upper() not in VALID_LOG_LEVELS:
+        loglevel = "WARNING"  # default log level for production mode
+
+    if docpath:
+        doc_name = Path(docpath).name
+    else:
+        doc_name = Path("unknown_document")
+
+    # The end user enabled logging and warnings are redirected to the input_svg.inkstitch.log file.
+
+    vars = {
+        'loglevel': loglevel.upper(),
+        'logfilename': LOGDIR / doc_name.with_suffix('.inkstitch.log')
+    }
+    config = expand_variables(deepcopy(frozen_config), vars)
+
+    # dictConfig has access to top level variables, dict contains: ext://__main__.var
+    #   - restriction: variable must be last token in string - very limited functionality, avoid using it
+
+    # After this operation, logging will be activated, so we can use the logger.
+    logging.config.dictConfig(config)  # configure root logger from dict
+    logging.captureWarnings(True) # capture all warnings to log file with level WARNING
+
+
 # in development mode we want to use configuration from some LOGGING.toml file
-def activate_for_development(ini: dict, SCRIPTDIR: Path):
+def activate_for_development(ini: dict, LOGDIR: Path):
     logging_config_file = safe_get(ini, "LOGGING", "log_config_file", default=None)
-    vars: dict[str, Any] = {'SCRIPTDIR': SCRIPTDIR}        # dynamic data for logging configuration
+    vars: dict[str, Any] = {'LOGDIR': LOGDIR, 'SCRIPTDIR': LOGDIR}  # dynamic data for logging configuration
 
     if logging_config_file is not None:
         logging_config_file = Path(logging_config_file)
@@ -152,46 +219,18 @@ def activate_for_development(ini: dict, SCRIPTDIR: Path):
             raise FileNotFoundError(f"{logging_config_file} file not found")
     else:                                   # if LOGGING.toml file does not exist, use default logging configuration
         vars['loglevel'] = 'DEBUG'          # set log level to DEBUG
-        vars['logfilename'] = SCRIPTDIR / "inkstitch.log"  # log file is created in current directory
+        vars['logfilename'] = LOGDIR / "inkstitch.log"  # log file is created in current directory
         devel_config = development_config   # get TOML configuration from module
 
-    original_config = deepcopy(devel_config)
-    try:
-        configure_logging(deepcopy(original_config), ini, vars)  # initialize and activate logging configuration
-    except (OSError, ValueError) as error:
-        if not _caused_by_permission_error(error):
-            raise
-
-        fallback_dir = _get_fallback_log_dir()
-        print(f"WARNING: Cannot write logs to '{SCRIPTDIR}'. Using '{fallback_dir}' instead.", file=sys.stderr)
-        fallback_vars = dict(vars)
-        fallback_vars['SCRIPTDIR'] = fallback_dir
-        if 'logfilename' in fallback_vars:
-            fallback_vars['logfilename'] = fallback_dir / Path(fallback_vars['logfilename']).name
-        configure_logging(deepcopy(original_config), ini, fallback_vars)
+    configure_logging(deepcopy(devel_config), ini, vars)  # initialize and activate logging configuration
 
     logger.info("Running in development mode")
     logger.info(f"Using logging configuration from file: {logging_config_file}")
     logger.debug(f"Logging configuration: {devel_config=}")
 
 
-def _caused_by_permission_error(error: BaseException | None) -> bool:
-    while error is not None:
-        if isinstance(error, PermissionError):
-            return True
-        error = error.__cause__
-    return False
-
-
-def _get_fallback_log_dir() -> Path:
-    from lib.utils.paths import get_user_dir
-
-    fallback_dir = Path(get_user_dir())
-    fallback_dir.mkdir(parents=True, exist_ok=True)
-    return fallback_dir
-
-
 # --------------------------------------------------------------------------------------------
+
 # configure logging from dictionary:
 #  - capture all warnings to log file with level WARNING - depends on warnings_capture
 #  - set action for warnings: 'error', 'ignore', 'always', 'default', 'module', 'once' - depends on warnings_action
@@ -246,13 +285,20 @@ def expand_variables(cfg: dict, vars: dict):
     return cfg
 
 
-def startup_info(logger: logging.Logger, SCRIPTDIR: Path, running_as_frozen: bool, running_from_inkscape: bool,
+def startup_info(logger: logging.Logger, SCRIPTDIR: Path, LOGDIR: Path,
+                 development_mode: bool,
+                 log_location: str,
+                 running_from_inkscape: bool,
                  debug_active: bool, debug_type: str, profiler_type: str):
-    logger.info(f"Running as frozen: {running_as_frozen}")
     logger.info(f"Running from inkscape: {running_from_inkscape}")
+    logger.info(f"Log location: {log_location}")
     logger.info(f"Debugger active: {debug_active}")
     logger.info(f"Debugger type: {debug_type!r}")
     logger.info(f"Profiler type: {profiler_type!r}")
+    logger.info(f"Development mode: {development_mode}")
+    logger.info(f"Script directory: {SCRIPTDIR}")
+    logger.info(f"Log directory: {LOGDIR}")
+
 
     # log Python version, platform, command line arguments, sys.path
     import sys

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -166,6 +166,8 @@ def activate_for_development(ini: dict, SCRIPTDIR: Path):
         print(f"WARNING: Cannot write logs to '{SCRIPTDIR}'. Using '{fallback_dir}' instead.", file=sys.stderr)
         fallback_vars = dict(vars)
         fallback_vars['SCRIPTDIR'] = fallback_dir
+        if 'logfilename' in fallback_vars:
+            fallback_vars['logfilename'] = fallback_dir / Path(fallback_vars['logfilename']).name
         configure_logging(deepcopy(original_config), ini, fallback_vars)
 
     logger.info("Running in development mode")

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -68,6 +68,7 @@
 # --------------------------------------------------------------------------------------------
 import os
 import sys
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict, Any
 
@@ -154,11 +155,38 @@ def activate_for_development(ini: dict, SCRIPTDIR: Path):
         vars['logfilename'] = SCRIPTDIR / "inkstitch.log"  # log file is created in current directory
         devel_config = development_config   # get TOML configuration from module
 
-    configure_logging(devel_config, ini, vars)  # initialize and activate logging configuration
+    original_config = deepcopy(devel_config)
+    try:
+        configure_logging(deepcopy(original_config), ini, vars)  # initialize and activate logging configuration
+    except (OSError, ValueError) as error:
+        if not _caused_by_permission_error(error):
+            raise
+
+        fallback_dir = _get_fallback_log_dir()
+        print(f"WARNING: Cannot write logs to '{SCRIPTDIR}'. Using '{fallback_dir}' instead.", file=sys.stderr)
+        fallback_vars = dict(vars)
+        fallback_vars['SCRIPTDIR'] = fallback_dir
+        configure_logging(deepcopy(original_config), ini, fallback_vars)
 
     logger.info("Running in development mode")
     logger.info(f"Using logging configuration from file: {logging_config_file}")
     logger.debug(f"Logging configuration: {devel_config=}")
+
+
+def _caused_by_permission_error(error: BaseException) -> bool:
+    while error is not None:
+        if isinstance(error, PermissionError):
+            return True
+        error = error.__cause__
+    return False
+
+
+def _get_fallback_log_dir() -> Path:
+    from lib.utils.paths import get_user_dir
+
+    fallback_dir = Path(get_user_dir())
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+    return fallback_dir
 
 
 # --------------------------------------------------------------------------------------------

--- a/lib/debug/logging.py
+++ b/lib/debug/logging.py
@@ -175,7 +175,7 @@ def activate_for_development(ini: dict, SCRIPTDIR: Path):
     logger.debug(f"Logging configuration: {devel_config=}")
 
 
-def _caused_by_permission_error(error: BaseException) -> bool:
+def _caused_by_permission_error(error: BaseException | None) -> bool:
     while error is not None:
         if isinstance(error, PermissionError):
             return True

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -76,7 +76,7 @@ def _write_offline_debug_script(bash_file: Path, bash_svg: Path, svg_file: Path,
         f.write('#!/usr/bin/env bash\n')
 
         # cmd line arguments for debugging and profiling
-        f.write(bash_parser())  # parse cmd line arguments: -d -p
+        f.write(bash_arg_parser())  # parse cmd line arguments: -d -p
 
         f.write(f'# python version: {sys.version}\n')   # python version
 
@@ -95,13 +95,11 @@ def _write_offline_debug_script(bash_file: Path, bash_svg: Path, svg_file: Path,
 
         # python module path
         f.write('# python sys.path:\n')
-        for p in sys.path:
-            f.write(f'#   {p}\n')
+        f.writelines(f'#   {p}\n' for p in sys.path)
 
         # see static void set_extensions_env() in inkscape/src/inkscape-main.cpp
         f.write('# PYTHONPATH:\n')
-        for p in os.environ.get('PYTHONPATH', '').split(os.pathsep):  # PYTHONPATH to list
-            f.write(f'#   {p}\n')
+        f.writelines(f'#   {p}\n' for p in os.environ.get('PYTHONPATH', '').split(os.pathsep))  # PYTHONPATH to list
 
         f.write(f'# copy {svg_file} to {bash_svg}\n#\n')
         shutil.copy(svg_file, debug_script_dir / bash_svg)  # copy file to bash_svg
@@ -127,21 +125,29 @@ def _write_offline_debug_script(bash_file: Path, bash_svg: Path, svg_file: Path,
     bash_file.chmod(0o0755)  # make file executable, hopefully ignored on Windows
 
 
-def bash_parser() -> str:
+def bash_arg_parser() -> str:
     return r'''
 set -e   #  exit on error
 
 # parse cmd line arguments:
 #   -d enable debugging
 #   -p enable profiling
+#   -h show help and exit
 #             ":..." - silent error reporting
-while getopts ":dp" opt; do
+while getopts ":dph" opt; do
   case $opt in
     d)
         export INKSTITCH_DEBUG_ENABLE="True"
         ;;
     p)
         export INKSTITCH_PROFILE_ENABLE="True"
+        ;;
+    h)
+        echo "Usage: $(basename "$0") [-d] [-p] [-h]"
+        echo "  -d  enable debugging"
+        echo "  -p  enable profiling"
+        echo "  -h  show this help and exit"
+        exit 0
         ;;
     \?)
         echo "Invalid option: -$OPTARG" >&2

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -69,6 +69,10 @@ def write_offline_debug_script(debug_script_dir: Path, ini: dict) -> None:
 
         f.write(f'# python version: {sys.version}\n')   # python version
 
+        # python interpreter that generated this script (used as first choice at runtime)
+        f.write(f'export SCRIPT_PYTHON="{sys.executable}"\n')
+        f.write(find_python_interpreter())  # fall back to venv/python3/py/python if SCRIPT_PYTHON is gone
+
         myargs = " ".join(sys.argv[1:])
         f.write(f'# script: {sys.argv[0]}  arguments: {myargs}\n')  # script name and arguments
 
@@ -108,7 +112,7 @@ def write_offline_debug_script(debug_script_dir: Path, ini: dict) -> None:
         f.write('export INKSTITCH_OFFLINE_SCRIPT="True"\n')
 
         f.write('# call inkstitch\n')
-        f.write(f'python3 inkstitch.py {myargs}\n')
+        f.write(f'"$INKSTITCH_PYTHON" inkstitch.py {myargs}\n')
     bash_file.chmod(0o0755)  # make file executable, hopefully ignored on Windows
 
 
@@ -138,6 +142,33 @@ while getopts ":dp" opt; do
         ;;
   esac
 done
+
+'''
+
+
+def find_python_interpreter() -> str:
+    return r'''
+# pick python interpreter to run inkstitch.py:
+#   1) SCRIPT_PYTHON - the interpreter that generated this script, if it still exists
+#   2) a .venv next to this script (Linux/macOS or Windows layout)
+#   3) python3 / py / python found in PATH
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -x "$SCRIPT_PYTHON" ]; then
+    INKSTITCH_PYTHON="$SCRIPT_PYTHON"
+elif [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+    INKSTITCH_PYTHON="$SCRIPT_DIR/.venv/bin/python"
+elif [ -x "$SCRIPT_DIR/.venv/Scripts/python.exe" ]; then
+    INKSTITCH_PYTHON="$SCRIPT_DIR/.venv/Scripts/python.exe"
+elif command -v python3 >/dev/null 2>&1; then
+    INKSTITCH_PYTHON="python3"
+elif command -v py >/dev/null 2>&1; then
+    INKSTITCH_PYTHON="py"
+elif command -v python >/dev/null 2>&1; then
+    INKSTITCH_PYTHON="python"
+else
+    echo "ERROR: no python interpreter found (tried SCRIPT_PYTHON, .venv, python3, py, python)" >&2
+    exit 1
+fi
 
 '''
 

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -170,6 +170,7 @@ def find_python_interpreter() -> str:
 #   2) a .venv next to this script (Linux/macOS or Windows layout)
 #   3) python3 / py / python found in PATH
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# "
 if [ -x "$SCRIPT_PYTHON" ]; then
     INKSTITCH_PYTHON="$SCRIPT_PYTHON"
 elif [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -11,7 +11,7 @@ import os
 import sys
 from pathlib import Path  # to work with paths as objects
 import logging
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..extensions.base import InkstitchExtension
 
@@ -254,7 +254,7 @@ def resolve_profiler_type(ini: dict) -> str:
 # - pyinstrument - profiler with nice html output
 
 
-def profile(profiler_type, profile_dir: Path, ini: dict, extension: 'InkstitchExtension', remaining_args: List[str]) -> None:
+def profile(profiler_type, profile_dir: Path, ini: dict, extension: 'InkstitchExtension', remaining_args: list[str]) -> None:
     '''
     profile with a profiler (e.g. cProfile, profile or pyinstrument)
     '''
@@ -281,7 +281,7 @@ def profile(profiler_type, profile_dir: Path, ini: dict, extension: 'InkstitchEx
         raise ValueError(f"unknown profiler type: '{profiler_type}'")
 
 
-def with_cprofile(extension: 'InkstitchExtension', remaining_args: List[str], profile_file_path: Path):
+def with_cprofile(extension: 'InkstitchExtension', remaining_args: list[str], profile_file_path: Path):
     '''
     profile with cProfile
     '''
@@ -304,7 +304,7 @@ def with_cprofile(extension: 'InkstitchExtension', remaining_args: List[str], pr
               file=sys.stderr)
 
 
-def with_profile(extension: 'InkstitchExtension', remaining_args: List[str], profile_file_path: Path) -> None:
+def with_profile(extension: 'InkstitchExtension', remaining_args: list[str], profile_file_path: Path) -> None:
     '''
     profile with profile
     '''
@@ -324,7 +324,7 @@ def with_profile(extension: 'InkstitchExtension', remaining_args: List[str], pro
               file=sys.stderr)
 
 
-def with_pyinstrument(extension: 'InkstitchExtension', remaining_args: List[str], profile_file_path: Path) -> None:
+def with_pyinstrument(extension: 'InkstitchExtension', remaining_args: list[str], profile_file_path: Path) -> None:
     '''
     profile with pyinstrument
     '''
@@ -343,7 +343,7 @@ def with_pyinstrument(extension: 'InkstitchExtension', remaining_args: List[str]
         print(f"Profiler: pyinstrument, stats written to '{profile_file_path.name}'. Use browser to see it.", file=sys.stderr)
 
 
-def with_time(extension: 'InkstitchExtension', remaining_args: List[str], profile_file_path: Path) -> None:
+def with_time(extension: 'InkstitchExtension', remaining_args: list[str], profile_file_path: Path) -> None:
     """
     A simple profiler that gives you similar information to running `time`.
     Low overhead, but of course only provides a high-level picture.
@@ -359,7 +359,7 @@ def with_time(extension: 'InkstitchExtension', remaining_args: List[str], profil
         print(f"Profiler: Time: real: {wall:.2f}s, proc (user+sys): {proc:.2f}s", file=sys.stderr)
 
 
-def with_monkeytype(extension: 'InkstitchExtension', remaining_args: List[str], profile_file_path: Path) -> None:
+def with_monkeytype(extension: 'InkstitchExtension', remaining_args: list[str], profile_file_path: Path) -> None:
     '''
     'profile' with monkeytype to get type information. This may be handy for anyone who wants to
     add type annotations to older parts of our code that don't have them.

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+import tempfile
 from pathlib import Path  # to work with paths as objects
 import logging
 from typing import TYPE_CHECKING
@@ -32,6 +33,54 @@ def safe_get(dictionary: dict, *keys, default=None):
             return default
         dictionary = dictionary[key]
     return dictionary
+
+
+def can_write_to_directory(path: Path) -> bool:
+    """Return True only if creating and deleting a temp file in the directory succeeds."""
+    try:
+        fd, probe_path = tempfile.mkstemp(prefix=".inkstitch-write-test-", dir=path)
+        os.close(fd)
+        os.unlink(probe_path)
+        return True
+    except OSError:
+        return False
+
+
+def _modules_referencing_module(target_module: object) -> list[tuple[str, str]]:
+    refs: list[tuple[str, str]] = []
+    for module_name, module in sys.modules.items():
+        module_dict = getattr(module, '__dict__', None)
+        if not isinstance(module_dict, dict):
+            continue
+
+        for attr_name, attr_value in module_dict.items():
+            if attr_value is target_module:
+                refs.append((module_name, attr_name))
+                break
+
+    return sorted(refs)
+
+
+def assert_inkex_not_imported_before_path_setup() -> None:
+    inkex_module = sys.modules.get('inkex')
+    if inkex_module is None:
+        return
+
+    inkex_file = getattr(inkex_module, '__file__', '<unknown>')
+    refs = _modules_referencing_module(inkex_module)
+    refs_msg = ', '.join([f"{module}.{attr}" for module, attr in refs[:10]])
+    if len(refs) > 10:
+        refs_msg += ', ...'
+
+    print(
+        "ERROR: 'inkex' was imported before sys.path setup. "
+        "This can select the wrong inkex installation when multiple versions are available.\n"
+        f"Loaded inkex module: {inkex_file}\n"
+        f"First modules referencing inkex: {refs_msg or '<none>'}\n"
+        "Fix: delay imports that depend on inkex until after reorder_sys_path().",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def write_offline_debug_script(debug_script_dir: Path, ini: dict) -> None:
@@ -58,7 +107,7 @@ def write_offline_debug_script(debug_script_dir: Path, ini: dict) -> None:
         print("WARN: input svg file is same as output svg file. No script created in write debug script.", file=sys.stderr)
         return
 
-    if not os.access(debug_script_dir, os.W_OK):
+    if not can_write_to_directory(debug_script_dir):
         logger.warning(f"No write permission to '{debug_script_dir}'. No script created in write debug script.")
         return
 

--- a/lib/debug/utils.py
+++ b/lib/debug/utils.py
@@ -58,9 +58,20 @@ def write_offline_debug_script(debug_script_dir: Path, ini: dict) -> None:
         print("WARN: input svg file is same as output svg file. No script created in write debug script.", file=sys.stderr)
         return
 
+    if not os.access(debug_script_dir, os.W_OK):
+        logger.warning(f"No write permission to '{debug_script_dir}'. No script created in write debug script.")
+        return
+
     import shutil  # to copy svg file
     bash_file = debug_script_dir / bash_name
 
+    try:
+        _write_offline_debug_script(bash_file, bash_svg, svg_file, debug_script_dir, shutil)
+    except OSError as e:
+        logger.error(f"Failed to write offline debug script to '{debug_script_dir}': {e}")
+
+
+def _write_offline_debug_script(bash_file: Path, bash_svg: Path, svg_file: Path, debug_script_dir: Path, shutil) -> None:
     with open(bash_file, 'w') as f:  # "w" text mode, automatic conversion of \n to os.linesep
         f.write('#!/usr/bin/env bash\n')
 

--- a/lib/elements/clone.py
+++ b/lib/elements/clone.py
@@ -5,7 +5,8 @@
 
 from contextlib import contextmanager
 from math import degrees
-from typing import Generator, Optional, Any, cast
+from collections.abc import Generator
+from typing import Optional, Any, cast
 
 from inkex import BaseElement, Title, Transform, Vector2d
 from lxml.etree import _Comment

--- a/lib/elements/clone.py
+++ b/lib/elements/clone.py
@@ -5,7 +5,7 @@
 
 from contextlib import contextmanager
 from math import degrees
-from typing import Dict, Generator, List, Optional, Tuple, Any, cast
+from typing import Generator, Optional, Any, cast
 
 from inkex import BaseElement, Title, Transform, Vector2d
 from lxml.etree import _Comment
@@ -69,12 +69,12 @@ class Clone(EmbroideryElement):
     def flip_angle(self) -> bool:
         return self.get_boolean_param('flip_angle', False)
 
-    def get_cache_key_data(self, previous_stitch: Any, next_element: EmbroideryElement) -> List[str]:
+    def get_cache_key_data(self, previous_stitch: Any, next_element: EmbroideryElement) -> list[str]:
         source_node = self.node.href
         source_elements = self.clone_to_elements(source_node)
         return [element.get_cache_key(previous_stitch, next_element) for element in source_elements]
 
-    def clone_to_elements(self, node: BaseElement) -> List[EmbroideryElement]:
+    def clone_to_elements(self, node: BaseElement) -> list[EmbroideryElement]:
         # Only used in get_cache_key_data, actual embroidery uses nodes_to_elements+iterate_nodes
         from .utils.nodes import node_to_elements
         elements = []
@@ -85,7 +85,7 @@ class Clone(EmbroideryElement):
                 elements.extend(self.clone_to_elements(child))
         return elements
 
-    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup], next_element: Optional[EmbroideryElement] = None) -> List[StitchGroup]:
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup], next_element: Optional[EmbroideryElement] = None) -> list[StitchGroup]:
         if not self.clone:
             return []
 
@@ -96,7 +96,7 @@ class Clone(EmbroideryElement):
 
             next_elements = [next_element]
             if len(elements) > 1:
-                next_elements = cast(List[Optional[EmbroideryElement]], elements[1:]) + next_elements
+                next_elements = cast(list[Optional[EmbroideryElement]], elements[1:]) + next_elements
             for element, next_element in zip(elements, next_elements):
                 # Using `embroider` here to get trim/stop after commands, etc.
                 element_stitch_groups = element.embroider(last_stitch_group, next_element)
@@ -134,14 +134,14 @@ class Clone(EmbroideryElement):
         return False
 
     @cache
-    def first_and_last_element(self) -> Tuple[Optional[EmbroideryElement], Optional[EmbroideryElement]]:
+    def first_and_last_element(self) -> tuple[Optional[EmbroideryElement], Optional[EmbroideryElement]]:
         with self.clone_elements() as elements:
             if len(elements):
                 return elements[0], elements[-1]
         return None, None
 
     @contextmanager
-    def clone_elements(self) -> Generator[List[EmbroideryElement], None, None]:
+    def clone_elements(self) -> Generator[list[EmbroideryElement], None, None]:
         """
         A context manager method which yields a set of elements representing the cloned element(s) href'd by this clone's element.
         Cleans up after itself afterwards.
@@ -161,7 +161,7 @@ class Clone(EmbroideryElement):
             for cloned_node in cloned_nodes:
                 cloned_node.delete()
 
-    def resolve_clone(self, recursive: bool = True) -> List[BaseElement]:
+    def resolve_clone(self, recursive: bool = True) -> list[BaseElement]:
         """
         "Resolve" this clone element by copying the node it hrefs as if unlinking the clone in Inkscape.
         The node will be added as a sibling of this element's node, with its transform and style applied.
@@ -185,7 +185,7 @@ class Clone(EmbroideryElement):
             if is_clone(cloned_node):
                 cloned_node = cloned_node.replace_with(Clone(cloned_node).resolve_clone()[0])
             else:
-                clones: List[BaseElement] = [n for n in cloned_node.iterdescendants() if is_clone(n)]
+                clones: list[BaseElement] = [n for n in cloned_node.iterdescendants() if is_clone(n)]
                 for clone in clones:
                     clone.replace_with(Clone(clone).resolve_clone()[0])
 
@@ -296,7 +296,7 @@ def clone_with_fixup(parent: BaseElement, node: BaseElement) -> BaseElement:
     references in the cloned subtree to point to elements from the clone subtree.
     """
     # A map of "#id" -> "#corresponding-id-in-the-cloned-subtree"
-    id_map: Dict[str, str] = {}
+    id_map: dict[str, str] = {}
 
     def clone_children(parent: BaseElement, node: BaseElement) -> BaseElement:
         # Copy the node without copying its children.

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -8,7 +8,7 @@ import json
 import sys
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Callable, List, Optional, TypeVar, Iterable, overload
+from typing import Any, Callable, Optional, TypeVar, Iterable, overload
 
 import inkex
 import numpy as np
@@ -584,11 +584,11 @@ class EmbroideryElement(object):
 
     @property
     @cache
-    def commands(self) -> List[Command]:
+    def commands(self) -> list[Command]:
         return find_commands(self.node)
 
     @cache
-    def get_commands(self, command: str) -> List[Command]:
+    def get_commands(self, command: str) -> list[Command]:
         return [c for c in self.commands if c.command == command]
 
     @cache
@@ -662,7 +662,7 @@ class EmbroideryElement(object):
 
         return lock_start, lock_end
 
-    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup], next_element: Optional[EmbroideryElement] = None) -> List[StitchGroup]:
+    def to_stitch_groups(self, last_stitch_group: Optional[StitchGroup], next_element: Optional[EmbroideryElement] = None) -> list[StitchGroup]:
         raise NotImplementedError("%s must implement to_stitch_groups()" % self.__class__.__name__)
 
     def color(self):
@@ -782,7 +782,7 @@ class EmbroideryElement(object):
 
         return cache_key
 
-    def embroider(self, last_stitch_group: Optional[StitchGroup], next_element=None) -> List[StitchGroup]:
+    def embroider(self, last_stitch_group: Optional[StitchGroup], next_element=None) -> list[StitchGroup]:
         debug.log(f"starting {self.node.get('id')} {self.node.get(INKSCAPE_LABEL)}")
 
         with self.handle_unexpected_exceptions():

--- a/lib/elements/element.py
+++ b/lib/elements/element.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Callable, Optional, TypeVar, Iterable, overload
+from typing import Any, Optional, TypeVar, overload
 
 import inkex
 import numpy as np

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -5,8 +5,9 @@
 
 import itertools
 from copy import deepcopy
+from collections.abc import Sequence
 from itertools import chain
-from typing import Optional, Sequence, overload
+from typing import Optional, overload
 
 import numpy as np
 from inkex import Path, Vector2d

--- a/lib/elements/satin_column.py
+++ b/lib/elements/satin_column.py
@@ -6,7 +6,7 @@
 import itertools
 from copy import deepcopy
 from itertools import chain
-from typing import List, Tuple, Optional, Sequence, overload
+from typing import Optional, Sequence, overload
 
 import numpy as np
 from inkex import Path, Vector2d
@@ -671,7 +671,7 @@ class SatinColumn(EmbroideryElement):
         else:
             return rails
 
-    def _get_compensated_line_string_rails(self, start: float, end: float) -> List[shgeo.Point | shgeo.LineString]:
+    def _get_compensated_line_string_rails(self, start: float, end: float) -> list[shgeo.Point | shgeo.LineString]:
         """Apply push compensation on rails"""
         return [self._apply_push_comp(rail, start, end) for rail in self.line_string_rails]
 
@@ -1245,7 +1245,7 @@ class SatinColumn(EmbroideryElement):
     @debug.time
     def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float] = (0, 0),
                              offset_proportional: tuple[float, float] = (0, 0), use_random: bool = False,
-                             ) -> List[Tuple[Point, Point]]:
+                             ) -> list[tuple[Point, Point]]:
         # Take a section from each rail in turn, and plot out an equal number
         # of points on both rails.  Return the points plotted. The points will
         # be contracted or expanded by offset using self.offset_points().

--- a/lib/elements/utils/nodes.py
+++ b/lib/elements/utils/nodes.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 from inkex import BaseElement
 from lxml.etree import Comment
@@ -26,7 +26,7 @@ from ..stroke import Stroke
 from ..text import TextObject
 
 
-def node_to_elements(node, clone_to_element=False) -> List[EmbroideryElement]:  # noqa: C901
+def node_to_elements(node, clone_to_element=False) -> list[EmbroideryElement]:  # noqa: C901
     if node.style('display') == 'none':
         return []
     if is_clone(node) and not clone_to_element:
@@ -40,7 +40,7 @@ def node_to_elements(node, clone_to_element=False) -> List[EmbroideryElement]:  
         return [MarkerObject(node)]
 
     elif node.tag in EMBROIDERABLE_TAGS or is_clone(node):
-        elements: List[EmbroideryElement] = []
+        elements: list[EmbroideryElement] = []
 
         from ...sew_stack import SewStack
         sew_stack = SewStack(node)
@@ -72,7 +72,7 @@ def node_to_elements(node, clone_to_element=False) -> List[EmbroideryElement]:  
         return []
 
 
-def nodes_to_elements(nodes: Iterable[BaseElement]) -> List[EmbroideryElement]:
+def nodes_to_elements(nodes: Iterable[BaseElement]) -> list[EmbroideryElement]:
     elements = []
     for node in nodes:
         elements.extend(node_to_elements(node))
@@ -81,11 +81,11 @@ def nodes_to_elements(nodes: Iterable[BaseElement]) -> List[EmbroideryElement]:
 
 
 def iterate_nodes(node: BaseElement,  # noqa: C901
-                  selection: Optional[List[BaseElement]] = None,
-                  troubleshoot=False) -> List[BaseElement]:
+                  selection: Optional[list[BaseElement]] = None,
+                  troubleshoot=False) -> list[BaseElement]:
     # Postorder traversal of selected nodes and their descendants.
     # Returns all nodes if there is no selection.
-    def walk(node: BaseElement, selected: bool) -> List[BaseElement]:
+    def walk(node: BaseElement, selected: bool) -> list[BaseElement]:
         nodes = []
 
         # lxml-stubs types are wrong, node.tag can be Comment.

--- a/lib/elements/utils/nodes.py
+++ b/lib/elements/utils/nodes.py
@@ -3,7 +3,8 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import Iterable, Optional
+from collections.abc import Iterable
+from typing import Optional
 
 from inkex import BaseElement
 from lxml.etree import Comment

--- a/lib/elements/validation.py
+++ b/lib/elements/validation.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import Optional, List
+from typing import Optional
 from shapely.geometry import Point as ShapelyPoint
 
 from ..utils import Point as InkstitchPoint
@@ -24,7 +24,7 @@ class ValidationMessage(object):
     # Subclasses will fill these in.
     name: Optional[str] = None
     description: Optional[str] = None
-    steps_to_solve: List[str] = []
+    steps_to_solve: list[str] = []
 
     def __init__(self, position=None, label=""):
         if isinstance(position, ShapelyPoint):

--- a/lib/extensions/apply_threadlist.py
+++ b/lib/extensions/apply_threadlist.py
@@ -6,7 +6,7 @@
 import os
 import re
 import sys
-from typing import List, Optional
+from typing import Optional
 
 import inkex
 
@@ -81,7 +81,7 @@ class ApplyThreadlist(InkstitchExtension):
             inkex.errormsg(_("The filepath specified is not a file but a dictionary.\nPlease choose a threadlist file to import."))
             sys.exit(1)
 
-    def verify_colors(self, colors: List[List[Optional[str]]], method: int) -> None:
+    def verify_colors(self, colors: list[list[Optional[str]]], method: int) -> None:
         if all(c is None for c in colors):
             inkex.errormsg(_("Couldn't find any matching colors in the file."))
             if method == 1:
@@ -90,7 +90,7 @@ class ApplyThreadlist(InkstitchExtension):
                 inkex.errormsg(_("Please chose an other color palette for your design."))
             sys.exit(1)
 
-    def parse_inkstitch_threadlist(self, path: str) -> List[List[Optional[str]]]:
+    def parse_inkstitch_threadlist(self, path: str) -> list[list[Optional[str]]]:
         colors = []
         with open(path) as threadlist:
             for line in threadlist:
@@ -103,7 +103,7 @@ class ApplyThreadlist(InkstitchExtension):
                         colors.append([None, None])
         return colors
 
-    def parse_color_format(self, path: str) -> List[List[Optional[str]]]:
+    def parse_color_format(self, path: str) -> list[list[Optional[str]]]:
         colors = []
         threads = pystitch.read(path).threadlist
         for color in threads:
@@ -114,7 +114,7 @@ class ApplyThreadlist(InkstitchExtension):
                 colors.append([color.hex_color(), None])
         return colors
 
-    def parse_threadlist_by_catalog_number(self, path: str) -> List[List[Optional[str]]]:
+    def parse_threadlist_by_catalog_number(self, path: str) -> list[list[Optional[str]]]:
         palette_name = self.options.palette
         palette = ThreadCatalog().get_palette_by_name(palette_name)
 

--- a/lib/extensions/auto_run.py
+++ b/lib/extensions/auto_run.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from inkex import Boolean, Group, Vector2d, errormsg
 
@@ -53,7 +53,7 @@ class AutoRun(CommandsExtension):
                 return command.target_point
         return None
 
-    def check_selection(self) -> List[Union[Stroke, Any]]:
+    def check_selection(self) -> list[Union[Stroke, Any]]:
         if not self.svg.selection:
             # L10N auto-route running stitch columns extension
             errormsg(_("Please select one or more stroke elements."))

--- a/lib/extensions/break_apart.py
+++ b/lib/extensions/break_apart.py
@@ -4,7 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from copy import copy
-from typing import List, Sequence
+from typing import Sequence
 
 from inkex import Path, errormsg
 from shapely import make_valid
@@ -69,7 +69,7 @@ class BreakApart(InkstitchExtension):
             if recombined_polygons:
                 self.polygons_to_nodes(recombined_polygons, element)
 
-    def break_apart_paths(self, paths: Sequence[Sequence[Sequence[float]]]) -> List[Polygon]:
+    def break_apart_paths(self, paths: Sequence[Sequence[Sequence[float]]]) -> list[Polygon]:
         polygons = []
         for path in paths:
             if len(path) < 3:
@@ -84,7 +84,7 @@ class BreakApart(InkstitchExtension):
                 polygons.append(polygon)
         return polygons
 
-    def combine_overlapping_polygons(self, polygons: List[Polygon]) -> List[Polygon]:
+    def combine_overlapping_polygons(self, polygons: list[Polygon]) -> list[Polygon]:
         for polygon in polygons:
             for other in polygons:
                 if polygon == other:
@@ -106,10 +106,10 @@ class BreakApart(InkstitchExtension):
         valid = geom.is_valid
         return valid
 
-    def ensure_minimum_size(self, polygons: List[Polygon]) -> List[Polygon]:
+    def ensure_minimum_size(self, polygons: list[Polygon]) -> list[Polygon]:
         return [polygon for polygon in polygons if polygon.area > self.minimum_size]
 
-    def recombine_polygons(self, polygons: List[Polygon]) -> List[List[Polygon]]:
+    def recombine_polygons(self, polygons: list[Polygon]) -> list[list[Polygon]]:
         polygons.sort(key=lambda polygon: polygon.area, reverse=True)
         multipolygons = []
         holes = []
@@ -134,7 +134,7 @@ class BreakApart(InkstitchExtension):
             multipolygons.append(polygon_list)
         return multipolygons
 
-    def polygons_to_nodes(self, polygon_list: List[List[Polygon]], element: EmbroideryElement) -> None:
+    def polygons_to_nodes(self, polygon_list: list[list[Polygon]], element: EmbroideryElement) -> None:
         # reverse the list of polygons, we don't want to cover smaller shapes
         polygon_list = polygon_list[::-1]
         parent = element.node.getparent()

--- a/lib/extensions/break_apart.py
+++ b/lib/extensions/break_apart.py
@@ -4,7 +4,7 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from copy import copy
-from typing import Sequence
+from collections.abc import Sequence
 
 from inkex import Path, errormsg
 from shapely import make_valid

--- a/lib/extensions/redwork.py
+++ b/lib/extensions/redwork.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2024 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
-from typing import List
 
 import networkx as nx
 from inkex import Boolean, Group, Path, PathElement, errormsg
@@ -81,8 +80,8 @@ class Redwork(InkstitchExtension):
         if not self.options.keep_originals:
             self._delete_original_elements(elements)
 
-    def _group_by_colors(self, elements: list[Stroke]) -> dict[str, List[Stroke]]:
-        color_groups: dict[str, List[Stroke]] = {}
+    def _group_by_colors(self, elements: list[Stroke]) -> dict[str, list[Stroke]]:
+        color_groups: dict[str, list[Stroke]] = {}
 
         if self.options.redwork_split_colors:
             for element in elements:

--- a/lib/extensions/stitch_plan_preview.py
+++ b/lib/extensions/stitch_plan_preview.py
@@ -7,7 +7,7 @@ import sys
 from base64 import b64encode
 from re import findall
 from tempfile import TemporaryDirectory
-from typing import Optional, Tuple
+from typing import Optional
 
 from inkex import BaseElement, Boolean, Image, errormsg
 
@@ -69,7 +69,7 @@ class StitchPlanPreview(InkstitchExtension):
         self.translate(svg, layer)
         self.set_needle_points(layer)
 
-    def parse_mode(self) -> Tuple[bool, Optional[int]]:
+    def parse_mode(self) -> tuple[bool, Optional[int]]:
         """
         Parse the "mode" option and return a tuple of a bool indicating if realistic rendering should be used,
         and an optional int indicating the dpi value to use for rasterization, or None if rasterization should not be used.

--- a/lib/extensions/unlink_clone.py
+++ b/lib/extensions/unlink_clone.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import List, Tuple, cast
+from typing import cast
 
 from inkex import BaseElement, Boolean, Group, errormsg
 
@@ -32,7 +32,7 @@ class UnlinkClone(InkstitchExtension):
 
         # Two passes here: One to resolve all clones, and then another to replace those clones with their resolved versions.
         # This way we don't accidentally remove a node that another clone refers to.
-        clones_resolved: List[Tuple[BaseElement, BaseElement]] = []
+        clones_resolved: list[tuple[BaseElement, BaseElement]] = []
         for element in self.elements:
             if isinstance(element, Clone):
                 resolved = element.resolve_clone(recursive=recursive)

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -5,7 +5,7 @@
 
 import gettext
 import os
-from typing import Callable
+from collections.abc import Callable
 
 from .utils import cache, get_resource_dir
 

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -5,7 +5,7 @@
 
 import gettext
 import os
-from typing import Callable, Tuple
+from typing import Callable
 
 from .utils import cache, get_resource_dir
 
@@ -18,7 +18,7 @@ def N_(message: str) -> str:
     return message
 
 
-def localize(languages=None) -> Tuple[Callable[[str], str], gettext.NullTranslations]:
+def localize(languages=None) -> tuple[Callable[[str], str], gettext.NullTranslations]:
     locale_dir = get_resource_dir('locales')
 
     global translation, _

--- a/lib/lettering/font_variant.py
+++ b/lib/lettering/font_variant.py
@@ -6,7 +6,7 @@
 import os
 from collections import defaultdict
 from unicodedata import normalize, category
-from typing import List, Dict, Optional
+from typing import Optional
 import lzma
 
 import inkex
@@ -63,7 +63,7 @@ class FontVariant(object):
         self.path = font_path
         self.variant = variant
         self.default_glyph = default_glyph
-        self.glyphs: Dict[str, Glyph] = {}
+        self.glyphs: dict[str, Glyph] = {}
         self._load_glyphs()
 
     def _load_glyphs(self) -> None:
@@ -93,7 +93,7 @@ class FontVariant(object):
                 except (AttributeError, ValueError):
                     pass
 
-    def _get_variant_file_paths(self, legacy=False) -> List[str]:
+    def _get_variant_file_paths(self, legacy=False) -> list[str]:
         variant = self.variant
         if legacy:
             variant = self.LEGACY_VARIANT_CONVERSION_DICT[variant]

--- a/lib/lettering/paths.py
+++ b/lib/lettering/paths.py
@@ -2,7 +2,6 @@ from ..utils import get_bundled_dir, get_user_dir
 
 import os
 import json
-from typing import List
 
 
 def get_custom_font_cfg_file() -> str:
@@ -23,7 +22,7 @@ def get_custom_font_dir() -> str:
     return ""
 
 
-def get_font_paths() -> List[str]:
+def get_font_paths() -> list[str]:
     font_paths = [
         os.path.join(get_bundled_dir("fonts"), "src"),
         os.path.expanduser("~/.inkstitch/fonts/"),

--- a/lib/sew_stack/stitch_layers/stitch_layer.py
+++ b/lib/sew_stack/stitch_layers/stitch_layer.py
@@ -1,4 +1,3 @@
-from typing import Type
 from ...utils import coordinate_list_to_point_list
 from ...utils.dotdict import DotDict
 from .stitch_layer_editor import StitchLayerEditor
@@ -6,7 +5,7 @@ from .stitch_layer_editor import StitchLayerEditor
 
 class StitchLayer:
     # must be overridden in child classes and set to a subclass of StitchLayerEditor
-    editor_class: Type[StitchLayerEditor] = None  # type:ignore[assignment]
+    editor_class: type[StitchLayerEditor] = None  # type:ignore[assignment]
 
     # not to be overridden in child classes
     _defaults = None

--- a/lib/sew_stack/stitch_layers/stitch_layer_editor.py
+++ b/lib/sew_stack/stitch_layers/stitch_layer_editor.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable
+from collections.abc import Callable
 
 import wx.html
 import wx.propgrid

--- a/lib/stitch_plan/color_block.py
+++ b/lib/stitch_plan/color_block.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from typing import List
-
 from ..svg import PIXELS_PER_MM
 from ..threads import ThreadColor
 from ..utils.geometry import Point
@@ -174,7 +172,7 @@ class ColorBlock(object):
 
         return minx, miny, maxx, maxy
 
-    def make_offsets(self, offsets: List[Point]):
+    def make_offsets(self, offsets: list[Point]):
         first_final_stitch = len(self.stitches)
         while (first_final_stitch > 0 and self.stitches[first_final_stitch-1].is_terminator):
             first_final_stitch -= 1

--- a/lib/stitch_plan/lock_stitch.py
+++ b/lib/stitch_plan/lock_stitch.py
@@ -1,6 +1,6 @@
 import re
 from math import degrees
-from typing import List, Optional
+from typing import Optional
 
 from inkex import DirectedLineSegment, Path
 from shapely.geometry import LineString
@@ -22,7 +22,7 @@ class LockStitchDefinition:
     def __repr__(self) -> str:
         return "LockStitchDefinition(%s, %s, %s, %s)" % (self.id, self.name, self._path, self.preview_image)
 
-    def stitches(self, stitches, pos, scale) -> List[Stitch]:
+    def stitches(self, stitches, pos, scale) -> list[Stitch]:
         raise NotImplementedError(f"{self.__class__.__name__} must implement stitches()")
 
 

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations  # Needed for using the Stitch type as a constructor arg
 
+from collections.abc import Iterable
 from math import cos, radians, sin
-from typing import Any, Iterable, Optional, Type, Union, overload
+from typing import Any, Optional, Union, overload
 
 from shapely import geometry as shgeo
 
@@ -129,7 +130,7 @@ class Stitch(Point):
             raise ValueError("Coordinates must have at least 2 elements")
         return cls(coords[0], coords[1])
 
-    def __new__(cls: Type[Stitch], *args, **kwargs) -> Stitch:
+    def __new__(cls: type[Stitch], *args, **kwargs) -> Stitch:
         instance = super().__new__(cls)
 
         # Set default values for any new attributes here (see note in __init__() above)

--- a/lib/stitch_plan/stitch.py
+++ b/lib/stitch_plan/stitch.py
@@ -6,7 +6,7 @@
 from __future__ import annotations  # Needed for using the Stitch type as a constructor arg
 
 from math import cos, radians, sin
-from typing import Any, Dict, Iterable, Optional, Set, Type, Union, overload
+from typing import Any, Iterable, Optional, Type, Union, overload
 
 from shapely import geometry as shgeo
 
@@ -23,7 +23,7 @@ class Stitch(Point):
     trim: bool
     color_change: bool
     min_stitch_length: Optional[float]
-    tags: Set[str]
+    tags: set[str]
 
     @overload
     def __init__(
@@ -214,12 +214,12 @@ class Stitch(Point):
         out.y = offset_y + sin_rad * adjusted_x + cos_rad * adjusted_y
         return out
 
-    def __json__(self) -> Dict[str, Any]:
+    def __json__(self) -> dict[str, Any]:
         attributes = dict(vars(self))
         attributes['tags'] = list(attributes['tags'])
         return attributes
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         # This is used by pickle.  We want to sort the tag list so that the
         # pickled representation is stable, since it's used to generate cache
         # keys.

--- a/lib/stitch_plan/stitch_group.py
+++ b/lib/stitch_plan/stitch_group.py
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
-from typing import Optional, Literal, Sequence
+from collections.abc import Sequence
+from typing import Optional, Literal
 
 from inkex import Color
 from shapely import geometry as shgeo

--- a/lib/stitch_plan/stitch_plan.py
+++ b/lib/stitch_plan/stitch_plan.py
@@ -4,7 +4,6 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 from sys import exit
-from typing import List
 
 from inkex import errormsg
 
@@ -224,7 +223,7 @@ class StitchPlan(object):
         else:
             return None
 
-    def make_offsets(self, offsets: List[Point]):
+    def make_offsets(self, offsets: list[Point]):
         out = StitchPlan()
         out.color_blocks = [block.make_offsets(offsets) for block in self]
         return out

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -5,7 +5,7 @@
 """Utility functions to produce running stitches."""
 
 import math
-import typing
+from collections.abc import Sequence
 from copy import copy
 from math import tau
 
@@ -211,11 +211,11 @@ def cut_segment_with_circle(origin: Point, r: float, a: Point, b: Point) -> Poin
 
 def take_stitch(
     start: Point,
-    points: typing.Sequence[Point],
+    points: Sequence[Point],
     idx: int,
     stitch_length: float,
     tolerance: float,
-) -> tuple[typing.Optional[Point], typing.Optional[int]]:
+) -> tuple[Point | None, int | None]:
     """Take a single stitch based on the Zhao-Saalfeld curve simplification algorithm.
 
     Based on: https://cartogis.org/docs/proceedings/archive/auto-carto-13/pdf/
@@ -246,7 +246,7 @@ def take_stitch(
 
 
 def stitch_curve_evenly_strict(  # noqa C901
-    points: typing.Sequence[Point],
+    points: Sequence[Point],
     stitch_length: list[float],
     tolerance: float,
     min_stitch_length: float,
@@ -262,7 +262,7 @@ def stitch_curve_evenly_strict(  # noqa C901
     """
     if len(points) < 2:
         return [], stitch_length_pos, stitch_distance_passed
-    i: typing.Optional[int] = 1
+    i: int | None = 1
     last = points[0]
     stitches: list[Point] = []
     while i is not None and i < len(points):
@@ -305,7 +305,7 @@ def stitch_curve_evenly_strict(  # noqa C901
 
 
 def stitch_curve_evenly(
-    points: typing.Sequence[Point],
+    points: Sequence[Point],
     stitch_length: list[float],
     tolerance: float,
     stitch_length_pos: int = 0,
@@ -320,7 +320,7 @@ def stitch_curve_evenly(
     for j in reversed(range(0, len(points) - 1)):
         dist_left[j] = dist_left[j + 1] + points[j].distance(points[j + 1])
 
-    i: typing.Optional[int] = 1
+    i: int | None = 1
     last = points[0]
     stitches: list[Point] = []
     while i is not None and i < len(points):
@@ -342,7 +342,7 @@ def stitch_curve_evenly(
 
 
 def stitch_curve_randomly(
-    points: typing.Sequence[Point],
+    points: Sequence[Point],
     stitch_length: list[float],
     tolerance: float,
     stitch_length_sigma: float,
@@ -361,7 +361,7 @@ def stitch_curve_randomly(
     min_stitch_length = max(0, stitch_length[stitch_length_pos] * (1 - stitch_length_sigma))
     max_stitch_length = stitch_length[stitch_length_pos] * (1 + stitch_length_sigma)
 
-    i: typing.Optional[int] = 1
+    i: int | None = 1
     last = points[0]
     last_shortened = 0.0
     stitches = []

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -23,7 +23,7 @@ def lerp(a, b, t: float) -> float:
     return (1 - t) * a + t * b
 
 
-def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_seed=None) -> typing.list[shgeo.Point]:
+def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_seed=None) -> list[shgeo.Point]:
     """Split a segment into n even parts, optionally with jitter."""
     if segments <= 1:
         return []
@@ -215,7 +215,7 @@ def take_stitch(
     idx: int,
     stitch_length: float,
     tolerance: float,
-) -> typing.tuple[typing.Optional[Point], typing.Optional[int]]:
+) -> tuple[typing.Optional[Point], typing.Optional[int]]:
     """Take a single stitch based on the Zhao-Saalfeld curve simplification algorithm.
 
     Based on: https://cartogis.org/docs/proceedings/archive/auto-carto-13/pdf/
@@ -252,7 +252,7 @@ def stitch_curve_evenly_strict(  # noqa C901
     min_stitch_length: float,
     stitch_length_pos: int = 0,
     stitch_distance_passed: float = 0,
-) -> typing.tuple[list[Point], int, float]:
+) -> tuple[list[Point], int, float]:
     """Split a curve into even-length stitches while handling curves correctly.
 
     Adapts stitch lengths to the distance that already has been passed,
@@ -348,7 +348,7 @@ def stitch_curve_randomly(
     stitch_length_sigma: float,
     random_seed: str,
     stitch_length_pos: int = 0,
-) -> typing.tuple[list[Point], int]:
+) -> tuple[list[Point], int]:
     """Split a curve into stitches of random length within a range.
 
     Attempts to randomize phase so distribution doesn't depend on direction.

--- a/lib/stitches/running_stitch.py
+++ b/lib/stitches/running_stitch.py
@@ -23,7 +23,7 @@ def lerp(a, b, t: float) -> float:
     return (1 - t) * a + t * b
 
 
-def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_seed=None) -> typing.List[shgeo.Point]:
+def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_seed=None) -> typing.list[shgeo.Point]:
     """Split a segment into n even parts, optionally with jitter."""
     if segments <= 1:
         return []
@@ -40,14 +40,14 @@ def split_segment_even_n(a, b, segments: int, jitter_sigma: float = 0.0, random_
     return [line.interpolate(x, normalized=True) for x in splits]
 
 
-def split_segment_even_dist(a: Point, b: Point, max_length: float, jitter_sigma: float = 0.0, random_seed=None) -> typing.List[shgeo.Point]:
+def split_segment_even_dist(a: Point, b: Point, max_length: float, jitter_sigma: float = 0.0, random_seed=None) -> list[shgeo.Point]:
     """Split a segment into even parts with maximum length."""
     distance = shgeo.Point(a).distance(shgeo.Point(b))
     segments = math.ceil(distance / max_length)
     return split_segment_even_n(a, b, segments, jitter_sigma, random_seed)
 
 
-def split_segment_random_phase(a: Point, b: Point, length: float, length_sigma: float, random_seed: str) -> typing.List[shgeo.Point]:
+def split_segment_random_phase(a: Point, b: Point, length: float, length_sigma: float, random_seed: str) -> list[shgeo.Point]:
     """Split a segment with randomized phase and length variation."""
     line = shgeo.LineString([a, b])
     progress = length * prng.uniform_floats(random_seed, "phase")[0]
@@ -71,7 +71,7 @@ def split_segment_stagger_phase(
     this_segment_num: int,
     min_val=0,
     max_val=None,
-) -> typing.List[shgeo.Point]:
+) -> list[shgeo.Point]:
     """Split a segment with staggered phase for pattern alignment."""
     line = shgeo.LineString([a, b])
     distance = line.length
@@ -215,7 +215,7 @@ def take_stitch(
     idx: int,
     stitch_length: float,
     tolerance: float,
-) -> typing.Tuple[typing.Optional[Point], typing.Optional[int]]:
+) -> typing.tuple[typing.Optional[Point], typing.Optional[int]]:
     """Take a single stitch based on the Zhao-Saalfeld curve simplification algorithm.
 
     Based on: https://cartogis.org/docs/proceedings/archive/auto-carto-13/pdf/
@@ -247,12 +247,12 @@ def take_stitch(
 
 def stitch_curve_evenly_strict(  # noqa C901
     points: typing.Sequence[Point],
-    stitch_length: typing.List[float],
+    stitch_length: list[float],
     tolerance: float,
     min_stitch_length: float,
     stitch_length_pos: int = 0,
     stitch_distance_passed: float = 0,
-) -> typing.Tuple[typing.List[Point], int, float]:
+) -> typing.tuple[list[Point], int, float]:
     """Split a curve into even-length stitches while handling curves correctly.
 
     Adapts stitch lengths to the distance that already has been passed,
@@ -264,7 +264,7 @@ def stitch_curve_evenly_strict(  # noqa C901
         return [], stitch_length_pos, stitch_distance_passed
     i: typing.Optional[int] = 1
     last = points[0]
-    stitches: typing.List[Point] = []
+    stitches: list[Point] = []
     while i is not None and i < len(points):
         stitch_len = stitch_length[stitch_length_pos]
 
@@ -306,10 +306,10 @@ def stitch_curve_evenly_strict(  # noqa C901
 
 def stitch_curve_evenly(
     points: typing.Sequence[Point],
-    stitch_length: typing.List[float],
+    stitch_length: list[float],
     tolerance: float,
     stitch_length_pos: int = 0,
-) -> typing.Tuple[typing.List[Point], int]:
+) -> tuple[list[Point], int]:
     """Split a curve into even-length stitches while handling curves correctly.
 
     Includes end point but not start point.
@@ -322,7 +322,7 @@ def stitch_curve_evenly(
 
     i: typing.Optional[int] = 1
     last = points[0]
-    stitches: typing.List[Point] = []
+    stitches: list[Point] = []
     while i is not None and i < len(points):
         d = last.distance(points[i]) + dist_left[i]
         if d == 0:
@@ -343,12 +343,12 @@ def stitch_curve_evenly(
 
 def stitch_curve_randomly(
     points: typing.Sequence[Point],
-    stitch_length: typing.List[float],
+    stitch_length: list[float],
     tolerance: float,
     stitch_length_sigma: float,
     random_seed: str,
     stitch_length_pos: int = 0,
-) -> typing.Tuple[typing.List[Point], int]:
+) -> typing.tuple[list[Point], int]:
     """Split a curve into stitches of random length within a range.
 
     Attempts to randomize phase so distribution doesn't depend on direction.
@@ -388,7 +388,7 @@ def stitch_curve_randomly(
     return stitches, stitch_length_pos
 
 
-def path_to_curves(points: typing.List[Point], min_len: float):
+def path_to_curves(points: list[Point], min_len: float):
     """Split a path at obvious corner points so they get stitched exactly.
 
     min_len controls the minimum length after splitting for which it won't

--- a/lib/stitches/tartan_fill.py
+++ b/lib/stitches/tartan_fill.py
@@ -9,7 +9,7 @@
 from collections import defaultdict
 from itertools import chain
 from math import cos, radians, sin
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from inkex import Color
 from networkx import is_empty
@@ -118,9 +118,9 @@ def tartan_fill(fill: 'FillStitch', outline: Polygon, starting_point: Union[tupl
 def _generate_herringbone_lines(
     outline: Polygon,
     fill: 'FillStitch',
-    dimensions: Tuple[float, float, float, float],
+    dimensions: tuple[float, float, float, float],
     rotation: float,
-) -> List[List[List[LineString]]]:
+) -> list[list[list[LineString]]]:
     """
     Generates herringbone lines with staggered stitch positions
 
@@ -176,9 +176,9 @@ def _generate_herringbone_lines(
 def _generate_tartan_lines(
     outline: Polygon,
     fill: 'FillStitch',
-    dimensions: Tuple[float, float, float, float],
+    dimensions: tuple[float, float, float, float],
     rotation: float,
-) -> List[LineString]:
+) -> list[LineString]:
     """
     Generates tartan lines with staggered stitch positions
 
@@ -214,7 +214,7 @@ def _generate_tartan_lines(
 
 
 def _split_herringbone_warp_weft(
-    lines: List[List[List[LineString]]],
+    lines: list[list[list[LineString]]],
     rows_per_thread: int,
     stitch_length: float
 ) -> tuple:
@@ -227,8 +227,8 @@ def _split_herringbone_warp_weft(
     :param stitch_length: maximum stitch length for weft connector lines
     :returns: [0] warp and [1] weft list of MultiLineString objects
     """
-    warp_lines: List[LineString] = []
-    weft_lines: List[LineString] = []
+    warp_lines: list[LineString] = []
+    weft_lines: list[LineString] = []
     for i, line_blocks in enumerate(lines):
         for line_block in line_blocks:
             if i == 0:
@@ -254,7 +254,7 @@ def _split_herringbone_warp_weft(
     return warp_lines, connected_weft
 
 
-def _split_warp_weft(lines: List[LineString], rows_per_thread: int) -> Tuple[List[LineString], List[LineString]]:
+def _split_warp_weft(lines: list[LineString], rows_per_thread: int) -> tuple[list[LineString], list[LineString]]:
     """
     Divide given lines in warp and weft, sort afterwards
 
@@ -270,7 +270,7 @@ def _split_warp_weft(lines: List[LineString], rows_per_thread: int) -> Tuple[Lis
     return _sort_lines(warp_lines), _sort_lines(weft_lines)
 
 
-def _sort_lines(lines: List[LineString]):
+def _sort_lines(lines: list[LineString]):
     """
     Sort given list of LineString shapes by first coordinate
     and reverse every second line
@@ -302,10 +302,10 @@ def _get_rotation_center(outline: Polygon) -> Point:
 def _get_dimensions(
     fill: 'FillStitch',
     outline: Polygon,
-    offset: Tuple[float, float],
+    offset: tuple[float, float],
     warp_width: float,
     weft_width: float
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     """
     Calculates the dimensions for the tartan pattern.
     Make sure it is big enough for pattern rotations, etc.
@@ -343,7 +343,7 @@ def _get_dimensions(
 
 
 def _get_herringbone_color_segments(
-    lines: List[MultiLineString],
+    lines: list[MultiLineString],
     polygons: defaultdict,
     outline: Polygon,
     rotation: float,
@@ -401,7 +401,7 @@ def _get_weft_herringbone_color_segments(
     """
     weft_lines = defaultdict(list)
     for color, lines in line_segments.items():
-        color_lines: List[LineString] = []
+        color_lines: list[LineString] = []
         for polygon in polygons[color][0]:
             polygon = polygon.normalize()
             polygon_coords = list(polygon.exterior.coords)
@@ -439,11 +439,11 @@ def _get_weft_herringbone_color_segments(
 
 
 def _get_weft_herringbone_connectors(
-    polygon_lines: List[LineString],
+    polygon_lines: list[LineString],
     polygon_top: LineString,
     polygon_bottom: LineString,
     stitch_length: float
-) -> List[LineString]:
+) -> list[LineString]:
     """
     Generates lines to connect lines
 
@@ -453,7 +453,7 @@ def _get_weft_herringbone_connectors(
     :param stitch_length: stitch length
     :returns: a list of LineString connectors
     """
-    connectors: List[LineString] = []
+    connectors: list[LineString] = []
     previous_end = None
     for line in reversed(polygon_lines):
         start = get_point(line, 0)
@@ -489,7 +489,7 @@ def _get_weft_herringbone_connectors(
 
 
 def _get_tartan_color_segments(
-    lines: List[LineString],
+    lines: list[LineString],
     polygons: defaultdict,
     outline: Polygon,
     rotation: float,
@@ -547,7 +547,7 @@ def _get_segment_lines(
     rotation: float,
     weft: bool,
     herringbone: bool
-) -> List[LineString]:
+) -> list[LineString]:
     """
     Fill the given polygon with lines
     Each line should start and end at the outline border
@@ -700,7 +700,7 @@ def _get_fill_stitch_groups(
     color_lines: defaultdict,
     starting_point: Union[tuple, Stitch, None],
     ending_point: Union[tuple, Stitch, None]
-) -> List[StitchGroup]:
+) -> list[StitchGroup]:
     """
     Route fill stitches
 
@@ -711,7 +711,7 @@ def _get_fill_stitch_groups(
     :paramt ending_point: the ending_point
     :returns: a list with StitchGroup objects
     """
-    stitch_groups: List[StitchGroup] = []
+    stitch_groups: list[StitchGroup] = []
     i = 0
     for color, lines in color_lines.items():
         inkex_color = Color(color)
@@ -740,7 +740,7 @@ def _get_run_stitch_groups(
     color_lines: defaultdict,
     starting_point: Optional[Union[tuple, Stitch]],
     ending_point: Optional[Union[tuple, Stitch]]
-) -> List[StitchGroup]:
+) -> list[StitchGroup]:
     """
     Route running stitches
 
@@ -751,7 +751,7 @@ def _get_run_stitch_groups(
     :param ending_point: the ending point
     :returns: a list with StitchGroup objects
     """
-    stitch_groups: List[StitchGroup] = []
+    stitch_groups: list[StitchGroup] = []
     for color, lines in color_lines.items():
         inkex_color = Color(color)
         if not fill.stop_at_ending_point and stitch_groups:
@@ -770,7 +770,7 @@ def _get_run_stitch_groups(
 def _segments_to_stitch_group(
     fill: 'FillStitch',
     shape: Polygon,
-    segments: List[List[Tuple[float, float]]],
+    segments: list[list[tuple[float, float]]],
     iteration: int,
     color: str,
     starting_point: Optional[Union[tuple, Stitch]],

--- a/lib/stitches/tatami_fill.py
+++ b/lib/stitches/tatami_fill.py
@@ -7,7 +7,7 @@
 
 import math
 from itertools import chain, groupby
-from typing import Iterator
+from collections.abc import Iterator
 
 import networkx
 from shapely import geometry as shgeo

--- a/lib/tartan/palette.py
+++ b/lib/tartan/palette.py
@@ -5,7 +5,7 @@
 # Additional credits to: https://github.com/clsn/pyTartan
 
 import re
-from typing import TYPE_CHECKING, List, cast
+from typing import TYPE_CHECKING, cast
 
 import wx
 from inkex import Color, ColorError
@@ -22,7 +22,7 @@ class Palette:
     def __init__(
         self,
         palette_code: str = '',
-        palette_stripes: List[list] = [[], []],
+        palette_stripes: list[list] = [[], []],
         symmetry: bool = True,
         equal_warp_weft: bool = True,
         tt_unit: float = 0.5
@@ -47,7 +47,7 @@ class Palette:
         self.symmetry = symmetry
         self.update_code()
 
-    def update_from_stripe_sizer(self, sizers: List[wx.BoxSizer], symmetry: bool = True, equal_warp_weft: bool = True) -> None:
+    def update_from_stripe_sizer(self, sizers: list[wx.BoxSizer], symmetry: bool = True, equal_warp_weft: bool = True) -> None:
         """
         Update palette code from stripes (customize panel)
 

--- a/lib/tartan/svg.py
+++ b/lib/tartan/svg.py
@@ -7,7 +7,7 @@ import time
 from collections import defaultdict
 from copy import copy
 from itertools import chain
-from typing import List, Optional, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 from inkex import BaseElement, Group, Path, PathElement
 from networkx import MultiGraph, is_empty
@@ -156,8 +156,8 @@ class TartanSvgGroup:
     def _get_routed_shapes(
         self,
         geometry_type: str,
-        polygons: Optional[List[Polygon]],
-        lines: Optional[List[LineString]],
+        polygons: Optional[list[Polygon]],
+        lines: Optional[list[LineString]],
         outline_shape: MultiPolygon,
         weft: bool
     ):
@@ -193,9 +193,9 @@ class TartanSvgGroup:
 
     def _path_to_shapes(
         self,
-        path: List[PathEdge],
+        path: list[PathEdge],
         fill_stitch_graph: MultiGraph,
-        polygons: Optional[List[Polygon]],
+        polygons: Optional[list[Polygon]],
         geometry_type: str,
         outline_shape: MultiPolygon
     ) -> list:
@@ -249,7 +249,7 @@ class TartanSvgGroup:
         edge: PathEdge,
         geometry_type: str,
         fill_stitch_graph: MultiGraph,
-        polygons: Optional[List[Polygon]]
+        polygons: Optional[list[Polygon]]
     ) -> list:
         """
         Turns an edge back into an element
@@ -262,7 +262,7 @@ class TartanSvgGroup:
             Polygons are wrapped in dictionaries to preserve information about start and end point.
         """
         start, end = edge
-        routed: List[Union[dict, LineString]] = []
+        routed: list[Union[dict, LineString]] = []
         if geometry_type == 'polygon' and polygons is not None:
             polygon = self._find_polygon(polygons, Point(start))
             if polygon:
@@ -280,7 +280,7 @@ class TartanSvgGroup:
         return routed
 
     @staticmethod
-    def _get_shortest_travel(start: Tuple[float, float], outline: LineString, travel_linestring: LineString) -> LineString:
+    def _get_shortest_travel(start: tuple[float, float], outline: LineString, travel_linestring: LineString) -> LineString:
         """
         Replace travel_linestring with a shorter travel line if possible
 
@@ -299,7 +299,7 @@ class TartanSvgGroup:
         return travel_linestring
 
     @staticmethod
-    def _find_polygon(polygons: List[Polygon], point: Point) -> Optional[Polygon]:
+    def _find_polygon(polygons: list[Polygon], point: Point) -> Optional[Polygon]:
         """
         Find the polygon for a given point
 
@@ -404,7 +404,7 @@ class TartanSvgGroup:
             path_element.set('inkstitch:flip', True)
         return path_element
 
-    def _combine_shapes(self, warp: defaultdict, weft: defaultdict, outline: MultiPolygon) -> Tuple[defaultdict, defaultdict]:
+    def _combine_shapes(self, warp: defaultdict, weft: defaultdict, outline: MultiPolygon) -> tuple[defaultdict, defaultdict]:
         """
         Combine warp and weft elements into color groups, but separated into polygons and linestrings
 
@@ -447,7 +447,7 @@ class TartanSvgGroup:
         return polygons, linestrings
 
     @staticmethod
-    def _get_travel(start: Tuple[float, float], end: Tuple[float, float], outline: LineString) -> LineString:
+    def _get_travel(start: tuple[float, float], end: tuple[float, float], outline: LineString) -> LineString:
         """
         Returns a travel line from start point to end point along the outline
 
@@ -465,7 +465,7 @@ class TartanSvgGroup:
         else:
             return result
 
-    def _get_dimensions(self, outline: MultiPolygon) -> Tuple[Tuple[float, float, float, float], Point]:
+    def _get_dimensions(self, outline: MultiPolygon) -> tuple[tuple[float, float, float, float], Point]:
         """
         Calculates the dimensions for the tartan pattern.
         Make sure it is big enough for pattern rotations.
@@ -497,8 +497,8 @@ class TartanSvgGroup:
         polygon: Polygon,
         weft: bool,
         transform: str,
-        start: Optional[Tuple[float, float]] = None,
-        end: Optional[Tuple[float, float]] = None
+        start: Optional[tuple[float, float]] = None,
+        end: Optional[tuple[float, float]] = None
     ) -> PathElement:
         """
         Convert a polygon to an svg path element

--- a/lib/tartan/utils.py
+++ b/lib/tartan/utils.py
@@ -6,7 +6,7 @@
 import json
 from collections import defaultdict
 from copy import copy
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from inkex import BaseElement
 from shapely import LineString, MultiPolygon, Point, Polygon, unary_union
@@ -19,8 +19,8 @@ from .palette import Palette
 
 
 def stripes_to_shapes(
-    stripes: List[dict],
-    dimensions: Tuple[float, float, float, float],
+    stripes: list[dict],
+    dimensions: tuple[float, float, float, float],
     outline: Union[MultiPolygon, Polygon],
     rotation: float,
     rotation_center: Point,
@@ -84,11 +84,11 @@ def stripes_to_shapes(
 
 
 def _stripes_to_sett(
-    stripes: List[dict],
+    stripes: list[dict],
     symmetry: bool,
     scale: int,
     min_stripe_width: float,
-) -> List[dict]:
+) -> list[dict]:
     """
     Builds a full sett for easier conversion into elements
 
@@ -151,7 +151,7 @@ def _stripes_to_sett(
     return sett
 
 
-def _get_last_fill_color(stripes: List[dict], scale: int, min_stripe_width: float, symmetry: bool,) -> Optional[str]:
+def _get_last_fill_color(stripes: list[dict], scale: int, min_stripe_width: float, symmetry: bool,) -> Optional[str]:
     '''
     Returns the first fill color of a pattern to substitute spaces if the pattern starts with strokes or
     stripes with render mode 2
@@ -194,8 +194,8 @@ def _merge_polygons(
     """
     shapes_copy = copy(shapes)
     for color, shape_group in shapes_copy.items():
-        polygons: List[Polygon] = []
-        lines: List[LineString] = []
+        polygons: list[Polygon] = []
+        lines: list[LineString] = []
         for shape in shape_group:
             if not shape.intersects(outline):
                 continue
@@ -212,7 +212,7 @@ def _merge_polygons(
     return shapes
 
 
-def _get_polygon(dimensions: List[float], rotation: float, rotation_center: Point, weft: bool) -> Polygon:
+def _get_polygon(dimensions: list[float], rotation: float, rotation_center: Point, weft: bool) -> Polygon:
     """
     Generates a rotated polygon with the given dimensions
 
@@ -234,10 +234,10 @@ def _get_polygon(dimensions: List[float], rotation: float, rotation_center: Poin
 
 def _get_linestrings(
     outline: Union[MultiPolygon, Polygon],
-    dimensions: List[float],
+    dimensions: list[float],
     rotation: float,
     rotation_center: Point, weft: bool
-) -> List[LineString]:
+) -> list[LineString]:
     """
     Generates a rotated linestrings with the given dimension (outline intersection)
 
@@ -262,7 +262,7 @@ def _get_linestrings(
     return linestrings
 
 
-def sort_fills_and_strokes(fills: defaultdict, strokes: defaultdict) -> Tuple[defaultdict, defaultdict]:
+def sort_fills_and_strokes(fills: defaultdict, strokes: defaultdict) -> tuple[defaultdict, defaultdict]:
     """
     Lines should be stitched out last, so they won't be covered by following fill elements.
     However, if we find lines of the same color as one of the polygon groups, we can make
@@ -325,7 +325,7 @@ def get_palette_width(settings: dict, direction: int = 0) -> float:
     return palette.get_palette_width(settings['scale'], settings['min_stripe_width'], direction)
 
 
-def get_tartan_stripes(settings: dict) -> Tuple[list, list]:
+def get_tartan_stripes(settings: dict) -> tuple[list, list]:
     """
     Get tartan stripes
 

--- a/lib/threads/color.py
+++ b/lib/threads/color.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
-from typing import Optional, Tuple, Union, List
+from typing import Optional, Union
 
 import colorsys
 
@@ -12,7 +12,7 @@ from pystitch.EmbThread import EmbThread
 
 
 class ThreadColor(object):
-    rgb: Tuple[int, int, int]
+    rgb: tuple[int, int, int]
     name: Optional[str]
     number: Optional[str]
     manufacturer: Optional[str]
@@ -21,14 +21,14 @@ class ThreadColor(object):
 
     def __init__(  # noqa: C901
         self,
-        color: Optional[Union[str, Color, EmbThread, Tuple[int, int, int], List[int]]],
+        color: Optional[Union[str, Color, EmbThread, tuple[int, int, int], list[int]]],
         name: Optional[str] = None,
         number: Optional[str] = None,
         manufacturer: Optional[str] = None,
         description: Optional[str] = None,
         chart: Optional[str] = None
     ):
-        rgb: Optional[Tuple[int, int, int]] = None
+        rgb: Optional[tuple[int, int, int]] = None
 
         if isinstance(color, str) and color.lower().startswith(('url', 'currentcolor', 'context')):
             '''

--- a/lib/threads/palette.py
+++ b/lib/threads/palette.py
@@ -3,8 +3,6 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-from collections.abc import Set
-
 from colormath2.color_conversions import convert_color
 from colormath2.color_diff import delta_e_cie1994
 from colormath2.color_objects import LabColor, sRGBColor
@@ -17,7 +15,7 @@ def compare_thread_colors(color1, color2):
     return delta_e_cie1994(color1, color2, K_L=2)
 
 
-class ThreadPalette(Set):
+class ThreadPalette(set):
     """Holds a set of ThreadColors all from the same manufacturer."""
 
     def __init__(self, palette_file):

--- a/lib/utils/cache.py
+++ b/lib/utils/cache.py
@@ -7,7 +7,8 @@ import hashlib
 import os
 import pickle
 import sqlite3
-from typing import TypeVar, Callable, Any, cast
+from collections.abc import Callable
+from typing import TypeVar, Any, cast
 
 import diskcache  # type: ignore[import-untyped]
 

--- a/lib/utils/geometry.py
+++ b/lib/utils/geometry.py
@@ -5,8 +5,9 @@
 
 import math
 import typing
+from collections.abc import Iterable, Iterator
 from itertools import groupby
-from typing import Iterable, Iterator, overload, NoReturn, TypeAlias
+from typing import overload, NoReturn, TypeAlias
 
 import numpy
 from inkex import Vector2d

--- a/lib/utils/paths.py
+++ b/lib/utils/paths.py
@@ -11,6 +11,7 @@ import tomllib
 
 import platformdirs
 
+
 def get_bundled_dir(name=None):
     if getattr(sys, 'frozen', None) is not None:
         if sys.platform == "darwin":

--- a/lib/utils/paths.py
+++ b/lib/utils/paths.py
@@ -7,14 +7,9 @@ import os
 import sys
 from os.path import dirname, realpath
 from pathlib import Path
+import tomllib
 
 import platformdirs
-
-if sys.version_info >= (3, 11):
-    import tomllib  # built-in in Python 3.11+
-else:
-    import tomli as tomllib
-
 
 def get_bundled_dir(name=None):
     if getattr(sys, 'frozen', None) is not None:

--- a/tests/test_extensions_smoke.py
+++ b/tests/test_extensions_smoke.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXTENSIONS_DIR = REPO_ROOT / "lib" / "extensions"
+
+
+def _iter_extension_modules() -> list[str]:
+    modules: list[str] = []
+    for path in sorted(EXTENSIONS_DIR.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+
+        relative = path.relative_to(REPO_ROOT).with_suffix("")
+        module_name = ".".join(relative.parts)
+        modules.append(module_name)
+
+    return modules
+
+
+EXTENSION_MODULES = _iter_extension_modules()
+OPTIONAL_IMPORT_ROOTS = {"wx", "winutils"}
+
+
+@pytest.mark.parametrize("module_name", EXTENSION_MODULES)
+def test_extension_module_import_smoke(module_name: str) -> None:
+    try:
+        import_module(module_name)
+    except ModuleNotFoundError as error:
+        missing_root = (error.name or "").split(".")[0]
+        if missing_root in OPTIONAL_IMPORT_ROOTS:
+            pytest.skip(f"Optional dependency is missing for smoke import: {error.name}")
+        raise

--- a/tests/test_no_deprecated_typing_aliases.py
+++ b/tests/test_no_deprecated_typing_aliases.py
@@ -37,6 +37,7 @@ def _is_in_virtualenv(path: Path) -> bool:
     resolved = path.resolve()
     return any(resolved.is_relative_to(env_root) for env_root in VIRTUALENV_ROOTS)
 
+
 # PEP 585: collection-style typing aliases from typing are deprecated in favor
 # of built-in generics (list[str], dict[str, int], type[Foo], ...).
 DEPRECATED_TYPING_ALIASES = {

--- a/tests/test_no_deprecated_typing_aliases.py
+++ b/tests/test_no_deprecated_typing_aliases.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import tokenize
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+}
+
+# PEP 585: collection-style typing aliases from typing are deprecated in favor
+# of built-in generics (list[str], dict[str, int], type[Foo], ...).
+DEPRECATED_TYPING_ALIASES = {
+    "AbstractSet",
+    "AsyncContextManager",
+    "AsyncGenerator",
+    "AsyncIterable",
+    "AsyncIterator",
+    "Awaitable",
+    "ByteString",
+    "Callable",
+    "ChainMap",
+    "Collection",
+    "Container",
+    "ContextManager",
+    "Coroutine",
+    "Counter",
+    "DefaultDict",
+    "Deque",
+    "Dict",
+    "FrozenSet",
+    "Generator",
+    "ItemsView",
+    "Iterable",
+    "Iterator",
+    "KeysView",
+    "List",
+    "Mapping",
+    "MappingView",
+    "Match",
+    "MutableMapping",
+    "MutableSequence",
+    "MutableSet",
+    "OrderedDict",
+    "Pattern",
+    "Reversible",
+    "Sequence",
+    "Set",
+    "Tuple",
+    "Type",
+    "ValuesView",
+}
+
+
+class DeprecatedTypingAliasVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.typing_module_aliases: set[str] = set()
+        self.issues: list[tuple[int, int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name == "typing":
+                self.typing_module_aliases.add(alias.asname or "typing")
+
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module == "typing":
+            for alias in node.names:
+                if alias.name in DEPRECATED_TYPING_ALIASES:
+                    self.issues.append(
+                        (
+                            node.lineno,
+                            node.col_offset,
+                            f"from typing import {alias.name}",
+                        )
+                    )
+
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if isinstance(node.value, ast.Name):
+            if node.value.id in self.typing_module_aliases and node.attr in DEPRECATED_TYPING_ALIASES:
+                self.issues.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        f"{node.value.id}.{node.attr}",
+                    )
+                )
+
+        self.generic_visit(node)
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*.py"):
+        if any(part in EXCLUDED_DIRS for part in path.parts):
+            continue
+        files.append(path)
+
+    return sorted(files)
+
+
+def test_no_deprecated_typing_aliases() -> None:
+    violations: list[str] = []
+
+    for python_file in _iter_python_files(REPO_ROOT):
+        with tokenize.open(python_file) as handle:
+            source = handle.read()
+
+        tree = ast.parse(source, filename=str(python_file))
+        visitor = DeprecatedTypingAliasVisitor()
+        visitor.visit(tree)
+
+        for line, col, symbol in visitor.issues:
+            rel_path = python_file.relative_to(REPO_ROOT)
+            violations.append(f"{rel_path}:{line}:{col + 1}: deprecated typing alias '{symbol}'")
+
+    if violations:
+        details = "\n".join(violations)
+        pytest.fail(
+            "Deprecated typing aliases from 'typing' were found. "
+            "Use built-in generics (list/dict/tuple/type/...) for Python >= 3.9.\n"
+            f"{details}"
+        )

--- a/tests/test_no_deprecated_typing_aliases.py
+++ b/tests/test_no_deprecated_typing_aliases.py
@@ -20,6 +20,22 @@ EXCLUDED_DIRS = {
     "venv",
     "node_modules",
 }
+EXCLUDED_PATH_PARTS = {
+    "site-packages",
+    "dist-packages",
+}
+
+
+def _find_virtualenv_roots(root: Path) -> set[Path]:
+    return {path.parent.resolve() for path in root.rglob("pyvenv.cfg")}
+
+
+VIRTUALENV_ROOTS = _find_virtualenv_roots(REPO_ROOT)
+
+
+def _is_in_virtualenv(path: Path) -> bool:
+    resolved = path.resolve()
+    return any(resolved.is_relative_to(env_root) for env_root in VIRTUALENV_ROOTS)
 
 # PEP 585: collection-style typing aliases from typing are deprecated in favor
 # of built-in generics (list[str], dict[str, int], type[Foo], ...).
@@ -109,6 +125,10 @@ def _iter_python_files(root: Path) -> list[Path]:
     files: list[Path] = []
     for path in root.rglob("*.py"):
         if any(part in EXCLUDED_DIRS for part in path.parts):
+            continue
+        if any(part in EXCLUDED_PATH_PARTS for part in path.parts):
+            continue
+        if _is_in_virtualenv(path):
             continue
         files.append(path)
 

--- a/tests/test_python_syntax.py
+++ b/tests/test_python_syntax.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tokenize
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXCLUDED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+    "node_modules",
+}
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*.py"):
+        if any(part in EXCLUDED_DIRS for part in path.parts):
+            continue
+        files.append(path)
+
+    return sorted(files)
+
+
+PYTHON_FILES = _iter_python_files(REPO_ROOT)
+
+
+@pytest.mark.parametrize(
+    "python_file",
+    PYTHON_FILES,
+    ids=[str(path.relative_to(REPO_ROOT)) for path in PYTHON_FILES],
+)
+def test_python_file_has_valid_syntax(python_file: Path) -> None:
+    # tokenize.open() respects PEP 263 encoding declarations.
+    with tokenize.open(python_file) as handle:
+        source = handle.read()
+
+    compile(source, str(python_file), "exec")

--- a/tests/test_python_syntax.py
+++ b/tests/test_python_syntax.py
@@ -19,12 +19,32 @@ EXCLUDED_DIRS = {
     "venv",
     "node_modules",
 }
+EXCLUDED_PATH_PARTS = {
+    "site-packages",
+    "dist-packages",
+}
+
+
+def _find_virtualenv_roots(root: Path) -> set[Path]:
+    return {path.parent.resolve() for path in root.rglob("pyvenv.cfg")}
+
+
+VIRTUALENV_ROOTS = _find_virtualenv_roots(REPO_ROOT)
+
+
+def _is_in_virtualenv(path: Path) -> bool:
+    resolved = path.resolve()
+    return any(resolved.is_relative_to(env_root) for env_root in VIRTUALENV_ROOTS)
 
 
 def _iter_python_files(root: Path) -> list[Path]:
     files: list[Path] = []
     for path in root.rglob("*.py"):
         if any(part in EXCLUDED_DIRS for part in path.parts):
+            continue
+        if any(part in EXCLUDED_PATH_PARTS for part in path.parts):
+            continue
+        if _is_in_virtualenv(path):
             continue
         files.append(path)
 


### PR DESCRIPTION
Pick the python interpreter at runtime (`SCRIPT_PYTHON` → `.venv` → `python3/py/python`) instead of hardcoding it and log write errors instead of raising.

