### PR TITLE
Initial satin column package split

### DIFF
--- a/lib/elements/satin_column/__init__.py
+++ b/lib/elements/satin_column/__init__.py
@@ -1,0 +1,8 @@
+# Authors: see git history
+#
+# Copyright (c) 2010 Authors
+# Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
+
+from .satin_column import SatinColumn
+
+__all__ = ["SatinColumn"]

--- a/lib/elements/satin_column/rails.py
+++ b/lib/elements/satin_column/rails.py
@@ -20,8 +20,8 @@ def get_rails_to_reverse(choice: str, rails: list[list[tuple[float, float]]]) ->
     elif choice == 'both':
         return True, True
     elif choice == 'automatic':
-        rails = [shgeo.LineString(rail) for rail in rails]
-        if len(rails) == 2:
+        rail_lines = [shgeo.LineString(rail) for rail in rails]
+        if len(rail_lines) == 2:
             # Sample ten points along the rails.  Compare the distance
             # between corresponding points on both rails with and without
             # one rail reversed.  If the average distance between points
@@ -32,9 +32,9 @@ def get_rails_to_reverse(choice: str, rails: list[list[tuple[float, float]]]) ->
 
             for i in range(10):
                 distance = i / 10
-                point0 = rails[0].interpolate(distance, normalized=True)
-                point1 = rails[1].interpolate(distance, normalized=True)
-                point1_reverse = rails[1].interpolate(1 - distance, normalized=True)
+                point0 = rail_lines[0].interpolate(distance, normalized=True)
+                point1 = rail_lines[1].interpolate(distance, normalized=True)
+                point1_reverse = rail_lines[1].interpolate(1 - distance, normalized=True)
 
                 lengths.append(point0.distance(point1))
                 lengths_reverse.append(point0.distance(point1_reverse))

--- a/lib/elements/satin_column/rails.py
+++ b/lib/elements/satin_column/rails.py
@@ -1,11 +1,15 @@
+from typing import Sequence, TYPE_CHECKING
+
 from shapely import geometry as shgeo
 
-from .satin_column import SatinColumn
 from .satin_processor import SatinProcessor
 from ..element import PIXELS_PER_MM
 from ...debug.debug import debug
-from ...utils.geometry import Point
+from ...utils import Point, cut
 from ...utils.threading import check_stop_flag
+
+if TYPE_CHECKING:
+    from .satin_column import SatinColumn
 
 
 def get_rails_to_reverse(choice: str, rails: list[list[tuple[float, float]]]) -> tuple[bool, bool]:
@@ -43,6 +47,7 @@ def get_rails_to_reverse(choice: str, rails: list[list[tuple[float, float]]]) ->
 
     return False, False
 
+
 def _stitch_distance(pos0: Point, pos1: Point, previous_pos0: Point, previous_pos1: Point) -> float:
     """Return the distance from one stitch to the next."""
 
@@ -64,6 +69,7 @@ def _stitch_distance(pos0: Point, pos1: Point, previous_pos0: Point, previous_po
         d0 = pos0 - previous_pos0
         d1 = pos1 - previous_pos1
         return max(abs(d0 * normal), abs(d1 * normal))
+
 
 @debug.time
 def plot_points_on_rails(satin: 'SatinColumn', spacing: float | int, offset_px: tuple[float, float] = (0, 0),
@@ -177,3 +183,41 @@ def plot_points_on_rails(satin: 'SatinColumn', spacing: float | int, offset_px: 
             pairs.append(processor.process_points(section0[-1], section1[-1]))
 
     return pairs
+
+
+def cut_rails(satin: 'SatinColumn', cut_points: Sequence[Point | shgeo.Point]) -> tuple[list[shgeo.LineString], list[shgeo.LineString]]:
+    """Cut the rails of this satin at the specified points.
+
+    cut_points is a list of two elements, corresponding to the cut points
+    for each rail in order.
+
+    Returns: A list of two elements, corresponding to the two new sets of
+      rails.  Each element is a list of two rails of type LineString.
+    """
+
+    rails = [shgeo.LineString(rail) for rail in satin.rails]
+
+    path_lists: tuple[list[shgeo.LineString], list[shgeo.LineString]] = ([], [])
+
+    rails_to_reverse = get_rails_to_reverse(satin.reverse_rails, satin.rails)
+
+    if rails_to_reverse[0] == rails_to_reverse[1]:
+        for i, rail in enumerate(rails):
+            before, after = cut(rail, rail.project(shgeo.Point(cut_points[i])))
+            path_lists[0].append(before)
+            path_lists[1].append(after)
+    else:
+        # rails have opposite direction
+        rail = rails[0]
+        before, after = cut(rail, rail.project(shgeo.Point(cut_points[0])))
+        path_lists[0].append(before)
+        path_lists[1].append(after)
+        rail = rails[1]
+        before, after = cut(rail, rail.project(shgeo.Point(cut_points[1])))
+        path_lists[1].append(before)
+        path_lists[0].append(after)
+
+    if rails_to_reverse[0]:
+        path_lists = (path_lists[1], path_lists[0])
+
+    return path_lists

--- a/lib/elements/satin_column/rails.py
+++ b/lib/elements/satin_column/rails.py
@@ -1,0 +1,179 @@
+from shapely import geometry as shgeo
+
+from .satin_column import SatinColumn
+from .satin_processor import SatinProcessor
+from ..element import PIXELS_PER_MM
+from ...debug.debug import debug
+from ...utils.geometry import Point
+from ...utils.threading import check_stop_flag
+
+
+def get_rails_to_reverse(choice: str, rails: list[list[tuple[float, float]]]) -> tuple[bool, bool]:
+    if choice == 'first':
+        return True, False
+    elif choice == 'second':
+        return False, True
+    elif choice == 'both':
+        return True, True
+    elif choice == 'automatic':
+        rails = [shgeo.LineString(rail) for rail in rails]
+        if len(rails) == 2:
+            # Sample ten points along the rails.  Compare the distance
+            # between corresponding points on both rails with and without
+            # one rail reversed.  If the average distance between points
+            # with one rail reversed is less than without one reversed, then
+            # the user has probably accidentally reversed a rail.
+            lengths = []
+            lengths_reverse = []
+
+            for i in range(10):
+                distance = i / 10
+                point0 = rails[0].interpolate(distance, normalized=True)
+                point1 = rails[1].interpolate(distance, normalized=True)
+                point1_reverse = rails[1].interpolate(1 - distance, normalized=True)
+
+                lengths.append(point0.distance(point1))
+                lengths_reverse.append(point0.distance(point1_reverse))
+
+            debug.log(f"lengths: {lengths}")
+            debug.log(f"lengths_reverse: {lengths_reverse}")
+            if sum(lengths) > sum(lengths_reverse):
+                # reverse the second rail
+                return False, True
+
+    return False, False
+
+def _stitch_distance(pos0: Point, pos1: Point, previous_pos0: Point, previous_pos1: Point) -> float:
+    """Return the distance from one stitch to the next."""
+
+    previous_stitch = previous_pos1 - previous_pos0
+    if previous_stitch.length() < 0.01:
+        return shgeo.LineString((pos0, pos1)).distance(shgeo.Point(previous_pos0))
+    else:
+        # Measure the distance at a right angle to the previous stitch, at
+        # the start and end of the stitch, and pick the biggest.  If we're
+        # going around a curve, the points on the inside of the curve will
+        # be much closer together, and we only care about the distance on
+        # the outside of the curve.
+        #
+        # In this example with two horizontal stitches, we want the vertical
+        # separation between them.
+        #  _________
+        #  \_______/
+        normal = previous_stitch.unit().rotate_left()
+        d0 = pos0 - previous_pos0
+        d1 = pos1 - previous_pos1
+        return max(abs(d0 * normal), abs(d1 * normal))
+
+@debug.time
+def plot_points_on_rails(satin: 'SatinColumn', spacing: float | int, offset_px: tuple[float, float] = (0, 0),
+                         offset_proportional: tuple[float, float] = (0, 0), use_random: bool = False,
+                         ) -> list[tuple[Point, Point]]:
+    # Take a section from each rail in turn, and plot out an equal number
+    # of points on both rails.  Return the points plotted. The points will
+    # be contracted or expanded by offset using self.offset_points().
+
+    processor = SatinProcessor(satin, offset_px, offset_proportional, use_random)
+
+    pairs = []
+
+    for i, (section0, section1) in enumerate(satin.flattened_sections):
+        check_stop_flag()
+
+        if i == 0:
+            old_pos0 = section0[0]
+            old_pos1 = section1[0]
+            pairs.append(processor.process_points(old_pos0, old_pos1))
+
+        path0 = shgeo.LineString(section0)
+        path1 = shgeo.LineString(section1)
+
+        # Base the number of stitches in each section on the _longer_ of
+        # the two sections. Otherwise, things could get too sparse when one
+        # side is significantly longer (e.g. when going around a corner).
+        num_points = max(path0.length, path1.length, 0.01) / spacing
+
+        # Section stitch spacing and the cursor are expressed as a fraction
+        # of the total length of the path, because we use normalized=True
+        # below.
+        section_stitch_spacing = 1.0 / num_points
+
+        # current_spacing, however, is in pixels.
+        spacing_multiple = processor.get_stitch_spacing_multiple()
+        current_spacing = spacing * spacing_multiple
+
+        # In all sections after the first, we need to figure out how far to
+        # travel before placing the first stitch.
+        distance = _stitch_distance(section0[0], section1[0], old_pos0, old_pos1)
+        to_travel = (1 - min(distance / spacing, 1.0)) * section_stitch_spacing * spacing_multiple
+        debug.log(f"num_points: {num_points}, section_stitch_spacing: {section_stitch_spacing}, distance: {distance}, to_travel: {to_travel}")
+
+        cursor = 0
+        iterations = 0
+        while cursor + to_travel <= 1:
+            iterations += 1
+            pos0 = Point.from_shapely_point(path0.interpolate(cursor + to_travel, normalized=True))
+            pos1 = Point.from_shapely_point(path1.interpolate(cursor + to_travel, normalized=True))
+
+            # If the rails are parallel, then our stitch spacing will be
+            # perfect.  If the rails are coming together or spreading apart,
+            # then we'll have to travel much further along the rails to get
+            # the right stitch spacing.  Imagine a satin like the letter V:
+            #
+            # \______/
+            #  \____/
+            #   \__/
+            #    \/
+            #
+            # In this case the stitches will be way too close together.
+            # We'll compensate for that here.
+            #
+            # We'll measure how far this stitch is from the previous one.
+            # If we went one third as far as we were expecting to, then
+            # we'll need to try again, this time travelling 3x as far as we
+            # originally tried.
+            #
+            # This works great for the V, but what if things change
+            # mid-stitch?
+            #
+            # \      /
+            #  \    /
+            #   \  /
+            #    ||
+            #
+            # In this case, we may way overshoot.  We can also undershoot
+            # for similar reasons.  To deal with that, we'll revise our
+            # guess a second time.  Two tries seems to be the sweet spot.
+            #
+            # In any case, we'll only revise if our stitch spacing is off by
+            # more than 5%.
+            if iterations <= 2:
+                distance = _stitch_distance(pos0, pos1, old_pos0, old_pos1)
+                if distance > 0.01 and abs((current_spacing - distance) / current_spacing) > 0.05:
+                    # We'll revise to_travel then go back to the start of
+                    # the loop and try again.
+                    to_travel = (current_spacing / distance) * to_travel
+                    if iterations == 1:
+                        # Don't overshoot the end of this section on the
+                        # first try. If we've gone too far, we want to have
+                        # a chance to correct.
+                        to_travel = min(to_travel, 1 - cursor)
+                    continue
+
+            cursor += to_travel
+            spacing_multiple = processor.get_stitch_spacing_multiple()
+            to_travel = section_stitch_spacing * spacing_multiple
+            current_spacing = spacing * spacing_multiple
+
+            old_pos0 = pos0
+            old_pos1 = pos1
+            pairs.append(processor.process_points(pos0, pos1))
+            iterations = 0
+
+    # Add one last stitch at the end unless our previous stitch is already
+    # really close to the end.
+    if pairs and section0 and section1:
+        if _stitch_distance(section0[-1], section1[-1], old_pos0, old_pos1) > 0.1 * PIXELS_PER_MM:
+            pairs.append(processor.process_points(section0[-1], section1[-1]))
+
+    return pairs

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -6,7 +6,7 @@
 import itertools
 from copy import deepcopy
 from itertools import chain
-from typing import List, Tuple, Optional, Sequence, overload
+from typing import List, Optional, Sequence, overload
 
 import numpy as np
 from inkex import Path, Vector2d
@@ -15,7 +15,6 @@ from shapely import geometry as shgeo
 from shapely import set_precision
 from shapely.ops import nearest_points, substring
 
-from ...debug.debug import debug
 from ...i18n import _
 from ...metadata import InkStitchMetadata
 from ...stitch_plan import Stitch, StitchGroup
@@ -24,12 +23,13 @@ from ...svg import line_strings_to_coordinate_lists
 from ...svg.styles import get_join_style_args
 from ...utils import AnyPointType, Point, cache, cut, cut_multiple, offset_points, prng
 from ...utils.param import ParamOption
-from ...utils.threading import check_stop_flag
 from ..element import PIXELS_PER_MM, EmbroideryElement, param
 from ..utils.stroke_to_satin import convert_path_to_satin, set_first_node
 from .validation_models import (NotStitchableError, ClosedPathWarning, DanglingRungWarning, NoRungWarning,
                                 TooManyIntersectionsWarning, StrokeSatinWarning, NarrowSatinWarning,
                                 TwoRungsWarning, UnequalPointsWarning)
+from .rails import get_rails_to_reverse, plot_points_on_rails
+from .stitches import do_top_layer_stitch_group
 
 ListOfPairs = list[tuple[Point, Point]]
 
@@ -262,41 +262,7 @@ class SatinColumn(EmbroideryElement):
         return self.get_param('reverse_rails', 'automatic')
 
     def _get_rails_to_reverse(self) -> tuple[bool, bool]:
-        choice = self.reverse_rails
-
-        if choice == 'first':
-            return True, False
-        elif choice == 'second':
-            return False, True
-        elif choice == 'both':
-            return True, True
-        elif choice == 'automatic':
-            rails = [shgeo.LineString(rail) for rail in self.rails]
-            if len(rails) == 2:
-                # Sample ten points along the rails.  Compare the distance
-                # between corresponding points on both rails with and without
-                # one rail reversed.  If the average distance between points
-                # with one rail reversed is less than without one reversed, then
-                # the user has probably accidentally reversed a rail.
-                lengths = []
-                lengths_reverse = []
-
-                for i in range(10):
-                    distance = i / 10
-                    point0 = rails[0].interpolate(distance, normalized=True)
-                    point1 = rails[1].interpolate(distance, normalized=True)
-                    point1_reverse = rails[1].interpolate(1 - distance, normalized=True)
-
-                    lengths.append(point0.distance(point1))
-                    lengths_reverse.append(point0.distance(point1_reverse))
-
-                debug.log(f"lengths: {lengths}")
-                debug.log(f"lengths_reverse: {lengths_reverse}")
-                if sum(lengths) > sum(lengths_reverse):
-                    # reverse the second rail
-                    return False, True
-
-        return False, False
+        return get_rails_to_reverse(self.reverse_rails, self.rails)
 
     @property
     @param(
@@ -554,7 +520,8 @@ class SatinColumn(EmbroideryElement):
     @property
     @cache
     def compensated_shape(self):
-        pairs = self.plot_points_on_rails(
+        pairs = plot_points_on_rails(
+            self,
             self.zigzag_spacing,
             self.pull_compensation_px,
             self.pull_compensation_percent/100,
@@ -858,7 +825,7 @@ class SatinColumn(EmbroideryElement):
         elif not self.to_stitch_groups() and self.line_string_rails:
             yield NotStitchableError(self.line_string_rails[0].representative_point())
 
-    def _center_walk_is_odd(self):
+    def center_walk_is_odd(self):
         return self.center_walk_underlay and self.center_walk_underlay_repeats % 2 == 1
 
     def reverse(self):
@@ -971,7 +938,7 @@ class SatinColumn(EmbroideryElement):
         """
 
         # like in do_satin()
-        points: list[Point] = list(chain.from_iterable(self.plot_points_on_rails(self.zigzag_spacing)))
+        points: list[Point] = list(chain.from_iterable(plot_points_on_rails(self, self.zigzag_spacing)))
 
         if isinstance(split_point, float):
             index_of_closest_stitch = int(round(len(points) * split_point))
@@ -1113,7 +1080,7 @@ class SatinColumn(EmbroideryElement):
     @cache
     def center_line(self):
         # similar technique to do_center_walk()
-        center_walk = [p[0] for p in self.plot_points_on_rails(self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
+        center_walk = [p[0] for p in self.plot_points_on_rails(self, self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
         if len(center_walk) < 2:
             center_walk = [center_walk[0], center_walk[0]]
         return shgeo.LineString(center_walk)
@@ -1131,7 +1098,7 @@ class SatinColumn(EmbroideryElement):
             stitch_length = self.running_stitch_length
 
         # Do it like contour underlay, but inset all the way to the center.
-        pairs = self.plot_points_on_rails(self.running_stitch_tolerance, (0, 0), inset_prop)
+        pairs = self.plot_points_on_rails(self, self.running_stitch_tolerance, (0, 0), inset_prop)
 
         points = [points[0] for points in pairs]
         stitches = running_stitch.even_running_stitch(points, [stitch_length], self.running_stitch_tolerance)
@@ -1140,141 +1107,6 @@ class SatinColumn(EmbroideryElement):
             stitches.append(stitches[0])
 
         return stitches
-
-    def _stitch_distance(self, pos0: Point, pos1: Point, previous_pos0: Point, previous_pos1: Point) -> float:
-        """Return the distance from one stitch to the next."""
-
-        previous_stitch = previous_pos1 - previous_pos0
-        if previous_stitch.length() < 0.01:
-            return shgeo.LineString((pos0, pos1)).distance(shgeo.Point(previous_pos0))
-        else:
-            # Measure the distance at a right angle to the previous stitch, at
-            # the start and end of the stitch, and pick the biggest.  If we're
-            # going around a curve, the points on the inside of the curve will
-            # be much closer together, and we only care about the distance on
-            # the outside of the curve.
-            #
-            # In this example with two horizontal stitches, we want the vertical
-            # separation between them.
-            #  _________
-            #  \_______/
-            normal = previous_stitch.unit().rotate_left()
-            d0 = pos0 - previous_pos0
-            d1 = pos1 - previous_pos1
-            return max(abs(d0 * normal), abs(d1 * normal))
-
-    @debug.time
-    def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float] = (0, 0),
-                             offset_proportional: tuple[float, float] = (0, 0), use_random: bool = False,
-                             ) -> List[Tuple[Point, Point]]:
-        # Take a section from each rail in turn, and plot out an equal number
-        # of points on both rails.  Return the points plotted. The points will
-        # be contracted or expanded by offset using self.offset_points().
-
-        processor = SatinProcessor(self, offset_px, offset_proportional, use_random)
-
-        pairs = []
-
-        for i, (section0, section1) in enumerate(self.flattened_sections):
-            check_stop_flag()
-
-            if i == 0:
-                old_pos0 = section0[0]
-                old_pos1 = section1[0]
-                pairs.append(processor.process_points(old_pos0, old_pos1))
-
-            path0 = shgeo.LineString(section0)
-            path1 = shgeo.LineString(section1)
-
-            # Base the number of stitches in each section on the _longer_ of
-            # the two sections. Otherwise, things could get too sparse when one
-            # side is significantly longer (e.g. when going around a corner).
-            num_points = max(path0.length, path1.length, 0.01) / spacing
-
-            # Section stitch spacing and the cursor are expressed as a fraction
-            # of the total length of the path, because we use normalized=True
-            # below.
-            section_stitch_spacing = 1.0 / num_points
-
-            # current_spacing, however, is in pixels.
-            spacing_multiple = processor.get_stitch_spacing_multiple()
-            current_spacing = spacing * spacing_multiple
-
-            # In all sections after the first, we need to figure out how far to
-            # travel before placing the first stitch.
-            distance = self._stitch_distance(section0[0], section1[0], old_pos0, old_pos1)
-            to_travel = (1 - min(distance / spacing, 1.0)) * section_stitch_spacing * spacing_multiple
-            debug.log(f"num_points: {num_points}, section_stitch_spacing: {section_stitch_spacing}, distance: {distance}, to_travel: {to_travel}")
-
-            cursor = 0
-            iterations = 0
-            while cursor + to_travel <= 1:
-                iterations += 1
-                pos0 = Point.from_shapely_point(path0.interpolate(cursor + to_travel, normalized=True))
-                pos1 = Point.from_shapely_point(path1.interpolate(cursor + to_travel, normalized=True))
-
-                # If the rails are parallel, then our stitch spacing will be
-                # perfect.  If the rails are coming together or spreading apart,
-                # then we'll have to travel much further along the rails to get
-                # the right stitch spacing.  Imagine a satin like the letter V:
-                #
-                # \______/
-                #  \____/
-                #   \__/
-                #    \/
-                #
-                # In this case the stitches will be way too close together.
-                # We'll compensate for that here.
-                #
-                # We'll measure how far this stitch is from the previous one.
-                # If we went one third as far as we were expecting to, then
-                # we'll need to try again, this time travelling 3x as far as we
-                # originally tried.
-                #
-                # This works great for the V, but what if things change
-                # mid-stitch?
-                #
-                # \      /
-                #  \    /
-                #   \  /
-                #    ||
-                #
-                # In this case, we may way overshoot.  We can also undershoot
-                # for similar reasons.  To deal with that, we'll revise our
-                # guess a second time.  Two tries seems to be the sweet spot.
-                #
-                # In any case, we'll only revise if our stitch spacing is off by
-                # more than 5%.
-                if iterations <= 2:
-                    distance = self._stitch_distance(pos0, pos1, old_pos0, old_pos1)
-                    if distance > 0.01 and abs((current_spacing - distance) / current_spacing) > 0.05:
-                        # We'll revise to_travel then go back to the start of
-                        # the loop and try again.
-                        to_travel = (current_spacing / distance) * to_travel
-                        if iterations == 1:
-                            # Don't overshoot the end of this section on the
-                            # first try. If we've gone too far, we want to have
-                            # a chance to correct.
-                            to_travel = min(to_travel, 1 - cursor)
-                        continue
-
-                cursor += to_travel
-                spacing_multiple = processor.get_stitch_spacing_multiple()
-                to_travel = section_stitch_spacing * spacing_multiple
-                current_spacing = spacing * spacing_multiple
-
-                old_pos0 = pos0
-                old_pos1 = pos1
-                pairs.append(processor.process_points(pos0, pos1))
-                iterations = 0
-
-        # Add one last stitch at the end unless our previous stitch is already
-        # really close to the end.
-        if pairs and section0 and section1:
-            if self._stitch_distance(section0[-1], section1[-1], old_pos0, old_pos1) > 0.1 * PIXELS_PER_MM:
-                pairs.append(processor.process_points(section0[-1], section1[-1]))
-
-        return pairs
 
     def _connect_stitch_group_with_point(self, first_stitch_group: StitchGroup, start_point: Point | Vector2d,
                                          end_point: Optional[Point | Vector2d] = None) -> StitchGroup:
@@ -1290,7 +1122,7 @@ class SatinColumn(EmbroideryElement):
             split_line = shgeo.LineString(self.find_cut_points(start_point))
         start = connector.project(nearest_points(split_line, connector)[1])
 
-        if end_point and not self._center_walk_is_odd():
+        if end_point and not self.center_walk_is_odd():
             end = connector.length
         else:
             split_line = shgeo.LineString(self.find_cut_points(first_stitch_group.stitches[0]))
@@ -1341,7 +1173,8 @@ class SatinColumn(EmbroideryElement):
         # other. if the two sides are far away, adding a running stitch to travel
         # in between avoids a long jump or a trim.
 
-        pairs = self.plot_points_on_rails(
+        pairs = plot_points_on_rails(
+            self,
             self.contour_underlay_stitch_tolerance,
             -self.contour_underlay_inset_px, -self.contour_underlay_inset_percent/100)
 
@@ -1373,7 +1206,7 @@ class SatinColumn(EmbroideryElement):
         first_side = self._apply_push_comp_on_point_list(first_side, self.contour_underlay_inset_px[0], self.contour_underlay_inset_px[1])
         second_side = self._apply_push_comp_on_point_list(second_side, self.contour_underlay_inset_px[0], self.contour_underlay_inset_px[1])
 
-        if self._center_walk_is_odd():
+        if self.center_walk_is_odd():
             first_side.reverse()
         else:
             second_side.reverse()
@@ -1430,7 +1263,7 @@ class SatinColumn(EmbroideryElement):
             tags = ("satin_column", "satin_column_underlay", "satin_center_walk")
             stitches = shgeo.LineString(stitches)
             start, end = self._split_linestring_at_end_point(stitches, end_point)
-            if self._center_walk_is_odd():
+            if self.center_walk_is_odd():
                 end, start = start, end
             stitch_groups.append(self._to_stitch_group(start, tags))
             stitch_groups.append(self._to_stitch_group(end, tags, True))
@@ -1464,11 +1297,12 @@ class SatinColumn(EmbroideryElement):
 
         stitch_groups = []
 
-        pairs = self.plot_points_on_rails(self.zigzag_underlay_spacing / 2.0,
-                                          -self.zigzag_underlay_inset_px,
-                                          -self.zigzag_underlay_inset_percent/100)
+        pairs = plot_points_on_rails(self,
+                                     self.zigzag_underlay_spacing / 2.0,
+                                      -self.zigzag_underlay_inset_px,
+                                      -self.zigzag_underlay_inset_percent/100)
 
-        if self._center_walk_is_odd():
+        if self.center_walk_is_odd():
             pairs = list(reversed(pairs))
 
         # This organizes the points in each side in the order that they'll be visited.
@@ -1508,16 +1342,6 @@ class SatinColumn(EmbroideryElement):
         stitch_group.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
         return stitch_group
 
-    def _do_top_layer_stitch_group(self) -> StitchGroup:
-        if self.satin_method == 'e_stitch':
-            return self.do_e_stitch()
-        elif self.satin_method == 's_stitch':
-            return self.do_s_stitch()
-        elif self.satin_method == 'zigzag':
-            return self.do_zigzag()
-        else:
-            return self.do_satin()
-
     def _split_linestring_at_end_point(self, linestring: LineString, end_point: Point):
         split_line = set_precision(shgeo.LineString(self.find_cut_points(end_point)), 0.00001)
         if not split_line:
@@ -1541,213 +1365,6 @@ class SatinColumn(EmbroideryElement):
         stitch_group1.stitches = [Stitch(*point) for point in start.coords]
         top_layer_stitch_groups = [stitch_group1, stitch_group2]
         return top_layer_stitch_groups
-
-    def do_satin(self):
-        # satin: do a zigzag pattern, alternating between the paths.  The
-        # zigzag looks like this to make the satin stitches look perpendicular
-        # to the column:
-        #
-        # |/|/|/|/|/|/|/|/|
-
-        # print >> dbg, "satin", self.zigzag_spacing, self.pull_compensation
-
-        stitch_group = StitchGroup(color=self.color)
-
-        # pull compensation is automatically converted from mm to pixels by get_float_param
-        pairs = self.plot_points_on_rails(
-            self.zigzag_spacing,
-            self.pull_compensation_px,
-            self.pull_compensation_percent/100,
-            True,
-        )
-
-        max_stitch_length = self.max_stitch_length_px
-        length_sigma = self.random_split_jitter
-        random_phase = self.random_split_phase
-        min_split_length = self.min_random_split_length_px
-        seed = self.random_seed
-
-        short_pairs = self.inset_short_stitches_sawtooth(pairs)
-
-        last_point = None
-        last_short_point = None
-        last_count = None
-        for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
-            if last_point is not None:
-                split_points, _ = self.get_split_points(
-                    last_point, a, last_short_point, a_short, max_stitch_length, last_count,
-                    length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
-                stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
-
-            stitch_group.add_stitch(a_short)
-            stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
-
-            split_points, last_count = self.get_split_points(
-                a, b, a_short, b_short, max_stitch_length, None,
-                length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
-            stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
-
-            stitch_group.add_stitch(b_short)
-            stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
-            last_point = b
-            last_short_point = b_short
-
-        if self._center_walk_is_odd():
-            stitch_group.stitches = list(reversed(stitch_group.stitches))
-
-        return stitch_group
-
-    def do_e_stitch(self):
-        # e stitch: do a pattern that looks like the letter "E".  It looks like
-        # this:
-        #
-        # _|_|_|_|_|_|_|_|_|_|_|_|
-
-        stitch_group = StitchGroup(color=self.color)
-
-        pairs = self.plot_points_on_rails(
-            self.zigzag_spacing,
-            self.pull_compensation_px,
-            self.pull_compensation_percent / 100,
-            True,
-        )
-
-        short_pairs = self.inset_short_stitches_sawtooth(pairs)
-        max_stitch_length = self.max_stitch_length_px
-        length_sigma = self.random_split_jitter
-        random_phase = self.random_split_phase
-        min_split_length = self.min_random_split_length_px
-        seed = self.random_seed
-        last_point = None
-        # "left" and "right" here are kind of arbitrary designations meaning
-        # a point from the first and second rail respectively
-        for i, (left, right), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
-            check_stop_flag()
-            split_points, _ = self.get_split_points(
-                left, right, a_short, b_short, max_stitch_length,
-                None, length_sigma, random_phase, min_split_length,
-                prng.join_args(seed, 'satin-split', 2 * i + 1), 2 * i + 1)
-
-            # zigzag spacing is wider than stitch length, subdivide
-            if last_point is not None and max_stitch_length is not None and self.zigzag_spacing > max_stitch_length:
-                points, _ = self.get_split_points(last_point, left, last_point, left, max_stitch_length)
-                stitch_group.add_stitches(points)
-
-            stitch_group.add_stitch(a_short, ("edge", "left"))
-            stitch_group.add_stitches(split_points, ("split_stitch",))
-            stitch_group.add_stitch(b_short, ("edge",))
-            stitch_group.add_stitches(split_points[::-1], ("split_stitch",))
-            stitch_group.add_stitch(a_short, ("edge",))
-
-            last_point = a_short
-
-        if self._center_walk_is_odd():
-            stitch_group.stitches = list(reversed(stitch_group.stitches))
-
-        stitch_group.add_tags(("satin_column", "e_stitch"))
-        return stitch_group
-
-    def do_s_stitch(self):
-        # S stitch: do a pattern that looks like the letter "S".  It looks like
-        # this:
-        #   _   _   _   _   _   _
-        # _| |_| |_| |_| |_| |_| |
-
-        stitch_group = StitchGroup(color=self.color)
-
-        pairs = self.plot_points_on_rails(
-            self.zigzag_spacing,
-            self.pull_compensation_px,
-            self.pull_compensation_percent / 100,
-            True,
-        )
-
-        short_pairs = self.inset_short_stitches_sawtooth(pairs)
-        max_stitch_length = self.max_stitch_length_px
-        length_sigma = self.random_split_jitter
-        random_phase = self.random_split_phase
-        min_split_length = self.min_random_split_length_px
-        seed = self.random_seed
-        last_point = None
-        for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
-            check_stop_flag()
-            points = [a_short]
-            split_points, _ = self.get_split_points(
-                a, b, a_short, b_short, max_stitch_length,
-                None, length_sigma, random_phase, min_split_length,
-                prng.join_args(seed, 'satin-split', i), i)
-            points.extend(split_points)
-            points.append(b_short)
-
-            if i % 2 == 0:
-                points = list(reversed(points))
-
-            # zigzag spacing is wider than stitch length, subdivide
-            if last_point is not None and max_stitch_length is not None and self.zigzag_spacing > max_stitch_length:
-                initial_points, _ = self.get_split_points(last_point, points[0], last_point, points[0], max_stitch_length)
-
-            stitch_group.add_stitches(points)
-            last_point = points[-1]
-
-        if self._center_walk_is_odd():
-            stitch_group.stitches = list(reversed(stitch_group.stitches))
-
-        stitch_group.add_tags(("satin_column", "s_stitch"))
-        return stitch_group
-
-    def do_zigzag(self):
-        stitch_group = StitchGroup(color=self.color)
-
-        # calculate pairs at double the requested density
-        pairs = self.plot_points_on_rails(
-            self.zigzag_spacing / 2.0,
-            self.pull_compensation_px,
-            self.pull_compensation_percent / 100,
-            True,
-        )
-
-        # alternate picking one point from each pair, first on one rail then the other
-        points = [p[i % 2] for i, p in enumerate(pairs)]
-
-        # turn the list of points back into pairs
-        pairs = [points[i:i + 2] for i in range(0, len(points), 2)]
-
-        # remove last item if it isn't paired up
-        if len(pairs[-1]) == 1:
-            del pairs[-1]
-
-        short_pairs = self.inset_short_stitches_sawtooth(pairs)
-        max_stitch_length = self.max_stitch_length_px
-        length_sigma = self.random_split_jitter
-        random_phase = self.random_split_phase
-        min_split_length = self.min_random_split_length_px
-        seed = self.random_seed
-
-        last_point = None
-        last_point_short = None
-        for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
-            if last_point:
-                split_points, _ = self.get_split_points(
-                    last_point, a, last_point_short, a_short, max_stitch_length, None,
-                    length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
-                stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
-
-            stitch_group.add_stitch(a_short, ("satin_column", "peak_a", "peak_stitch"))
-
-            split_points, _ = self.get_split_points(
-                a, b, a_short, b_short, max_stitch_length, None,
-                length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
-            stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
-
-            stitch_group.add_stitch(b_short,  ("satin_column", "peak_b", "peak_stitch"))
-
-            last_point = b
-            last_point_short = b_short
-
-        if self._center_walk_is_odd():
-            stitch_group.stitches = list(reversed(stitch_group.stitches))
-
-        return stitch_group
 
     def get_split_points(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0,
                          random_phase=False, min_split_length=None, seed=None, row_num=0, from_end=False):
@@ -1943,7 +1560,7 @@ class SatinColumn(EmbroideryElement):
         stitch_groups: list[StitchGroup] = []
 
         # top layer
-        top_layer_group = self._do_top_layer_stitch_group()
+        top_layer_group = do_top_layer_stitch_group(self)
 
         # underlays
         stitch_groups.extend(self._do_underlay_stitch_groups(top_layer_group, end_point))
@@ -1979,36 +1596,3 @@ class SatinColumn(EmbroideryElement):
 
         return [stitch_group]
 
-
-class SatinProcessor:
-    def __init__(self, satin: 'SatinColumn', offset_px: tuple[float, float], offset_proportional: tuple[float, float], use_random: bool):
-        self.satin = satin
-        self.use_random = use_random
-        self.offset_px = offset_px
-        self.offset_proportional = offset_proportional
-        self.random_zigzag_spacing = satin.random_zigzag_spacing
-
-        if use_random:
-            self.seed = prng.join_args(satin.random_seed, "satin-points")
-            self.offset_proportional_min = np.array(offset_proportional) - satin.random_width_decrease
-            self.offset_range = (satin.random_width_increase + satin.random_width_decrease)
-            self.cycle = 0
-
-    def process_points(self, pos0: Point, pos1: Point) -> tuple[Point, Point]:
-        if self.use_random:
-            roll = prng.uniform_floats(self.seed, self.cycle)
-            self.cycle += 1
-            offset_prop = self.offset_proportional_min + roll[0:2] * self.offset_range
-        else:
-            offset_prop = self.offset_proportional
-
-        a, b = offset_points(pos0, pos1, self.offset_px, offset_prop)
-        return a, b
-
-    def get_stitch_spacing_multiple(self):
-        if self.use_random:
-            roll = prng.uniform_floats(self.seed, self.cycle)
-            self.cycle += 1
-            return max(1.0 + ((roll[0] - 0.5) * 2) * self.random_zigzag_spacing, 0.01)
-        else:
-            return 1.0

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -27,7 +27,7 @@ from ..utils.stroke_to_satin import convert_path_to_satin, set_first_node
 from .validation_models import (NotStitchableError, ClosedPathWarning, DanglingRungWarning, NoRungWarning,
                                 TooManyIntersectionsWarning, StrokeSatinWarning, NarrowSatinWarning,
                                 TwoRungsWarning, UnequalPointsWarning)
-from .rails import get_rails_to_reverse, plot_points_on_rails, cut_rails
+from .rails import cut_rails, get_rails_to_reverse, plot_points_on_rails as _plot_points_on_rails
 from .stitches import do_top_layer_stitch_group
 
 ListOfPairs = list[tuple[Point, Point]]
@@ -516,8 +516,7 @@ class SatinColumn(EmbroideryElement):
     @property
     @cache
     def compensated_shape(self):
-        pairs = plot_points_on_rails(
-            self,
+        pairs = self.plot_points_on_rails(
             self.zigzag_spacing,
             self.pull_compensation_px,
             self.pull_compensation_percent/100,
@@ -601,7 +600,7 @@ class SatinColumn(EmbroideryElement):
         """The rails, as LineStrings."""
         paths = [set_precision(shgeo.LineString(rail), 0.00001) for rail in self.rails]
 
-        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
+        rails_to_reverse = self._get_rails_to_reverse()
         if paths and rails_to_reverse is not None:
             for i, reverse in enumerate(rails_to_reverse):
                 if reverse:
@@ -649,7 +648,7 @@ class SatinColumn(EmbroideryElement):
         # check for unequal length of rails
         equal_length = len(rails[0]) == len(rails[1])
 
-        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
+        rails_to_reverse = self._get_rails_to_reverse()
         for i, points in enumerate(rails):
 
             if rails_to_reverse[i]:
@@ -934,7 +933,7 @@ class SatinColumn(EmbroideryElement):
         """
 
         # like in do_satin()
-        points: list[Point] = list(chain.from_iterable(plot_points_on_rails(self, self.zigzag_spacing)))
+        points: list[Point] = list(chain.from_iterable(self.plot_points_on_rails(self.zigzag_spacing)))
 
         if isinstance(split_point, float):
             index_of_closest_stitch = int(round(len(points) * split_point))
@@ -991,7 +990,7 @@ class SatinColumn(EmbroideryElement):
 
     def _add_rung(self, path_list, position, normalized=False):
         rung_start = path_list[0].interpolate(position, normalized=normalized)
-        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
+        rails_to_reverse = self._get_rails_to_reverse()
         if rails_to_reverse[0] == rails_to_reverse[1]:
             rung_end = path_list[1].interpolate(position, normalized=normalized)
         else:
@@ -1035,11 +1034,19 @@ class SatinColumn(EmbroideryElement):
                 filtered_rungs.append(list(rung.coords))
         return filtered_rungs
 
+    def _get_rails_to_reverse(self) -> tuple[bool, bool]:
+        return get_rails_to_reverse(self.reverse_rails, self.rails)
+
+    def plot_points_on_rails(self, spacing: float | int, offset_px: tuple[float, float] = (0, 0),
+                             offset_proportional: tuple[float, float] = (0, 0), use_random: bool = False,
+                             ) -> list[tuple[Point, Point]]:
+        return _plot_points_on_rails(self, spacing, offset_px, offset_proportional, use_random)
+
     @property
     @cache
     def center_line(self):
         # similar technique to do_center_walk()
-        center_walk = [p[0] for p in plot_points_on_rails(self, self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
+        center_walk = [p[0] for p in self.plot_points_on_rails(self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
         if len(center_walk) < 2:
             center_walk = [center_walk[0], center_walk[0]]
         return shgeo.LineString(center_walk)
@@ -1057,7 +1064,7 @@ class SatinColumn(EmbroideryElement):
             stitch_length = self.running_stitch_length
 
         # Do it like contour underlay, but inset all the way to the center.
-        pairs = plot_points_on_rails(self, self.running_stitch_tolerance, (0, 0), inset_prop)
+        pairs = self.plot_points_on_rails(self.running_stitch_tolerance, (0, 0), inset_prop)
 
         points = [points[0] for points in pairs]
         stitches = running_stitch.even_running_stitch(points, [stitch_length], self.running_stitch_tolerance)
@@ -1132,8 +1139,7 @@ class SatinColumn(EmbroideryElement):
         # other. if the two sides are far away, adding a running stitch to travel
         # in between avoids a long jump or a trim.
 
-        pairs = plot_points_on_rails(
-            self,
+        pairs = self.plot_points_on_rails(
             self.contour_underlay_stitch_tolerance,
             -self.contour_underlay_inset_px, -self.contour_underlay_inset_percent/100)
 
@@ -1256,10 +1262,10 @@ class SatinColumn(EmbroideryElement):
 
         stitch_groups = []
 
-        pairs = plot_points_on_rails(self,
-                                     self.zigzag_underlay_spacing / 2.0,
-                                     -self.zigzag_underlay_inset_px,
-                                     -self.zigzag_underlay_inset_percent/100)
+        pairs = self.plot_points_on_rails(
+            self.zigzag_underlay_spacing / 2.0,
+            -self.zigzag_underlay_inset_px,
+            -self.zigzag_underlay_inset_percent/100)
 
         if self.center_walk_is_odd():
             pairs = list(reversed(pairs))

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -15,102 +15,23 @@ from shapely import geometry as shgeo
 from shapely import set_precision
 from shapely.ops import nearest_points, substring
 
-from lib.utils import AnyPointType
-from ..debug.debug import debug
-from ..i18n import _
-from ..metadata import InkStitchMetadata
-from ..stitch_plan import Stitch, StitchGroup
-from ..stitches import running_stitch
-from ..svg import line_strings_to_coordinate_lists
-from ..svg.styles import get_join_style_args
-from ..utils import Point, cache, cut, cut_multiple, offset_points, prng
-from ..utils.param import ParamOption
-from ..utils.threading import check_stop_flag
-from .element import PIXELS_PER_MM, EmbroideryElement, param
-from .utils.stroke_to_satin import convert_path_to_satin, set_first_node
-from .validation import ValidationError, ValidationWarning
-
+from ...debug.debug import debug
+from ...i18n import _
+from ...metadata import InkStitchMetadata
+from ...stitch_plan import Stitch, StitchGroup
+from ...stitches import running_stitch
+from ...svg import line_strings_to_coordinate_lists
+from ...svg.styles import get_join_style_args
+from ...utils import AnyPointType, Point, cache, cut, cut_multiple, offset_points, prng
+from ...utils.param import ParamOption
+from ...utils.threading import check_stop_flag
+from ..element import PIXELS_PER_MM, EmbroideryElement, param
+from ..utils.stroke_to_satin import convert_path_to_satin, set_first_node
+from .validation_models import (NotStitchableError, ClosedPathWarning, DanglingRungWarning, NoRungWarning,
+                                TooManyIntersectionsWarning, StrokeSatinWarning, NarrowSatinWarning,
+                                TwoRungsWarning, UnequalPointsWarning)
 
 ListOfPairs = list[tuple[Point, Point]]
-
-
-class NotStitchableError(ValidationError):
-    name = _("Not stitchable satin column")
-    description = _("A satin column can be build from a single stroke or consists of two rails and optional rungs. "
-                    "This satin column has a different setup.")
-    steps_to_solve = [
-        _('Make sure your satin column is not a combination of multiple satin columns.'),
-        _('Go to our website and read how a satin column should look like https://inkstitch.org/docs/stitches/satin-column/'),
-    ]
-
-
-rung_message = _("Each rung should intersect both rails once.")
-
-
-class ClosedPathWarning(ValidationWarning):
-    name = _("Rail is a closed path")
-    description = _("Rail is a closed path without a definite starting and ending point.")
-    steps_to_solve = [
-        _('* Select the node where you want the satin to start.'),
-        _('* Click on: Break path at selected nodes.')
-    ]
-
-
-class DanglingRungWarning(ValidationWarning):
-    name = _("Rung doesn't intersect rails")
-    description = _("Satin column: A rung doesn't intersect both rails.") + " " + rung_message
-
-
-class NoRungWarning(ValidationWarning):
-    name = _("Satin has no rungs")
-    description = _("Rungs control the stitch direction in satin columns. It is best pratice to use them.")
-    steps_to_solve = [
-        _('* With the selected object press "P" to activate the pencil tool.'),
-        _('* Hold "Shift" while drawing a rung.')
-    ]
-
-
-class TooManyIntersectionsWarning(ValidationWarning):
-    name = _("Rung intersects too many times")
-    description = _("Satin column: A rung intersects a rail more than once.") + " " + rung_message
-
-
-class StrokeSatinWarning(ValidationWarning):
-    name = _("Simple Satin")
-    description = ("If you need more control over the stitch directions within this satin column, convert it to a real satin path")
-    steps_to_solve = [
-        _('* Select the satin path'),
-        _('* Run Extensions > Ink/Stitch > Tools: Satin > Stroke to Satin')
-    ]
-
-
-class NarrowSatinWarning(ValidationWarning):
-    name = _("Narrow Satin")
-    description = _("This element renders as a satin, but it is too narrow.")
-    steps_to_solve = [
-        _("* Increase stroke width."),
-        _("Ink/Stitch will not register elements with a stroke width underneath 0.3 mm as satin, but it is recommended to stay above 1mm."),
-    ]
-
-
-class TwoRungsWarning(ValidationWarning):
-    name = _("Satin has exactly two rungs")
-    description = _("There are exactly two rungs. This may lead to false rail/rung detection.")
-    steps_to_solve = [
-        _('* With the selected object press "P" to activate the pencil tool.'),
-        _('* Hold "Shift" while drawing a rung.')
-    ]
-
-
-class UnequalPointsWarning(ValidationWarning):
-    name = _("Unequal number of points")
-    description = _("Satin column: There are no rungs and rails have an unequal number of points.")
-    steps_to_solve = [
-        _('The easiest way to solve this issue is to add one or more rungs. '),
-        _('Rungs control the stitch direction in satin columns.'),
-        _('* With the selected object press "P" to activate the pencil tool.'),
-        _('* Hold "Shift" while drawing the rung.')
-    ]
 
 
 class SatinColumn(EmbroideryElement):
@@ -138,7 +59,7 @@ class SatinColumn(EmbroideryElement):
            options=_satin_methods,
            sort_index=0)
     def satin_method(self):
-        return self.get_param('satin_method', 'satin_column')
+        return self.get_param('satin_method', '')
 
     @property
     @param('random_width_decrease_percent',

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -3,7 +3,6 @@
 # Copyright (c) 2010 Authors
 # Licensed under the GNU GPL version 3.0 or later.  See the file LICENSE for details.
 
-import itertools
 from copy import deepcopy
 from itertools import chain
 from typing import List, Optional, Sequence, overload
@@ -21,14 +20,14 @@ from ...stitch_plan import Stitch, StitchGroup
 from ...stitches import running_stitch
 from ...svg import line_strings_to_coordinate_lists
 from ...svg.styles import get_join_style_args
-from ...utils import AnyPointType, Point, cache, cut, cut_multiple, offset_points, prng
+from ...utils import AnyPointType, Point, cache, cut_multiple, offset_points
 from ...utils.param import ParamOption
 from ..element import PIXELS_PER_MM, EmbroideryElement, param
 from ..utils.stroke_to_satin import convert_path_to_satin, set_first_node
 from .validation_models import (NotStitchableError, ClosedPathWarning, DanglingRungWarning, NoRungWarning,
                                 TooManyIntersectionsWarning, StrokeSatinWarning, NarrowSatinWarning,
                                 TwoRungsWarning, UnequalPointsWarning)
-from .rails import get_rails_to_reverse, plot_points_on_rails
+from .rails import get_rails_to_reverse, plot_points_on_rails, cut_rails
 from .stitches import do_top_layer_stitch_group
 
 ListOfPairs = list[tuple[Point, Point]]
@@ -260,9 +259,6 @@ class SatinColumn(EmbroideryElement):
         sort_index=10)
     def reverse_rails(self):
         return self.get_param('reverse_rails', 'automatic')
-
-    def _get_rails_to_reverse(self) -> tuple[bool, bool]:
-        return get_rails_to_reverse(self.reverse_rails, self.rails)
 
     @property
     @param(
@@ -605,7 +601,7 @@ class SatinColumn(EmbroideryElement):
         """The rails, as LineStrings."""
         paths = [set_precision(shgeo.LineString(rail), 0.00001) for rail in self.rails]
 
-        rails_to_reverse = self._get_rails_to_reverse()
+        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
         if paths and rails_to_reverse is not None:
             for i, reverse in enumerate(rails_to_reverse):
                 if reverse:
@@ -653,7 +649,7 @@ class SatinColumn(EmbroideryElement):
         # check for unequal length of rails
         equal_length = len(rails[0]) == len(rails[1])
 
-        rails_to_reverse = self._get_rails_to_reverse()
+        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
         for i, points in enumerate(rails):
 
             if rails_to_reverse[i]:
@@ -912,7 +908,7 @@ class SatinColumn(EmbroideryElement):
 
         # prevent error when split points lies at the start or end of the satin column
         path_lists: list[Optional[list[shgeo.LineString]]] = []
-        for path_list in self._cut_rails(cut_points):
+        for path_list in cut_rails(self, cut_points):
             if any(path is None or shgeo.LineString(path).length < self.zigzag_spacing for path in path_list):
                 path_lists.append(None)
             else:
@@ -955,43 +951,6 @@ class SatinColumn(EmbroideryElement):
             return (points[index_of_closest_stitch - 1],
                     points[index_of_closest_stitch])
 
-    def _cut_rails(self, cut_points) -> tuple[list[shgeo.LineString], list[shgeo.LineString]]:
-        """Cut the rails of this satin at the specified points.
-
-        cut_points is a list of two elements, corresponding to the cut points
-        for each rail in order.
-
-        Returns: A list of two elements, corresponding to the two new sets of
-          rails.  Each element is a list of two rails of type LineString.
-        """
-
-        rails = [shgeo.LineString(rail) for rail in self.rails]
-
-        path_lists: tuple[list[shgeo.LineString], list[shgeo.LineString]] = ([], [])
-
-        rails_to_reverse = self._get_rails_to_reverse()
-
-        if rails_to_reverse[0] == rails_to_reverse[1]:
-            for i, rail in enumerate(rails):
-                before, after = cut(rail, rail.project(shgeo.Point(cut_points[i])))
-                path_lists[0].append(before)
-                path_lists[1].append(after)
-        else:
-            # rails have opposite direction
-            rail = rails[0]
-            before, after = cut(rail, rail.project(shgeo.Point(cut_points[0])))
-            path_lists[0].append(before)
-            path_lists[1].append(after)
-            rail = rails[1]
-            before, after = cut(rail, rail.project(shgeo.Point(cut_points[1])))
-            path_lists[1].append(before)
-            path_lists[0].append(after)
-
-        if rails_to_reverse[0]:
-            path_lists = (path_lists[1], path_lists[0])
-
-        return path_lists
-
     def _assign_rungs_to_split_rails(self, split_rails):
         """Add this satin's rungs to the new satins.
 
@@ -1032,7 +991,7 @@ class SatinColumn(EmbroideryElement):
 
     def _add_rung(self, path_list, position, normalized=False):
         rung_start = path_list[0].interpolate(position, normalized=normalized)
-        rails_to_reverse = self._get_rails_to_reverse()
+        rails_to_reverse = get_rails_to_reverse(self.reverse_rails, self.rails)
         if rails_to_reverse[0] == rails_to_reverse[1]:
             rung_end = path_list[1].interpolate(position, normalized=normalized)
         else:
@@ -1080,7 +1039,7 @@ class SatinColumn(EmbroideryElement):
     @cache
     def center_line(self):
         # similar technique to do_center_walk()
-        center_walk = [p[0] for p in self.plot_points_on_rails(self, self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
+        center_walk = [p[0] for p in plot_points_on_rails(self, self.zigzag_spacing, (0, 0), (-0.5, -0.5))]
         if len(center_walk) < 2:
             center_walk = [center_walk[0], center_walk[0]]
         return shgeo.LineString(center_walk)
@@ -1098,7 +1057,7 @@ class SatinColumn(EmbroideryElement):
             stitch_length = self.running_stitch_length
 
         # Do it like contour underlay, but inset all the way to the center.
-        pairs = self.plot_points_on_rails(self, self.running_stitch_tolerance, (0, 0), inset_prop)
+        pairs = plot_points_on_rails(self, self.running_stitch_tolerance, (0, 0), inset_prop)
 
         points = [points[0] for points in pairs]
         stitches = running_stitch.even_running_stitch(points, [stitch_length], self.running_stitch_tolerance)
@@ -1299,8 +1258,8 @@ class SatinColumn(EmbroideryElement):
 
         pairs = plot_points_on_rails(self,
                                      self.zigzag_underlay_spacing / 2.0,
-                                      -self.zigzag_underlay_inset_px,
-                                      -self.zigzag_underlay_inset_percent/100)
+                                     -self.zigzag_underlay_inset_px,
+                                     -self.zigzag_underlay_inset_percent/100)
 
         if self.center_walk_is_odd():
             pairs = list(reversed(pairs))
@@ -1595,4 +1554,3 @@ class SatinColumn(EmbroideryElement):
             return []
 
         return [stitch_group]
-

--- a/lib/elements/satin_column/satin_processor.py
+++ b/lib/elements/satin_column/satin_processor.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from .satin_column import SatinColumn
+from ...utils import prng, Point, offset_points
+
+
+class SatinProcessor:
+    def __init__(self, satin: 'SatinColumn', offset_px: tuple[float, float], offset_proportional: tuple[float, float], use_random: bool):
+        self.satin = satin
+        self.use_random = use_random
+        self.offset_px = offset_px
+        self.offset_proportional = offset_proportional
+        self.random_zigzag_spacing = satin.random_zigzag_spacing
+
+        if use_random:
+            self.seed = prng.join_args(satin.random_seed, "satin-points")
+            self.offset_proportional_min = np.array(offset_proportional) - satin.random_width_decrease
+            self.offset_range = (satin.random_width_increase + satin.random_width_decrease)
+            self.cycle = 0
+
+    def process_points(self, pos0: Point, pos1: Point) -> tuple[Point, Point]:
+        if self.use_random:
+            roll = prng.uniform_floats(self.seed, self.cycle)
+            self.cycle += 1
+            offset_prop = self.offset_proportional_min + roll[0:2] * self.offset_range
+        else:
+            offset_prop = self.offset_proportional
+
+        a, b = offset_points(pos0, pos1, self.offset_px, offset_prop)
+        return a, b
+
+    def get_stitch_spacing_multiple(self):
+        if self.use_random:
+            roll = prng.uniform_floats(self.seed, self.cycle)
+            self.cycle += 1
+            return max(1.0 + ((roll[0] - 0.5) * 2) * self.random_zigzag_spacing, 0.01)
+        else:
+            return 1.0

--- a/lib/elements/satin_column/satin_processor.py
+++ b/lib/elements/satin_column/satin_processor.py
@@ -1,7 +1,11 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from .satin_column import SatinColumn
 from ...utils import prng, Point, offset_points
+
+if TYPE_CHECKING:
+    from .satin_column import SatinColumn
 
 
 class SatinProcessor:

--- a/lib/elements/satin_column/stitches.py
+++ b/lib/elements/satin_column/stitches.py
@@ -1,10 +1,13 @@
 import itertools
+from typing import TYPE_CHECKING
 
-from elements import SatinColumn
-from elements.satin_column.rails import plot_points_on_rails
-from stitch_plan import StitchGroup
-from utils import prng
-from utils.threading import check_stop_flag
+from .rails import plot_points_on_rails
+from ...stitch_plan import StitchGroup
+from ...utils import prng
+from ...utils.threading import check_stop_flag
+
+if TYPE_CHECKING:
+    from .satin_column import SatinColumn
 
 
 def _do_e_stitch(satin: 'SatinColumn'):
@@ -166,6 +169,7 @@ def _do_zigzag(satin: 'SatinColumn'):
 
     return stitch_group
 
+
 def _do_satin(satin: 'SatinColumn'):
     # satin: do a zigzag pattern, alternating between the paths.  The
     # zigzag looks like this to make the satin stitches look perpendicular
@@ -221,6 +225,7 @@ def _do_satin(satin: 'SatinColumn'):
         stitch_group.stitches = list(reversed(stitch_group.stitches))
 
     return stitch_group
+
 
 def do_top_layer_stitch_group(satin: 'SatinColumn'):
     if satin.satin_method == 'e_stitch':

--- a/lib/elements/satin_column/stitches.py
+++ b/lib/elements/satin_column/stitches.py
@@ -1,0 +1,233 @@
+import itertools
+
+from elements import SatinColumn
+from elements.satin_column.rails import plot_points_on_rails
+from stitch_plan import StitchGroup
+from utils import prng
+from utils.threading import check_stop_flag
+
+
+def _do_e_stitch(satin: 'SatinColumn'):
+    # e stitch: do a pattern that looks like the letter "E".  It looks like
+    # this:
+    #
+    # _|_|_|_|_|_|_|_|_|_|_|_|
+
+    stitch_group = StitchGroup(color=satin.color)
+
+    pairs = plot_points_on_rails(
+        satin,
+        satin.zigzag_spacing,
+        satin.pull_compensation_px,
+        satin.pull_compensation_percent / 100,
+        True,
+    )
+
+    short_pairs = satin.inset_short_stitches_sawtooth(pairs)
+    max_stitch_length = satin.max_stitch_length_px
+    length_sigma = satin.random_split_jitter
+    random_phase = satin.random_split_phase
+    min_split_length = satin.min_random_split_length_px
+    seed = satin.random_seed
+    last_point = None
+    # "left" and "right" here are kind of arbitrary designations meaning
+    # a point from the first and second rail respectively
+    for i, (left, right), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
+        check_stop_flag()
+        split_points, _ = satin.get_split_points(
+            left, right, a_short, b_short, max_stitch_length,
+            None, length_sigma, random_phase, min_split_length,
+            prng.join_args(seed, 'satin-split', 2 * i + 1), 2 * i + 1)
+
+        # zigzag spacing is wider than stitch length, subdivide
+        if last_point is not None and max_stitch_length is not None and satin.zigzag_spacing > max_stitch_length:
+            points, _ = satin.get_split_points(last_point, left, last_point, left, max_stitch_length)
+            stitch_group.add_stitches(points)
+
+        stitch_group.add_stitch(a_short, ("edge", "left"))
+        stitch_group.add_stitches(split_points, ("split_stitch",))
+        stitch_group.add_stitch(b_short, ("edge",))
+        stitch_group.add_stitches(split_points[::-1], ("split_stitch",))
+        stitch_group.add_stitch(a_short, ("edge",))
+
+        last_point = a_short
+
+    if satin.center_walk_is_odd():
+        stitch_group.stitches = list(reversed(stitch_group.stitches))
+
+    stitch_group.add_tags(("satin_column", "e_stitch"))
+    return stitch_group
+
+
+def _do_s_stitch(satin: 'SatinColumn'):
+    # S stitch: do a pattern that looks like the letter "S".  It looks like
+    # this:
+    #   _   _   _   _   _   _
+    # _| |_| |_| |_| |_| |_| |
+
+    stitch_group = StitchGroup(color=satin.color)
+
+    pairs = plot_points_on_rails(
+        satin,
+        satin.zigzag_spacing,
+        satin.pull_compensation_px,
+        satin.pull_compensation_percent / 100,
+        True,
+    )
+
+    short_pairs = satin.inset_short_stitches_sawtooth(pairs)
+    max_stitch_length = satin.max_stitch_length_px
+    length_sigma = satin.random_split_jitter
+    random_phase = satin.random_split_phase
+    min_split_length = satin.min_random_split_length_px
+    seed = satin.random_seed
+    last_point = None
+    for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
+        check_stop_flag()
+        points = [a_short]
+        split_points, _ = satin.get_split_points(
+            a, b, a_short, b_short, max_stitch_length,
+            None, length_sigma, random_phase, min_split_length,
+            prng.join_args(seed, 'satin-split', i), i)
+        points.extend(split_points)
+        points.append(b_short)
+
+        if i % 2 == 0:
+            points = list(reversed(points))
+
+        # zigzag spacing is wider than stitch length, subdivide
+        if last_point is not None and max_stitch_length is not None and satin.zigzag_spacing > max_stitch_length:
+            initial_points, _ = satin.get_split_points(last_point, points[0], last_point, points[0], max_stitch_length)
+
+        stitch_group.add_stitches(points)
+        last_point = points[-1]
+
+    if satin.center_walk_is_odd():
+        stitch_group.stitches = list(reversed(stitch_group.stitches))
+
+    stitch_group.add_tags(("satin_column", "s_stitch"))
+    return stitch_group
+
+
+def _do_zigzag(satin: 'SatinColumn'):
+    stitch_group = StitchGroup(color=satin.color)
+
+    # calculate pairs at double the requested density
+    pairs = plot_points_on_rails(
+        satin,
+        satin.zigzag_spacing / 2.0,
+        satin.pull_compensation_px,
+        satin.pull_compensation_percent / 100,
+        True,
+    )
+
+    # alternate picking one point from each pair, first on one rail then the other
+    points = [p[i % 2] for i, p in enumerate(pairs)]
+
+    # turn the list of points back into pairs
+    pairs = [points[i:i + 2] for i in range(0, len(points), 2)]
+
+    # remove last item if it isn't paired up
+    if len(pairs[-1]) == 1:
+        del pairs[-1]
+
+    short_pairs = satin.inset_short_stitches_sawtooth(pairs)
+    max_stitch_length = satin.max_stitch_length_px
+    length_sigma = satin.random_split_jitter
+    random_phase = satin.random_split_phase
+    min_split_length = satin.min_random_split_length_px
+    seed = satin.random_seed
+
+    last_point = None
+    last_point_short = None
+    for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
+        if last_point:
+            split_points, _ = satin.get_split_points(
+                last_point, a, last_point_short, a_short, max_stitch_length, None,
+                length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i,
+                from_end=True)
+            stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
+
+        stitch_group.add_stitch(a_short, ("satin_column", "peak_a", "peak_stitch"))
+
+        split_points, _ = satin.get_split_points(
+            a, b, a_short, b_short, max_stitch_length, None,
+            length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1),
+            row_num=2 * i + 1)
+        stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
+
+        stitch_group.add_stitch(b_short, ("satin_column", "peak_b", "peak_stitch"))
+
+        last_point = b
+        last_point_short = b_short
+
+    if satin.center_walk_is_odd():
+        stitch_group.stitches = list(reversed(stitch_group.stitches))
+
+    return stitch_group
+
+def _do_satin(satin: 'SatinColumn'):
+    # satin: do a zigzag pattern, alternating between the paths.  The
+    # zigzag looks like this to make the satin stitches look perpendicular
+    # to the column:
+    #
+    # |/|/|/|/|/|/|/|/|
+
+    # print >> dbg, "satin", self.zigzag_spacing, self.pull_compensation
+
+    stitch_group = StitchGroup(color=satin.color)
+
+    # pull compensation is automatically converted from mm to pixels by get_float_param
+    pairs = plot_points_on_rails(
+        satin,
+        satin.zigzag_spacing,
+        satin.pull_compensation_px,
+        satin.pull_compensation_percent / 100,
+        True,
+        )
+
+    max_stitch_length = satin.max_stitch_length_px
+    length_sigma = satin.random_split_jitter
+    random_phase = satin.random_split_phase
+    min_split_length = satin.min_random_split_length_px
+    seed = satin.random_seed
+
+    short_pairs = satin.inset_short_stitches_sawtooth(pairs)
+
+    last_point = None
+    last_short_point = None
+    last_count = None
+    for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
+        if last_point is not None:
+            split_points, _ = satin.get_split_points(
+                last_point, a, last_short_point, a_short, max_stitch_length, last_count,
+                length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
+            stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
+
+        stitch_group.add_stitch(a_short)
+        stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
+
+        split_points, last_count = satin.get_split_points(
+            a, b, a_short, b_short, max_stitch_length, None,
+            length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
+        stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
+
+        stitch_group.add_stitch(b_short)
+        stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
+        last_point = b
+        last_short_point = b_short
+
+    if satin.center_walk_is_odd():
+        stitch_group.stitches = list(reversed(stitch_group.stitches))
+
+    return stitch_group
+
+def do_top_layer_stitch_group(satin: 'SatinColumn'):
+    if satin.satin_method == 'e_stitch':
+        return _do_e_stitch(satin)
+    elif satin.satin_method == 's_stitch':
+        return _do_s_stitch(satin)
+    elif satin.satin_method == 'zigzag':
+        return _do_zigzag(satin)
+    else:
+        return _do_satin(satin)

--- a/lib/elements/satin_column/validation_models.py
+++ b/lib/elements/satin_column/validation_models.py
@@ -1,0 +1,80 @@
+from ...i18n import _
+from ..validation import ValidationError, ValidationWarning
+
+rung_message = _("Each rung should intersect both rails once.")
+
+
+class NotStitchableError(ValidationError):
+    name = _("Not stitchable satin column")
+    description = _("A satin column can be build from a single stroke or consists of two rails and optional rungs. "
+                    "This satin column has a different setup.")
+    steps_to_solve = [
+        _('Make sure your satin column is not a combination of multiple satin columns.'),
+        _('Go to our website and read how a satin column should look like https://inkstitch.org/docs/stitches/satin-column/'),
+    ]
+
+
+class ClosedPathWarning(ValidationWarning):
+    name = _("Rail is a closed path")
+    description = _("Rail is a closed path without a definite starting and ending point.")
+    steps_to_solve = [
+        _('* Select the node where you want the satin to start.'),
+        _('* Click on: Break path at selected nodes.')
+    ]
+
+
+class DanglingRungWarning(ValidationWarning):
+    name = _("Rung doesn't intersect rails")
+    description = _("Satin column: A rung doesn't intersect both rails.") + " " + rung_message
+
+
+class NoRungWarning(ValidationWarning):
+    name = _("Satin has no rungs")
+    description = _("Rungs control the stitch direction in satin columns. It is best practice to use them.")
+    steps_to_solve = [
+        _('* With the selected object press "P" to activate the pencil tool.'),
+        _('* Hold "Shift" while drawing a rung.')
+    ]
+
+
+class TooManyIntersectionsWarning(ValidationWarning):
+    name = _("Rung intersects too many times")
+    description = _("Satin column: A rung intersects a rail more than once.") + " " + rung_message
+
+
+class StrokeSatinWarning(ValidationWarning):
+    name = _("Simple Satin")
+    description = _("If you need more control over the stitch directions within this satin column, convert it to a real satin path")
+    steps_to_solve = [
+        _('* Select the satin path'),
+        _('* Run Extensions > Ink/Stitch > Tools: Satin > Stroke to Satin')
+    ]
+
+
+class NarrowSatinWarning(ValidationWarning):
+    name = _("Narrow Satin")
+    description = _("This element renders as a satin, but it is too narrow.")
+    steps_to_solve = [
+        _("* Increase stroke width."),
+        _("Ink/Stitch will not register elements with a stroke width underneath 0.3 mm as satin, but it is recommended to stay above 1mm."),
+    ]
+
+
+class TwoRungsWarning(ValidationWarning):
+    name = _("Satin has exactly two rungs")
+    description = _("There are exactly two rungs. This may lead to false rail/rung detection.")
+    steps_to_solve = [
+        _('* With the selected object press "P" to activate the pencil tool.'),
+        _('* Hold "Shift" while drawing a rung.')
+    ]
+
+
+class UnequalPointsWarning(ValidationWarning):
+    name = _("Unequal number of points")
+    description = _("Satin column: There are no rungs and rails have an unequal number of points.")
+    steps_to_solve = [
+        _('The easiest way to solve this issue is to add one or more rungs. '),
+        _('Rungs control the stitch direction in satin columns.'),
+        _('* With the selected object press "P" to activate the pencil tool.'),
+        _('* Hold "Shift" while drawing the rung.')
+    ]


### PR DESCRIPTION
This PR moves some functionality from satin_column.py into separate 'free functions' in a new satin_column package. 

The motivation here is that SatinColumn is large (2k+ lines) and has a ton of responsibilities . The class itself knows how to do different types of satin stitches + rail operations + etc, but those logic bits are independent from each other (cutting rails vs zigzag stitch for example), and yet they live in the same class next to each other. This has made it really hard for me to understand dependencies in the class and add new functionality.

Anyway, the things that were moved
- All validation error definitions (basically free). Also fixed a typo and what appears to be a mistakenly-missing i18n call
- SatinProcessor, which was already independent
- Some rails operations: cut_rails, get_rails_to_reverse, plot_points_on_rails
- Some stitch planning functionality: E/S/ZigZag/Satin stitches and the calling top layer function. 

satin_column.py gets like 25% smaller with this change, and IMO it is already a decent improvement in readability here. The two public-facing operations that were moved (plot_points_on_rails and get_rails_to_reverse) are still on SatinColumn and just point to the new free functions to avoid churn on those callers outside SatinColumn.

There are more things I want to pull out but I didn't want this PR to be too large. I did zero changes to the actual functions beyond making them work outside of the SatinColumn class itself, so hopefully the review isn't terribly hard. I can also scope down the PR if needed and do in even smaller chunks than this.

I think this is probably a good idea to do across the board (not just for satin), but satin is my current target because I am trying to implement a feature on SatinColumn & these refactors would make it much easier to implement and understand the code dependencies overall.