### PR TITLE
Simulator Loading Screen

### DIFF
--- a/lib/extensions/params.py
+++ b/lib/extensions/params.py
@@ -21,7 +21,7 @@ from ..elements import (Clone, EmbroideryElement, FillStitch, SatinColumn,
                         Stroke, nodes_to_elements)
 from ..elements.clone import is_clone
 from ..exceptions import InkstitchException, format_uncaught_exception
-from ..gui import PresetsPanel, PreviewRenderer, WarningPanel
+from ..gui import PresetsPanel, WarningPanel
 from ..gui.simulator import SplitSimulatorWindow
 from ..i18n import _
 from ..stitch_plan import stitch_groups_to_stitch_plan
@@ -563,9 +563,9 @@ class SettingsPanel(wx.Panel):
         self.simulator = simulator
         self.parent = parent
 
-        super().__init__(self.parent, wx.ID_ANY)
+        self.simulator.set_render_fn(self.render_stitch_plan)
 
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        super().__init__(self.parent, wx.ID_ANY)
 
         self.notebook = wx.Notebook(self, wx.ID_ANY)
         self.tabs = self.tabs_factory(self.notebook)
@@ -593,8 +593,7 @@ class SettingsPanel(wx.Panel):
 
     def update_preview(self, tab=None):
         self.simulator.stop()
-        self.simulator.clear()
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def render_stitch_plan(self):
 
@@ -634,15 +633,6 @@ class SettingsPanel(wx.Panel):
         if stroke_index:
             tabs.append(tabs.pop(stroke_index[0]))
         return tabs
-
-    def on_stitch_plan_rendered(self, stitch_plan):
-        try:
-            self.simulator.stop()
-            self.simulator.load(stitch_plan)
-            self.simulator.go()
-        except RuntimeError:
-            # this can happen when they close the window at a bad time
-            pass
 
     def _hide_warning(self):
         self.warning_panel.clear()

--- a/lib/extensions/sew_stack_editor.py
+++ b/lib/extensions/sew_stack_editor.py
@@ -12,7 +12,7 @@ from wx.lib.splitter import MultiSplitterWindow  # type:ignore[import-untyped]
 from .base import InkstitchExtension
 from ..debug.debug import debug
 from ..exceptions import InkstitchException, format_uncaught_exception
-from ..gui import PreviewRenderer, WarningPanel, confirm_dialog
+from ..gui import WarningPanel, confirm_dialog
 from ..gui.simulator import SplitSimulatorWindow
 from ..i18n import _
 from ..sew_stack import SewStack
@@ -110,7 +110,7 @@ class SewStackPanel(wx.Panel):
         # self.layer_list.Bind(ulc.EVT_LIST_ITEM_DESELECTED, self.on_layer_selection_changed)
         self.Bind(wx.EVT_CHECKBOX, self.on_checkbox)
 
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        self.simulator.set_render_fn(self.render_stitch_plan)
 
         self.warning_panel = WarningPanel(self)
         self.warning_panel.Hide()
@@ -440,8 +440,7 @@ class SewStackPanel(wx.Panel):
 
     def update_preview(self):
         self.simulator.stop()
-        self.simulator.clear()
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def render_stitch_plan(self):
         try:
@@ -473,15 +472,6 @@ class SewStackPanel(wx.Panel):
             wx.CallAfter(self._show_warning, str(exc))
         except Exception:
             wx.CallAfter(self._show_warning, format_uncaught_exception())
-
-    def on_stitch_plan_rendered(self, stitch_plan):
-        try:
-            self.simulator.stop()
-            self.simulator.load(stitch_plan)
-            self.simulator.go()
-        except RuntimeError:
-            # this can happen when they close the window at a bad time
-            pass
 
     def _hide_warning(self):
         self.warning_panel.clear()

--- a/lib/extensions/sew_stack_editor.py
+++ b/lib/extensions/sew_stack_editor.py
@@ -454,9 +454,9 @@ class SewStackPanel(wx.Panel):
             for sew_stack in self.sew_stacks:
                 if self.single_layer_preview_button.GetValue():
                     layer = sew_stack.layers[self.layer_list.GetFirstSelected()]
-                    stitch_groups.extend(layer.embroider(None))
+                    stitch_groups.extend(layer.embroider(None, None))
                 else:
-                    stitch_groups.extend(sew_stack.embroider(stitch_groups[-1] if stitch_groups else None))
+                    stitch_groups.extend(sew_stack.embroider(stitch_groups[-1] if stitch_groups else None, None))
 
                 check_stop_flag()
 

--- a/lib/extensions/simulator.py
+++ b/lib/extensions/simulator.py
@@ -6,7 +6,7 @@
 import wx
 
 from ..gui.simulator import SimulatorWindow
-from ..stitch_plan import stitch_groups_to_stitch_plan
+from ..stitch_plan import stitch_groups_to_stitch_plan, StitchPlan
 from ..svg import convert_length
 from ..utils.svg_data import get_pagecolor
 from .base import InkstitchExtension
@@ -20,11 +20,6 @@ class Simulator(InkstitchExtension):
         if not self.get_elements():
             return
 
-        metadata = self.get_inkstitch_metadata()
-        collapse_len = metadata['collapse_len_mm']
-        min_stitch_len = metadata['min_stitch_len_mm']
-        stitch_groups = self.elements_to_stitch_groups(self.elements)
-        stitch_plan = stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
         background_color = get_pagecolor(self.svg.namedview)
 
         app = wx.App()
@@ -37,12 +32,20 @@ class Simulator(InkstitchExtension):
         wx.CallLater(100, simulator.Centre)
         app.SetTopWindow(simulator)
         simulator.Show()
-        simulator.load(stitch_plan)
-        simulator.set_page_specs(self.get_page_specs(stitch_plan))
+        simulator.panel.set_render_fn(self.render)
+        simulator.panel.render()
+        simulator.set_page_specs(self.get_page_specs())
         simulator.go()
         app.MainLoop()
 
-    def get_page_specs(self, stitch_plan):
+    def render(self) -> StitchPlan:
+        metadata = self.get_inkstitch_metadata()
+        collapse_len = metadata['collapse_len_mm']
+        min_stitch_len = metadata['min_stitch_len_mm']
+        stitch_groups = self.elements_to_stitch_groups(self.elements)
+        return stitch_groups_to_stitch_plan(stitch_groups, collapse_len=collapse_len, min_stitch_len=min_stitch_len)
+
+    def get_page_specs(self):
         svg = self.document.getroot()
         width = svg.get('width', 0)
         height = svg.get('height', 0)
@@ -61,8 +64,6 @@ class Simulator(InkstitchExtension):
         return {
             "width": convert_length(width),
             "height": convert_length(height),
-            "x": stitch_plan.bounding_box[0],
-            "y": stitch_plan.bounding_box[1],
             "page_color": page_color,
             "desk_color": desk_color,
             "border_color": border_color,

--- a/lib/extensions/simulator.py
+++ b/lib/extensions/simulator.py
@@ -35,7 +35,6 @@ class Simulator(InkstitchExtension):
         simulator.panel.set_render_fn(self.render)
         simulator.panel.render()
         simulator.set_page_specs(self.get_page_specs())
-        simulator.go()
         app.MainLoop()
 
     def render(self) -> StitchPlan:

--- a/lib/gui/__init__.py
+++ b/lib/gui/__init__.py
@@ -5,5 +5,4 @@
 
 from .dialogs import confirm_dialog, info_dialog
 from .presets import PresetsPanel
-from .simulator import PreviewRenderer
 from .warnings import WarningPanel

--- a/lib/gui/edit_json/main_panel.py
+++ b/lib/gui/edit_json/main_panel.py
@@ -25,7 +25,7 @@ from ...stitch_plan import stitch_groups_to_stitch_plan
 from ...svg.tags import SVG_GROUP_TAG, SVG_PATH_TAG
 from ...utils.settings import global_settings
 from ...utils.threading import ExitThread, check_stop_flag
-from .. import PreviewRenderer, WarningPanel
+from .. import WarningPanel
 from . import HelpPanel, SettingsPanel
 
 LETTER_CASE = {0: '', 1: 'upper', 2: 'lower'}
@@ -60,7 +60,7 @@ class LetteringEditJsonPanel(wx.Panel):
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
 
         # preview
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        self.simulator.set_render_fn(self.render_stitch_plan)
 
         # warning
         self.warning_panel = WarningPanel(self)
@@ -484,7 +484,7 @@ class LetteringEditJsonPanel(wx.Panel):
         self.GetTopLevelParent().Close()
 
     def update_preview(self, event=None):
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def update_lettering(self):
         del self.layer[:]
@@ -615,8 +615,3 @@ class LetteringEditJsonPanel(wx.Panel):
             wx.CallAfter(self._show_warning, str(exc))
         except Exception:
             wx.CallAfter(self._show_warning, format_uncaught_exception())
-
-    def on_stitch_plan_rendered(self, stitch_plan):
-        self.simulator.stop()
-        self.simulator.load(stitch_plan)
-        self.simulator.go()

--- a/lib/gui/lettering/main_panel.py
+++ b/lib/gui/lettering/main_panel.py
@@ -20,7 +20,7 @@ from ...svg.tags import INKSTITCH_LETTERING
 from ...utils import DotDict, cache
 from ...utils.settings import global_settings
 from ...utils.threading import ExitThread, check_stop_flag
-from .. import PresetsPanel, PreviewRenderer, info_dialog
+from .. import PresetsPanel, info_dialog
 from . import LetteringHelpPanel, LetteringOptionsPanel
 
 
@@ -38,7 +38,7 @@ class LetteringPanel(wx.Panel):
 
         outer_sizer = wx.BoxSizer(wx.VERTICAL)
 
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        self.simulator.set_render_fn(self.render_stitch_plan)
 
         # notebook
         self.notebook = wx.Notebook(self, wx.ID_ANY)
@@ -302,7 +302,7 @@ class LetteringPanel(wx.Panel):
         self.Layout()
 
     def update_preview(self, event=None):
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def update_lettering(self, raise_error=False):
         # return if there is no font in the font list (possibly due to a font size filter)
@@ -371,11 +371,6 @@ class LetteringPanel(wx.Panel):
             # Ignore errors.  This can be things like incorrect paths for
             # satins or division by zero caused by incorrect param values.
             pass
-
-    def on_stitch_plan_rendered(self, stitch_plan):
-        self.simulator.stop()
-        self.simulator.load(stitch_plan)
-        self.simulator.go()
 
     def get_preset_data(self):
         # called by self.presets_panel

--- a/lib/gui/satin_multicolor/main_panel.py
+++ b/lib/gui/satin_multicolor/main_panel.py
@@ -18,7 +18,7 @@ from ...stitch_plan import (StitchGroup, StitchPlan,
 from ...svg.tags import INKSTITCH_SATIN_MULTICOLOR
 from ...utils import DotDict
 from ...utils.threading import ExitThread, check_stop_flag
-from .. import PreviewRenderer, WarningPanel
+from .. import WarningPanel
 from . import ColorizePanel, HelpPanel
 
 
@@ -48,7 +48,7 @@ class MultiColorSatinPanel(wx.Panel):
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
 
         # preview
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        self.simulator.set_render_fn(self.render_stitch_plan)
         # warnings
         self.warning_panel = WarningPanel(self)
         self.warning_panel.Hide()
@@ -215,7 +215,7 @@ class MultiColorSatinPanel(wx.Panel):
         self.Layout()
 
     def update_preview(self, event=None):
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def close(self) -> None:
         self.simulator.stop()
@@ -349,11 +349,6 @@ class MultiColorSatinPanel(wx.Panel):
 
             parent.insert(index + 1, group)
             self.output_groups.append(group)
-
-    def on_stitch_plan_rendered(self, stitch_plan: StitchPlan) -> None:
-        self.simulator.stop()
-        self.simulator.load(stitch_plan)
-        self.simulator.go()
 
     def on_change(self, attribute, event) -> None:
         value = event.GetEventObject().GetValue()

--- a/lib/gui/simulator/__init__.py
+++ b/lib/gui/simulator/__init__.py
@@ -10,6 +10,5 @@ from .control_panel import ControlPanel
 from .view_panel import ViewPanel
 from .drawing_panel import DrawingPanel
 from .simulator_panel import SimulatorPanel
-from .simulator_renderer import PreviewRenderer
 from .simulator_window import SimulatorWindow
 from .split_simulator_window import SplitSimulatorWindow

--- a/lib/gui/simulator/design_info.py
+++ b/lib/gui/simulator/design_info.py
@@ -58,7 +58,7 @@ class DesignInfoDialog(wx.Dialog):
         self.update()
 
     def update(self):
-        if not self.drawing_panel.loaded:
+        if self.drawing_panel.stitch_plan is None:
             return
         self.dimensions.SetLabel("{:.2f} x {:.2f}".format(self.drawing_panel.dimensions_mm[0], self.drawing_panel.dimensions_mm[1]))
         self.num_stitches.SetLabel(f"{self.drawing_panel.num_stitches}")

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -26,7 +26,7 @@ COLOR_CHANGE = 4
 
 class LoadingIndicator:
     """ Loading indicator that looks kind of like the one used in Half-Life 2 """
-    RENDERING = _("Rendering...")
+    RENDERING = _("Stitching...")
     PADDING = 10  # Padding around the text in px
     CORNER_RADIUS = 10  # px
 
@@ -48,8 +48,8 @@ class LoadingIndicator:
         canvas.SetPen(wx.TRANSPARENT_PEN)  # type:ignore[attr-defined]
         canvas.SetBrush(self.bg_brush)
         canvas.DrawRoundedRectangle(
-            (panel_width-w)/2-self.PADDING,
-            (panel_height-h)/2-self.PADDING,
+            ((panel_width-w)/2)-self.PADDING,
+            ((panel_height-h)/2)-self.PADDING,
             w+2*self.PADDING,
             h+2*self.PADDING,
             self.CORNER_RADIUS

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -7,6 +7,7 @@ import math
 
 import wx
 from numpy import split
+from typing import Optional, Tuple
 
 from ...debug.debug import debug
 from ...i18n import _
@@ -21,6 +22,24 @@ JUMP = 1
 TRIM = 2
 STOP = 3
 COLOR_CHANGE = 4
+
+class LoadingIndicator:
+    RENDERING = "Rendering..."
+
+    def __init__(self, panel: wx.Panel):
+        self.panel = panel
+
+        self.font = wx.Font(30, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
+        self.bounds: Optional[Tuple[float, float]] = None
+    
+    def paint(self, canvas: wx.GraphicsContext):
+        w, h = canvas.GetSize()
+
+        if self.bounds is None:
+            w, h, d, el = canvas.GetFullTextExtent(self.RENDERING)
+            self.bounds = (w, h)
+        
+
 
 
 class DrawingPanel(wx.Panel):
@@ -51,6 +70,8 @@ class DrawingPanel(wx.Panel):
         self.SetMinSize((300, 300))
         self.SetBackgroundColour('#FFFFFF')
         self.SetDoubleBuffered(True)
+
+        self.loading = False
 
         self.animating = False
         self.timer = wx.Timer(self)
@@ -134,15 +155,26 @@ class DrawingPanel(wx.Panel):
 
     def OnPaint(self, e):
         dc = wx.PaintDC(self)
+        canvas = wx.GraphicsContext.Create(dc)
 
         if not self.loaded:
             dc.Clear()
-            return
+        else:
+            self.draw_stitches(canvas)
+            self.draw_scale(canvas)
 
-        canvas = wx.GraphicsContext.Create(dc)
+        if self.loading:
+            panel_width, panel_height = self.GetClientSize()
+            canvas.SetFont(wx.Font(30, wx.DEFAULT, wx.NORMAL, wx.NORMAL), wx.WHITE)
+            RENDERING = "Rendering..."
+            w, h, d, el = canvas.GetFullTextExtent(RENDERING)
+            PADDING = 10
+            canvas.SetPen(wx.TRANSPARENT_PEN)
+            canvas.SetBrush(canvas.CreateBrush(wx.Brush(wx.Colour(0, 0, 0, alpha=65))))
+            canvas.DrawRoundedRectangle((panel_width-w)/2-PADDING, (panel_height-h)/2-PADDING, w+2*PADDING, h+2*PADDING, 7)
+            canvas.DrawText(RENDERING, (panel_width-w)/2, (panel_height-h)/2)
 
-        self.draw_stitches(canvas)
-        self.draw_scale(canvas)
+
 
     def draw_page(self, canvas):
         self._update_background_color()
@@ -530,4 +562,8 @@ class DrawingPanel(wx.Panel):
 
         self.zoom *= zoom_delta
 
+        self.Refresh()
+
+    def set_loading(self, loading: bool) -> None:
+        self.loading = loading
         self.Refresh()

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -23,23 +23,38 @@ TRIM = 2
 STOP = 3
 COLOR_CHANGE = 4
 
+
 class LoadingIndicator:
-    RENDERING = "Rendering..."
+    """ Loading indicator that looks kind of like the one used in Half-Life 2 """
+    RENDERING = _("Rendering...")
+    PADDING = 10  # Padding around the text in px
+    CORNER_RADIUS = 10  # px
 
-    def __init__(self, panel: wx.Panel):
-        self.panel = panel
-
+    def __init__(self) -> None:
         self.font = wx.Font(30, wx.DEFAULT, wx.NORMAL, wx.NORMAL)
+        self.bg_brush = wx.Brush(wx.Colour(0, 0, 0, alpha=100))
         self.bounds: Optional[Tuple[float, float]] = None
-    
-    def paint(self, canvas: wx.GraphicsContext):
-        w, h = canvas.GetSize()
 
+    def paint(self, canvas: wx.GraphicsContext) -> None:
+        panel_width, panel_height = canvas.GetSize()
+
+        canvas.SetFont(self.font, wx.WHITE)
         if self.bounds is None:
-            w, h, d, el = canvas.GetFullTextExtent(self.RENDERING)
-            self.bounds = (w, h)
-        
+            t_w, t_h, t_d, t_el = canvas.GetFullTextExtent(self.RENDERING)
+            self.bounds = (t_w, t_h)
 
+        w, h = self.bounds
+        # TRANSPARENT_PEN is there, but it's not in the types for some reason.
+        canvas.SetPen(wx.TRANSPARENT_PEN)  # type:ignore[attr-defined]
+        canvas.SetBrush(self.bg_brush)
+        canvas.DrawRoundedRectangle(
+            (panel_width-w)/2-self.PADDING,
+            (panel_height-h)/2-self.PADDING,
+            w+2*self.PADDING,
+            h+2*self.PADDING,
+            self.CORNER_RADIUS
+        )
+        canvas.DrawText(self.RENDERING, (panel_width-w)/2, (panel_height-h)/2)
 
 
 class DrawingPanel(wx.Panel):
@@ -72,6 +87,7 @@ class DrawingPanel(wx.Panel):
         self.SetDoubleBuffered(True)
 
         self.loading = False
+        self.loading_indicator = LoadingIndicator()
 
         self.animating = False
         self.timer = wx.Timer(self)
@@ -164,17 +180,7 @@ class DrawingPanel(wx.Panel):
             self.draw_scale(canvas)
 
         if self.loading:
-            panel_width, panel_height = self.GetClientSize()
-            canvas.SetFont(wx.Font(30, wx.DEFAULT, wx.NORMAL, wx.NORMAL), wx.WHITE)
-            RENDERING = "Rendering..."
-            w, h, d, el = canvas.GetFullTextExtent(RENDERING)
-            PADDING = 10
-            canvas.SetPen(wx.TRANSPARENT_PEN)
-            canvas.SetBrush(canvas.CreateBrush(wx.Brush(wx.Colour(0, 0, 0, alpha=65))))
-            canvas.DrawRoundedRectangle((panel_width-w)/2-PADDING, (panel_height-h)/2-PADDING, w+2*PADDING, h+2*PADDING, 7)
-            canvas.DrawText(RENDERING, (panel_width-w)/2, (panel_height-h)/2)
-
-
+            self.loading_indicator.paint(canvas)
 
     def draw_page(self, canvas):
         self._update_background_color()
@@ -188,7 +194,7 @@ class DrawingPanel(wx.Panel):
                 canvas.SetPen(wx.TRANSPARENT_PEN)
                 canvas.SetBrush(canvas.CreateBrush(wx.Brush(wx.Colour(border_color.Red(), border_color.Green(), border_color.Blue(), alpha=65))))
                 canvas.DrawRoundedRectangle(
-                    (-self.page_specs['x'] + 4) * self.PIXEL_DENSITY, (-self.page_specs['y'] + 4) * self.PIXEL_DENSITY,
+                    4 * self.PIXEL_DENSITY, 4 * self.PIXEL_DENSITY,
                     self.page_specs['width'] * self.PIXEL_DENSITY, self.page_specs['height'] * self.PIXEL_DENSITY,
                     1 * self.PIXEL_DENSITY
                 )
@@ -200,7 +206,7 @@ class DrawingPanel(wx.Panel):
             canvas.SetBrush(wx.Brush(wx.Colour(self.background_color or self.page_specs['page_color'])))
 
             canvas.DrawRectangle(
-                -self.page_specs['x'] * self.PIXEL_DENSITY, -self.page_specs['y'] * self.PIXEL_DENSITY,
+                0.0, 0.0,
                 self.page_specs['width'] * self.PIXEL_DENSITY, self.page_specs['height'] * self.PIXEL_DENSITY
             )
 
@@ -319,11 +325,12 @@ class DrawingPanel(wx.Panel):
         self.Refresh()
 
     def load(self, stitch_plan):
+        self.stitch_plan = stitch_plan
         self.current_stitch = 1
         self.direction = 1
-        self.minx, self.miny, self.maxx, self.maxy = stitch_plan.bounding_box
-        self.width = self.maxx - self.minx
-        self.height = self.maxy - self.miny
+        minx, miny, maxx, maxy = stitch_plan.bounding_box
+        self.width = maxx - minx
+        self.height = maxy - miny
         self.dimensions_mm = stitch_plan.dimensions_mm
         self.num_stitches = stitch_plan.num_stitches
         self.num_trims = stitch_plan.num_trims
@@ -369,19 +376,22 @@ class DrawingPanel(wx.Panel):
 
     def choose_zoom_and_pan(self, event=None):
         # ignore if EVT_SIZE fired before we load the stitch plan
-        if not self.width and not self.height and event is not None:
+        if self.stitch_plan is None:
             return
 
+        minx, miny, maxx, maxy = self.stitch_plan.bounding_box
+        width = maxx-minx
+        height = maxy-miny
         panel_width, panel_height = self.GetClientSize()
 
         # add some padding to make stitches at the edge more visible
-        width_ratio = panel_width / float(self.width + 10)
-        height_ratio = panel_height / float(self.height + 10)
+        width_ratio = panel_width / float(width + 10)
+        height_ratio = panel_height / float(height + 10)
         self.zoom = max(min(width_ratio, height_ratio), 0.01)
 
         # center the design
-        self.pan = ((panel_width - self.zoom * self.width) / 2.0,
-                    (panel_height - self.zoom * self.height) / 2.0)
+        self.pan = ((panel_width - self.zoom * (minx + maxx)) / 2.0,
+                    (panel_height - self.zoom * (miny + maxy)) / 2.0)
 
     def stop(self):
         self.animating = False
@@ -427,10 +437,9 @@ class DrawingPanel(wx.Panel):
             stitch_index = 0
 
             for stitch in color_block:
-                # trim any whitespace on the left and top and scale to the
-                # pixel density
-                stitch_block.append((self.PIXEL_DENSITY * (stitch.x - self.minx),
-                                     self.PIXEL_DENSITY * (stitch.y - self.miny)))
+                # scale to the pixel density
+                stitch_block.append((self.PIXEL_DENSITY * (stitch.x),
+                                     self.PIXEL_DENSITY * (stitch.y)))
 
                 if stitch.trim:
                     self.commands.append(TRIM)

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -415,6 +415,9 @@ class DrawingPanel(wx.Panel):
         return wx.Pen(list(map(int, color.visible_on_background(background_color).rgb)), int(line_width))
 
     def update_pen_size(self):
+        if self.stitch_plan is None:
+            return  # Pens are only valid after a stitch plan is loaded
+
         line_width = global_settings['simulator_line_width'] * PIXELS_PER_MM * self.PIXEL_DENSITY
         for pen in self.pens:
             pen.SetWidth(int(line_width))

--- a/lib/gui/simulator/drawing_panel.py
+++ b/lib/gui/simulator/drawing_panel.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple
 
 from ...debug.debug import debug
 from ...i18n import _
+from ...stitch_plan import StitchPlan
 from ...svg import PIXELS_PER_MM
 from ...utils.settings import global_settings
 
@@ -25,7 +26,7 @@ COLOR_CHANGE = 4
 
 
 class LoadingIndicator:
-    """ Loading indicator that looks kind of like the one used in Half-Life 2 """
+    """ Loading indicator that is shown while generating the stitch plan """
     RENDERING = _("Stitching...")
     PADDING = 10  # Padding around the text in px
     CORNER_RADIUS = 10  # px
@@ -69,10 +70,10 @@ class DrawingPanel(wx.Panel):
     # corresponding amount during rendering.
     PIXEL_DENSITY = 10
 
-    def __init__(self, parent, *args, **kwargs):
+    def __init__(self, parent, *args, **kwargs) -> None:
         """"""
         self.parent = parent
-        self.stitch_plan = kwargs.pop('stitch_plan', None)
+        self.stitch_plan: Optional[StitchPlan] = kwargs.pop('stitch_plan', None)
         kwargs['style'] = wx.BORDER_SUNKEN
 
         wx.Panel.__init__(self, parent, *args, **kwargs)
@@ -98,8 +99,7 @@ class DrawingPanel(wx.Panel):
         self.black_pen = wx.Pen((128, 128, 128))
         self.width = 0
         self.height = 0
-        self.loaded = False
-        self.page_specs = {}
+        self.page_specs: dict = {}
         self.show_page = global_settings['toggle_page_button_status']
         self.background_color = None
 
@@ -118,9 +118,8 @@ class DrawingPanel(wx.Panel):
         self.Bind(wx.EVT_SIZE, self.on_resize)
         self.Bind(wx.EVT_TIMER, self.animate)
 
-        # wait for layouts so that panel size is set
-        if self.stitch_plan:
-            wx.CallLater(50, self.load, self.stitch_plan)
+        if self.stitch_plan is not None:
+            self.load(self.stitch_plan)
 
     def on_resize(self, event):
         self.choose_zoom_and_pan()
@@ -173,9 +172,7 @@ class DrawingPanel(wx.Panel):
         dc = wx.PaintDC(self)
         canvas = wx.GraphicsContext.Create(dc)
 
-        if not self.loaded:
-            dc.Clear()
-        else:
+        if self.stitch_plan is not None:
             self.draw_stitches(canvas)
             self.draw_scale(canvas)
 
@@ -321,10 +318,10 @@ class DrawingPanel(wx.Panel):
                 canvas.DrawEllipse(stitch[0]-(npp_size / 2), stitch[1]-(npp_size / 2), npp_size, npp_size)
 
     def clear(self):
-        self.loaded = False
+        self.stitch_plan = None
         self.Refresh()
 
-    def load(self, stitch_plan):
+    def load(self, stitch_plan: StitchPlan) -> None:
         self.stitch_plan = stitch_plan
         self.current_stitch = 1
         self.direction = 1
@@ -340,7 +337,8 @@ class DrawingPanel(wx.Panel):
         self.parse_stitch_plan(stitch_plan)
         self.choose_zoom_and_pan()
         self.set_current_stitch(0)
-        statusbar = self.GetTopLevelParent().statusbar
+        # Detangling the DrawingPanel-> SimulatorWindow.statusbar dependency can wait for now
+        statusbar = self.GetTopLevelParent().statusbar  # type:ignore[attr-defined]
         statusbar.SetStatusText(
             _("Dimensions: {:.2f} x {:.2f}").format(
                 stitch_plan.dimensions_mm[0],
@@ -348,7 +346,6 @@ class DrawingPanel(wx.Panel):
             ),
             1
         )
-        self.loaded = True
         self.go()
         if hasattr(self.view_panel, 'info_panel') and self.view_panel.info_panel is not None:
             self.view_panel.info_panel.update()
@@ -399,7 +396,7 @@ class DrawingPanel(wx.Panel):
         self.control_panel.on_stop()
 
     def go(self):
-        if not self.loaded:
+        if self.stitch_plan is None:
             return
 
         if not self.animating:
@@ -509,7 +506,7 @@ class DrawingPanel(wx.Panel):
         self.set_current_stitch(self.current_stitch - 1)
 
     def on_left_mouse_button_down(self, event):
-        if self.loaded:
+        if self.stitch_plan is not None:
             self.CaptureMouse()
             self.drag_start = event.GetPosition()
             self.drag_original_pan = self.pan

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -12,7 +12,7 @@ from ...stitch_plan import StitchPlan
 
 class SimulatorPanel(wx.Panel):
     """"""
-    def __init__(self, parent, stitch_plan=None, background_color='white', target_duration=5, stitches_per_second=16, detach_callback=None):
+    def __init__(self, parent, stitch_plan=None, background_color='white', target_duration=5, stitches_per_second=16, detach_callback=None) -> None:
         """"""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
 
@@ -84,7 +84,7 @@ class SimulatorPanel(wx.Panel):
         self.accel_table = wx.AcceleratorTable(self.accel_entries)
         self.SetAcceleratorTable(self.accel_table)
 
-        self.render_fn: Callable[[], Optional[StitchPlan]] = None
+        self.render_fn: Optional[Callable[[], Optional[StitchPlan]]] = None
 
     def go(self):
         self.dp.go()
@@ -113,7 +113,7 @@ class SimulatorPanel(wx.Panel):
         self.dp.set_loading(True)
         self.preview_renderer.update()
 
-    def _call_render(self) -> None:
+    def _call_render(self) -> Optional[StitchPlan]:
         if self.render_fn is None:
             return None
 
@@ -129,4 +129,3 @@ class SimulatorPanel(wx.Panel):
         except RuntimeError:
             # this can happen when they close the window at a bad time
             pass
-

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 import wx
-from typing import Callable, Optional
+from typing import Optional
 
 from . import ControlPanel, DrawingPanel, ViewPanel
 from .simulator_renderer import PreviewRenderer, RenderFunction
@@ -103,7 +103,7 @@ class SimulatorPanel(wx.Panel):
 
     def set_render_fn(self, render_fn: RenderFunction) -> None:
         self.preview_renderer = PreviewRenderer(
-            render_stitch_plan=render_fn, 
+            render_stitch_plan=render_fn,
             rendering_completed=self.on_stitch_plan_rendered
         )
 

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -6,7 +6,7 @@ import wx
 from typing import Callable, Optional
 
 from . import ControlPanel, DrawingPanel, ViewPanel
-from .simulator_renderer import PreviewRenderer
+from .simulator_renderer import PreviewRenderer, RenderFunction
 from ...stitch_plan import StitchPlan
 
 
@@ -16,7 +16,7 @@ class SimulatorPanel(wx.Panel):
         """"""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
 
-        self.preview_renderer = PreviewRenderer(self._call_render, self.on_stitch_plan_rendered)
+        self.preview_renderer: PreviewRenderer | None = None
 
         self.cp = ControlPanel(
             self,
@@ -84,40 +84,35 @@ class SimulatorPanel(wx.Panel):
         self.accel_table = wx.AcceleratorTable(self.accel_entries)
         self.SetAcceleratorTable(self.accel_table)
 
-        self.render_fn: Optional[Callable[[], Optional[StitchPlan]]] = None
-
-    def go(self):
+    def go(self) -> None:
         self.dp.go()
 
-    def stop(self):
+    def stop(self) -> None:
         self.dp.stop()
 
-    def load(self, stitch_plan):
+    def load(self, stitch_plan: StitchPlan) -> None:
         self.dp.load(stitch_plan)
         self.cp.load(stitch_plan)
 
-    def clear(self):
+    def clear(self) -> None:
         self.dp.clear()
         self.cp.clear()
 
-    def set_page_specs(self, page_specs):
+    def set_page_specs(self, page_specs: dict) -> None:
         self.dp.set_page_specs(page_specs)
 
-    def set_render_fn(self, render_fn: Callable[[], Optional[StitchPlan]]) -> None:
-        self.render_fn = render_fn
+    def set_render_fn(self, render_fn: RenderFunction) -> None:
+        self.preview_renderer = PreviewRenderer(
+            render_stitch_plan=render_fn, 
+            rendering_completed=self.on_stitch_plan_rendered
+        )
 
     def render(self) -> None:
-        if self.render_fn is None:
+        if self.preview_renderer is None:
             return
 
         self.dp.set_loading(True)
         self.preview_renderer.update()
-
-    def _call_render(self) -> Optional[StitchPlan]:
-        if self.render_fn is None:
-            return None
-
-        return self.render_fn()
 
     def on_stitch_plan_rendered(self, stitch_plan: Optional[StitchPlan]) -> None:
         try:

--- a/lib/gui/simulator/simulator_panel.py
+++ b/lib/gui/simulator/simulator_panel.py
@@ -3,16 +3,20 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 import wx
+from typing import Callable, Optional
 
 from . import ControlPanel, DrawingPanel, ViewPanel
+from .simulator_renderer import PreviewRenderer
+from ...stitch_plan import StitchPlan
 
 
 class SimulatorPanel(wx.Panel):
     """"""
-
     def __init__(self, parent, stitch_plan=None, background_color='white', target_duration=5, stitches_per_second=16, detach_callback=None):
         """"""
         super().__init__(parent, style=wx.BORDER_SUNKEN)
+
+        self.preview_renderer = PreviewRenderer(self._call_render, self.on_stitch_plan_rendered)
 
         self.cp = ControlPanel(
             self,
@@ -80,6 +84,8 @@ class SimulatorPanel(wx.Panel):
         self.accel_table = wx.AcceleratorTable(self.accel_entries)
         self.SetAcceleratorTable(self.accel_table)
 
+        self.render_fn: Callable[[], Optional[StitchPlan]] = None
+
     def go(self):
         self.dp.go()
 
@@ -96,3 +102,31 @@ class SimulatorPanel(wx.Panel):
 
     def set_page_specs(self, page_specs):
         self.dp.set_page_specs(page_specs)
+
+    def set_render_fn(self, render_fn: Callable[[], Optional[StitchPlan]]) -> None:
+        self.render_fn = render_fn
+
+    def render(self) -> None:
+        if self.render_fn is None:
+            return
+
+        self.dp.set_loading(True)
+        self.preview_renderer.update()
+
+    def _call_render(self) -> None:
+        if self.render_fn is None:
+            return None
+
+        return self.render_fn()
+
+    def on_stitch_plan_rendered(self, stitch_plan: Optional[StitchPlan]) -> None:
+        try:
+            self.dp.set_loading(False)
+            if stitch_plan is not None:
+                self.stop()
+                self.load(stitch_plan)
+                self.go()
+        except RuntimeError:
+            # this can happen when they close the window at a bad time
+            pass
+

--- a/lib/gui/simulator/simulator_preferences.py
+++ b/lib/gui/simulator/simulator_preferences.py
@@ -4,22 +4,28 @@
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
 import wx
+from typing import TYPE_CHECKING, cast
 
 from ...i18n import _
 from ...utils.settings import global_settings
+
+if TYPE_CHECKING:
+    from .drawing_panel import DrawingPanel
+    from .control_panel import ControlPanel
+    from .view_panel import ViewPanel
 
 
 class SimulatorPreferenceDialog(wx.Dialog):
     """A dialog to set simulator preferences
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(SimulatorPreferenceDialog, self).__init__(*args, **kwargs)
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
 
-        self.view_panel = self.GetParent()
-        self.drawing_panel = self.view_panel.drawing_panel
-        self.control_panel = self.view_panel.control_panel
+        self.view_panel = cast('ViewPanel', self.GetParent())
+        self.drawing_panel: 'DrawingPanel' = self.view_panel.drawing_panel
+        self.control_panel: 'ControlPanel' = self.view_panel.control_panel
 
         self.adaptive_speed_value = global_settings['simulator_adaptive_speed']
         self.line_width_value = global_settings['simulator_line_width']
@@ -83,7 +89,7 @@ class SimulatorPreferenceDialog(wx.Dialog):
 
     def on_change(self, attribute, event):
         global_settings[attribute] = event.EventObject.GetValue()
-        if self.drawing_panel.loaded and attribute == 'simulator_line_width':
+        if attribute == 'simulator_line_width':
             self.drawing_panel.update_pen_size()
         self.drawing_panel.Refresh()
 
@@ -107,7 +113,6 @@ class SimulatorPreferenceDialog(wx.Dialog):
 
     def on_cancel(self, event):
         self.save_settings()
-        if self.drawing_panel.loaded:
-            self.drawing_panel.update_pen_size()
-            self.drawing_panel.Refresh()
+        self.drawing_panel.update_pen_size()
+        self.drawing_panel.Refresh()
         self.Close()

--- a/lib/gui/simulator/simulator_renderer.py
+++ b/lib/gui/simulator/simulator_renderer.py
@@ -9,23 +9,24 @@ import wx
 from ...debug.debug import debug
 from ...utils.threading import ExitThread
 from ...stitch_plan import StitchPlan
-from typing import Callable
+from typing import Callable, Optional
 
+RenderFunction = Callable[[], Optional[StitchPlan]]
 
 class PreviewRenderer(Thread):
     """Render stitch plan in a background thread."""
 
     def __init__(
             self,
-            render_stitch_plan_hook: Callable[[], StitchPlan | None],
-            rendering_completed_hook: Callable[[StitchPlan | None], None]
+            render_stitch_plan: RenderFunction,
+            rendering_completed: Callable[[StitchPlan | None], None]
             ) -> None:
         super(PreviewRenderer, self).__init__()
         self.daemon = True
         self.refresh_needed = Event()
 
-        self.render_stitch_plan_hook = render_stitch_plan_hook
-        self.rendering_completed_hook = rendering_completed_hook
+        self.render_stitch_plan = render_stitch_plan
+        self.rendering_completed = rendering_completed
 
         # This is read by utils.threading.check_stop_flag() to abort stitch plan
         # generation.
@@ -34,8 +35,8 @@ class PreviewRenderer(Thread):
     def update(self) -> None:
         """Request to render a new stitch plan.
 
-        self.render_stitch_plan_hook() will be called in a background thread, and then
-        self.rendering_completed_hook() will be called with the resulting stitch plan.
+        self.render_stitch_plan() will be called in a background thread, and then
+        self.rendering_completed() will be called with the resulting stitch plan.
         """
 
         if not self.is_alive():
@@ -53,9 +54,9 @@ class PreviewRenderer(Thread):
             try:
                 debug.log("update_patches")
 
-                stitch_plan = self.render_stitch_plan_hook()
+                stitch_plan = self.render_stitch_plan()
                 # rendering_completed() will be called in the main thread.
-                wx.CallAfter(self.rendering_completed_hook, stitch_plan)
+                wx.CallAfter(self.rendering_completed, stitch_plan)
 
             except ExitThread:
                 debug.log("ExitThread caught")

--- a/lib/gui/simulator/simulator_renderer.py
+++ b/lib/gui/simulator/simulator_renderer.py
@@ -13,6 +13,7 @@ from typing import Callable, Optional
 
 RenderFunction = Callable[[], Optional[StitchPlan]]
 
+
 class PreviewRenderer(Thread):
     """Render stitch plan in a background thread."""
 

--- a/lib/gui/simulator/simulator_renderer.py
+++ b/lib/gui/simulator/simulator_renderer.py
@@ -52,13 +52,14 @@ class PreviewRenderer(Thread):
                 self.stop.clear()
 
     def render_stitch_plan(self):
+        stitch_plan = None
         try:
             stitch_plan = self.render_stitch_plan_hook()
-            if stitch_plan:
-                # rendering_completed() will be called in the main thread.
-                wx.CallAfter(self.rendering_completed_hook, stitch_plan)
         except ExitThread:
             raise
         except:  # noqa: E722
             import traceback
             debug.log("unhandled exception in PreviewRenderer.render_stitch_plan(): " + traceback.format_exc())
+        finally:
+            # rendering_completed() will be called in the main thread.
+            wx.CallAfter(self.rendering_completed_hook, stitch_plan)

--- a/lib/gui/simulator/simulator_renderer.py
+++ b/lib/gui/simulator/simulator_renderer.py
@@ -8,12 +8,18 @@ import wx
 
 from ...debug.debug import debug
 from ...utils.threading import ExitThread
+from ...stitch_plan import StitchPlan
+from typing import Callable
 
 
 class PreviewRenderer(Thread):
     """Render stitch plan in a background thread."""
 
-    def __init__(self, render_stitch_plan_hook, rendering_completed_hook):
+    def __init__(
+            self,
+            render_stitch_plan_hook: Callable[[], StitchPlan | None],
+            rendering_completed_hook: Callable[[StitchPlan | None], None]
+            ) -> None:
         super(PreviewRenderer, self).__init__()
         self.daemon = True
         self.refresh_needed = Event()
@@ -25,7 +31,7 @@ class PreviewRenderer(Thread):
         # generation.
         self.stop = Event()
 
-    def update(self):
+    def update(self) -> None:
         """Request to render a new stitch plan.
 
         self.render_stitch_plan_hook() will be called in a background thread, and then
@@ -38,7 +44,7 @@ class PreviewRenderer(Thread):
         self.stop.set()
         self.refresh_needed.set()
 
-    def run(self):
+    def run(self) -> None:
         while True:
             self.refresh_needed.wait()
             self.refresh_needed.clear()
@@ -46,20 +52,13 @@ class PreviewRenderer(Thread):
 
             try:
                 debug.log("update_patches")
-                self.render_stitch_plan()
+
+                stitch_plan = self.render_stitch_plan_hook()
+                # rendering_completed() will be called in the main thread.
+                wx.CallAfter(self.rendering_completed_hook, stitch_plan)
+
             except ExitThread:
                 debug.log("ExitThread caught")
-                self.stop.clear()
-
-    def render_stitch_plan(self):
-        stitch_plan = None
-        try:
-            stitch_plan = self.render_stitch_plan_hook()
-        except ExitThread:
-            raise
-        except:  # noqa: E722
-            import traceback
-            debug.log("unhandled exception in PreviewRenderer.render_stitch_plan(): " + traceback.format_exc())
-        finally:
-            # rendering_completed() will be called in the main thread.
-            wx.CallAfter(self.rendering_completed_hook, stitch_plan)
+            except:  # noqa: E722
+                import traceback
+                debug.log("unhandled exception in PreviewRenderer.render_stitch_plan(): " + traceback.format_exc())

--- a/lib/gui/tartan/main_panel.py
+++ b/lib/gui/tartan/main_panel.py
@@ -19,7 +19,7 @@ from ...tartan.palette import Palette
 from ...tartan.svg import TartanSvgGroup
 from ...utils import DotDict
 from ...utils.threading import ExitThread, check_stop_flag
-from .. import PresetsPanel, PreviewRenderer, WarningPanel
+from .. import PresetsPanel, WarningPanel
 from . import CodePanel, CustomizePanel, EmbroideryPanel, HelpPanel
 
 
@@ -38,7 +38,7 @@ class TartanMainPanel(wx.Panel):
         self.SetWindowStyle(wx.FRAME_FLOAT_ON_PARENT | wx.DEFAULT_FRAME_STYLE)
 
         # preview
-        self.preview_renderer = PreviewRenderer(self.render_stitch_plan, self.on_stitch_plan_rendered)
+        self.simulator.set_render_fn(self.render_stitch_plan)
         # presets
         self.presets_panel = PresetsPanel(self)
         # warnings
@@ -183,7 +183,7 @@ class TartanMainPanel(wx.Panel):
         self.Layout()
 
     def update_preview(self, event=None):
-        self.preview_renderer.update()
+        self.simulator.render()
 
     def apply_preset_data(self, preset_data):
         settings = DotDict(preset_data)
@@ -271,8 +271,3 @@ class TartanMainPanel(wx.Panel):
                 TartanSvgGroup(self.settings).generate(node)
             else:
                 prepare_tartan_fill_element(node)
-
-    def on_stitch_plan_rendered(self, stitch_plan):
-        self.simulator.stop()
-        self.simulator.load(stitch_plan)
-        self.simulator.go()

--- a/lib/sew_stack/stitch_layers/running_stitch/running_stitch_layer.py
+++ b/lib/sew_stack/stitch_layers/running_stitch/running_stitch_layer.py
@@ -101,7 +101,7 @@ class RunningStitchLayer(StitchLayer, RandomizationMixin, PathMixin):
 
             stitches.extend(running_stitch(
                 this_path,
-                self.config.stitch_length * PIXELS_PER_MM,
+                [self.config.stitch_length * PIXELS_PER_MM],
                 self.config.tolerance * PIXELS_PER_MM,
                 (self.config.stitch_length_jitter_percent > 0),
                 self.config.stitch_length_jitter_percent,

--- a/lib/utils/threading.py
+++ b/lib/utils/threading.py
@@ -12,12 +12,9 @@ class ExitThread(InkstitchException):
     pass
 
 
-# A default flag used for the main thread.  It will never be set.
-_default_stop_flag = threading.Event()
-
-
-def check_stop_flag():
+def check_stop_flag() -> None:
     # This getattr() actually looks at the PreviewRenderer instance's stop attribute.
-    if getattr(threading.current_thread(), 'stop', _default_stop_flag).is_set():
+    stop_event: threading.Event | None = getattr(threading.current_thread(), 'stop', None)
+    if stop_event is not None and stop_event.is_set():
         debug.log("exiting thread")
         raise ExitThread()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,101 @@
+from lib.gui.simulator.simulator_renderer import PreviewRenderer
+from lib.utils.threading import check_stop_flag
+from lib.stitch_plan import StitchPlan
+
+from typing import Iterator
+from threading import Event
+
+from unittest.mock import MagicMock, patch, sentinel
+import time
+import pytest
+
+
+def test_check_stop_flag_on_main():
+    """ Using check_stop_flag on a non-preview-renderer thread doesn't throw"""
+    check_stop_flag()
+
+
+# ThreadingMock is only available in 3.13+, so we'll have to set up waiting on
+# this mock being called ourselves.
+@pytest.fixture
+def call_after_called() -> Event:
+    return Event()
+
+
+@pytest.fixture
+def call_after_mock(call_after_called) -> Iterator[MagicMock]:
+    with patch('wx.CallAfter') as call_after:
+        def call_after_side_effect(self, *args, **kwargs):
+            call_after_called.set()
+        call_after.side_effect = call_after_side_effect
+
+        yield call_after
+
+
+def test_basic(call_after_called, call_after_mock):
+    """ PreviewRenderer calls render_plan and invokes on_rendered on main thread. """
+    def render_plan() -> StitchPlan:
+        return sentinel.rendered_plan
+
+    def on_rendered(plan: StitchPlan | None) -> None:
+        pass
+
+    # Exercise
+    renderer = PreviewRenderer(render_plan, on_rendered)
+    renderer.update()
+
+    # Verify
+    assert call_after_called.wait(10), "wx.call_after was not invoked"
+    call_after_mock.assert_called_once_with(on_rendered, sentinel.rendered_plan)
+
+
+def test_no_on_render_on_cancel(call_after_called, call_after_mock):
+    """ PreviewRenderer does not invoke on_rendered when cancelled. """
+    render_entered = Event()
+    render_done = Event()
+
+    def render_plan() -> StitchPlan:
+        render_entered.set()
+        render_done.wait()
+        check_stop_flag()
+
+        return sentinel.rendered_plan
+
+    def on_rendered(plan: StitchPlan | None) -> None:
+        pass
+
+    # Exercise
+    renderer = PreviewRenderer(render_plan, on_rendered)
+
+    # Run an update, wait for entry
+    renderer.update()
+    render_entered.wait()
+    # Queue another update before the stop flag is set
+    renderer.update()
+    # Allow the render to proceed. It should check the flag, cancel, and retry
+    render_done.set()
+
+    # Verify, should have only been called once.
+    assert call_after_called.wait(10), "wx.call_after was not invoked"
+    call_after_mock.assert_called_once_with(on_rendered, sentinel.rendered_plan)
+
+
+def test_exception_does_not_loop(call_after_called, call_after_mock):
+    """ PreviewRenderer does not retry when the render function throws. """
+    render_plan = MagicMock()
+    render_plan.side_effect = RuntimeError("Oops")
+
+    def on_rendered(plan: StitchPlan | None) -> None:
+        pass
+
+    # Exercise
+    renderer = PreviewRenderer(render_plan, on_rendered)
+    renderer.update()
+
+    # Wait a moment. Not ideal but we can't otherwise prove a negative.
+    time.sleep(1)
+
+    # Verify - Render should have only been called once and not re-run
+    render_plan.assert_called_once()
+    # ...and wx.call_after should never have neen invoked
+    call_after_mock.assert_not_called()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -41,7 +41,7 @@ def test_basic(call_after_called, call_after_mock):
         pass
 
     # Exercise
-    renderer = PreviewRenderer(render_plan, on_rendered)
+    renderer = PreviewRenderer(render_stitch_plan=render_plan, rendering_completed=on_rendered)
     renderer.update()
 
     # Verify
@@ -65,7 +65,7 @@ def test_no_on_render_on_cancel(call_after_called, call_after_mock):
         pass
 
     # Exercise
-    renderer = PreviewRenderer(render_plan, on_rendered)
+    renderer = PreviewRenderer(render_stitch_plan=render_plan, rendering_completed=on_rendered)
 
     # Run an update, wait for entry
     renderer.update()
@@ -80,7 +80,7 @@ def test_no_on_render_on_cancel(call_after_called, call_after_mock):
     call_after_mock.assert_called_once_with(on_rendered, sentinel.rendered_plan)
 
 
-def test_exception_does_not_loop(call_after_called, call_after_mock):
+def test_exception_does_not_loop(call_after_mock):
     """ PreviewRenderer does not retry when the render function throws. """
     render_plan = MagicMock()
     render_plan.side_effect = RuntimeError("Oops")
@@ -89,7 +89,7 @@ def test_exception_does_not_loop(call_after_called, call_after_mock):
         pass
 
     # Exercise
-    renderer = PreviewRenderer(render_plan, on_rendered)
+    renderer = PreviewRenderer(render_stitch_plan=render_plan, rendering_completed=on_rendered)
     renderer.update()
 
     # Wait a moment. Not ideal but we can't otherwise prove a negative.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,10 @@
 from lib.debug.debug import sew_stack_enabled
 
+# Mark this module as non-test, otherwise pytest thinks the contents of this file are tests,
+# despite element_count obviously not having "test" in its name???
+__test__ = False
 
-def element_count():
+def element_count() -> int:
     element_count = 1
     if sew_stack_enabled:
         element_count = 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ from lib.debug.debug import sew_stack_enabled
 # despite element_count obviously not having "test" in its name???
 __test__ = False
 
+
 def element_count() -> int:
     element_count = 1
     if sew_stack_enabled:


### PR DESCRIPTION
- During re-render, a "Loading..." indicator is shown over the display. It's currently not animated and kinda minimal (I ended up subconsciously making the Half Life 2 loading indicator) but can be extended later. Any ideas for what sort of loading widget we'd want? A standard spinner? Something with the Ink/Stitch logo?
- Simulator Panel now owns the Preview Renderer thread, and can be passed a callback to define how re-rendering text works.
- Simulator extension now starts window immediately and shows the loading screen during stitch planning, making it seem a little more responsive
- Removed the minx/miny offset from the drawing window, and instead adjust the pan/zoom to compensate. This is also a minor prereq for the GL simulator.

Screenshots:
<img width="1920" height="915" alt="screen09" src="https://github.com/user-attachments/assets/4bef8e62-6932-4d4c-84d8-6955c92dd960" />
<img width="1920" height="915" alt="screen08" src="https://github.com/user-attachments/assets/0a67349d-15d5-45e8-b613-b6a9660051b2" />

Further work:
- Wanted to consolidate the rendering even further, we have the same "generate stitch plan from these elements" implemented in multiple places in the codebase and they're not all 100% consistent. However, I hit some circular dependency issues and it was starting to bloat the diff, so that'll have to be for another day.
- Make something prettier