### PR TITLE
Satin column responsibility split #2

### DIFF
--- a/lib/elements/satin_column/compensation.py
+++ b/lib/elements/satin_column/compensation.py
@@ -25,7 +25,12 @@ def _extend_line(linestring: shgeo.LineString, value: float, at_end: bool = Fals
         extended_line = extended_line.reverse()
     return extended_line
 
-def get_compensated_line_string_rails(line_string_rails: Sequence[shgeo.LineString], start: float, end: float) -> list[shgeo.Point | shgeo.LineString]:
+
+def get_compensated_line_string_rails(
+    line_string_rails: Sequence[shgeo.LineString],
+    start: float,
+    end: float,
+) -> list[shgeo.Point | shgeo.LineString]:
     """Apply push compensation on rails"""
     return [apply_push_comp(rail, start, end) for rail in line_string_rails]
 

--- a/lib/elements/satin_column/compensation.py
+++ b/lib/elements/satin_column/compensation.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from shapely import affinity as shaffinity
+from shapely import geometry as shgeo
+from shapely.ops import substring
+
+from ...utils import Point
+
+
+def _extend_line(linestring: shgeo.LineString, value: float, at_end: bool = False) -> shgeo.LineString:
+    """Extends either the first or the last segment of the given line by given value.
+    """
+    if at_end:
+        linestring = linestring.reverse()
+    coords = list(linestring.coords)
+    start_segment = shgeo.LineString([coords[0], coords[1]])
+    line_length = start_segment.length
+    target_length = line_length - value
+    scale_factor = target_length / line_length
+    extended_segment = shaffinity.scale(start_segment, xfact=scale_factor, yfact=scale_factor,
+                                        origin=shgeo.Point(coords[1]))
+    first = list(extended_segment.coords)[0]
+    extended_line = shgeo.LineString([first] + coords)
+    if at_end:
+        extended_line = extended_line.reverse()
+    return extended_line
+
+def get_compensated_line_string_rails(line_string_rails: Sequence[shgeo.LineString], start: float, end: float) -> list[shgeo.Point | shgeo.LineString]:
+    """Apply push compensation on rails"""
+    return [apply_push_comp(rail, start, end) for rail in line_string_rails]
+
+
+def apply_push_comp_on_point_list(rail: list[Point], start: float, end: float):
+    line = shgeo.LineString(rail)
+    return [Point(*point) for point in apply_push_comp(line, start, end).coords]
+
+
+def apply_push_comp(linestring: shgeo.LineString, start: float, end: float) -> shgeo.Point | shgeo.LineString:
+    if start < 0:
+        linestring = _extend_line(linestring, start)
+        start = 0
+    if end < 0:
+        linestring = _extend_line(linestring, end, True)
+        end = 0
+    if not start and not end:
+        return linestring
+    if end == 0:
+        end = 0.00000001
+    if start + end >= linestring.length - 0.5:
+        return linestring
+    return substring(linestring, start, -end)

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -5,7 +5,7 @@
 
 from copy import deepcopy
 from itertools import chain
-from typing import List, Optional, Sequence, overload
+from typing import Optional, Sequence, overload
 
 import numpy as np
 from inkex import Path, Vector2d
@@ -1063,7 +1063,6 @@ class SatinColumn(EmbroideryElement):
             tags=("satin_column",),
             stitches=[Point(*end_point)]
         )
-
 
     def split_linestring_at_end_point(self, linestring: LineString, end_point: Point):
         split_line = set_precision(shgeo.LineString(self.find_cut_points(end_point)), 0.00001)

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -1024,16 +1024,6 @@ class SatinColumn(EmbroideryElement):
 
         return SatinColumn(node)
 
-    def _get_filtered_rungs(self, rails, rungs):
-        # returns a filtered list of rungs which do intersect the rails exactly twice
-        rails = shgeo.MultiLineString(rails)
-        filtered_rungs = []
-        for rung in shgeo.MultiLineString(rungs).geoms:
-            intersection = rung.intersection(rails)
-            if intersection.geom_type == "MultiPoint" and len(intersection.geoms) == 2:
-                filtered_rungs.append(list(rung.coords))
-        return filtered_rungs
-
     def _get_rails_to_reverse(self) -> tuple[bool, bool]:
         return get_rails_to_reverse(self.reverse_rails, self.rails)
 
@@ -1330,70 +1320,6 @@ class SatinColumn(EmbroideryElement):
         stitch_group1.stitches = [Stitch(*point) for point in start.coords]
         top_layer_stitch_groups = [stitch_group1, stitch_group2]
         return top_layer_stitch_groups
-
-    def get_split_points(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0,
-                         random_phase=False, min_split_length=None, seed=None, row_num=0, from_end=False):
-        if self.split_method == "default":
-            return self._get_split_points_default(
-                a, b, a_short, b_short, length, count, length_sigma,
-                random_phase, min_split_length, seed)
-        elif self.split_method == "simple":
-            return self._get_split_points_simple(a, b, a_short, b_short, length, row_num, from_end), None
-        elif self.split_method == "staggered":
-            return self._get_split_points_staggered(a, b, a_short, b_short, length, row_num, from_end), None
-
-    def _get_split_points_default(self, a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False, min_split_length=None,
-                                  seed=None):
-        if not length:
-            return ([], None)
-        if min_split_length is None:
-            min_split_length = length
-        distance = a.distance(b)
-        if distance <= min_split_length:
-            return ([], 1)
-        if random_phase:
-            points = running_stitch.split_segment_random_phase(a_short, b_short, length, length_sigma, seed)
-            # avoid hard stitches: do not insert split stitches near the end points
-            if len(points) > 1 and points[0].distance(shgeo.Point(a)) <= self.min_stitch_len:
-                del points[0]
-            if len(points) > 1 and points[-1].distance(shgeo.Point(b)) <= self.min_stitch_len:
-                del points[-1]
-            return (points, None)
-        elif count is not None:
-            points = running_stitch.split_segment_even_n(a, b, count, length_sigma, seed)
-            return (points, count)
-        else:
-            points = running_stitch.split_segment_even_dist(a, b, length, length_sigma, seed)
-            return (points, len(points) + 1)
-
-    def _get_split_points_simple(self, a, b, a_short, b_short, length, row_num=0, from_end=False):
-        return self._get_split_points_staggered(a, b, a_short, b_short, length, row_num, from_end, 1)
-
-    def _get_split_points_staggered(self, a, b, a_short, b_short, length, row_num=0, from_end=False, _staggers=None):
-        if not length or a.distance(b) <= length:
-            return []
-
-        if _staggers is None:
-            # This is only here to allow _get_split_points_simple to override
-            _staggers = self.split_staggers
-
-        if from_end:
-            a, b = b, a
-            a_short, b_short = b_short, a_short
-
-        line = shgeo.LineString((a, b))
-        a_short_projection = line.project(shgeo.Point(a_short))
-        b_short_projection = line.project(shgeo.Point(b_short))
-        split_points = running_stitch.split_segment_stagger_phase(
-            a, b, length,
-            _staggers, row_num,
-            min_val=a_short_projection,
-            max_val=b_short_projection)
-
-        if from_end:
-            split_points = list(reversed(split_points))
-
-        return split_points
 
     def inset_short_stitches_sawtooth(self, pairs):
         max_stitch_length = None if self.random_split_phase else self.max_stitch_length_px

--- a/lib/elements/satin_column/satin_column.py
+++ b/lib/elements/satin_column/satin_column.py
@@ -24,11 +24,13 @@ from ...utils import AnyPointType, Point, cache, cut_multiple, offset_points
 from ...utils.param import ParamOption
 from ..element import PIXELS_PER_MM, EmbroideryElement, param
 from ..utils.stroke_to_satin import convert_path_to_satin, set_first_node
+from .compensation import get_compensated_line_string_rails
+from .rails import cut_rails, get_rails_to_reverse, plot_points_on_rails as _plot_points_on_rails
+from .stitches import do_top_layer_stitch_group
+from .underlay import do_underlay_stitch_groups
 from .validation_models import (NotStitchableError, ClosedPathWarning, DanglingRungWarning, NoRungWarning,
                                 TooManyIntersectionsWarning, StrokeSatinWarning, NarrowSatinWarning,
                                 TwoRungsWarning, UnequalPointsWarning)
-from .rails import cut_rails, get_rails_to_reverse, plot_points_on_rails as _plot_points_on_rails
-from .stitches import do_top_layer_stitch_group
 
 ListOfPairs = list[tuple[Point, Point]]
 
@@ -554,46 +556,6 @@ class SatinColumn(EmbroideryElement):
         else:
             return rails
 
-    def _get_compensated_line_string_rails(self, start: float, end: float) -> List[shgeo.Point | shgeo.LineString]:
-        """Apply push compensation on rails"""
-        return [self._apply_push_comp(rail, start, end) for rail in self.line_string_rails]
-
-    def _apply_push_comp_on_point_list(self, rail, start, end):
-        line = shgeo.LineString(rail)
-        return [Point(*point) for point in self._apply_push_comp(line, start, end).coords]
-
-    def _apply_push_comp(self, linestring: shgeo.LineString, start: float, end: float) -> shgeo.Point | shgeo.LineString:
-        if start < 0:
-            linestring = self._extend_line(linestring, start)
-            start = 0
-        if end < 0:
-            linestring = self._extend_line(linestring, end, True)
-            end = 0
-        if not start and not end:
-            return linestring
-        if end == 0:
-            end = 0.00000001
-        if start + end >= linestring.length - 0.5:
-            return linestring
-        return substring(linestring, start, -end)
-
-    def _extend_line(self, linestring: shgeo.LineString, value: float, at_end: bool = False) -> shgeo.LineString:
-        '''Extends either the first or the last segment of the given line by given value.
-        '''
-        if at_end:
-            linestring = linestring.reverse()
-        coords = list(linestring.coords)
-        start_segment = shgeo.LineString([coords[0], coords[1]])
-        line_length = start_segment.length
-        target_length = line_length - value
-        scale_factor = target_length / line_length
-        extended_segment = shaffinity.scale(start_segment, xfact=scale_factor, yfact=scale_factor, origin=shgeo.Point(coords[1]))
-        first = list(extended_segment.coords)[0]
-        extended_line = shgeo.LineString([first] + coords)
-        if at_end:
-            extended_line = extended_line.reverse()
-        return extended_line
-
     @property
     @cache
     def line_string_rails(self) -> tuple[shgeo.LineString, ...]:
@@ -747,7 +709,7 @@ class SatinColumn(EmbroideryElement):
     @cache
     def flattened_sections(self):
         """Flatten the rails, cut with the rungs, and return the sections in pairs."""
-        rails = self._get_compensated_line_string_rails(*self.push_compensation_px)
+        rails = get_compensated_line_string_rails(self.line_string_rails, *self.push_compensation_px)
         rungs = list(self.line_string_rungs)
         cut_points = [[], []]
         for rung in rungs:
@@ -1044,11 +1006,11 @@ class SatinColumn(EmbroideryElement):
     @property
     @cache
     def offset_center_line(self):
-        stitches = self._get_center_line_stitches(self.running_stitch_position)
+        stitches = self.get_center_line_stitches(self.running_stitch_position)
         linestring = shgeo.LineString(stitches)
         return linestring
 
-    def _get_center_line_stitches(self, position, stitch_length=None):
+    def get_center_line_stitches(self, position, stitch_length=None):
         inset_prop = -np.array([position, 100-position]) / 100
         if stitch_length is None:
             stitch_length = self.running_stitch_length
@@ -1102,202 +1064,8 @@ class SatinColumn(EmbroideryElement):
             stitches=[Point(*end_point)]
         )
 
-    def _do_underlay_stitch_groups(self, top_layer: StitchGroup, end_point: Optional[Point]) -> list[StitchGroup]:
-        stitch_groups: list[StitchGroup] = []
-        if self.center_walk_underlay:
-            stitch_groups.extend(self.do_center_walk(end_point))
 
-        if self.contour_underlay:
-            stitch_groups.extend(self.do_contour_underlay(top_layer, end_point))
-
-        if self.zigzag_underlay:
-            stitch_groups.extend(self.do_zigzag_underlay(end_point))
-
-        return stitch_groups
-
-    def _to_stitch_group(self, linestring: LineString, tags, reverse: bool = False) -> StitchGroup:
-        if reverse:
-            linestring = linestring.reverse()
-        return StitchGroup(
-                color=self.color,
-                tags=tags,
-                stitches=[Stitch.from_coordinates(coord) for coord in linestring.coords]
-            )
-
-    def do_contour_underlay(self, top_layer: StitchGroup, end_point: Optional[Point]):
-        # "contour walk" underlay: do stitches up one side and down the
-        # other. if the two sides are far away, adding a running stitch to travel
-        # in between avoids a long jump or a trim.
-
-        pairs = self.plot_points_on_rails(
-            self.contour_underlay_stitch_tolerance,
-            -self.contour_underlay_inset_px, -self.contour_underlay_inset_percent/100)
-
-        if not pairs:
-            return []
-
-        first_side = running_stitch.even_running_stitch(
-            [points[0] for points in pairs],
-            [self.contour_underlay_stitch_length],
-            self.contour_underlay_stitch_tolerance
-        )
-        second_side = running_stitch.even_running_stitch(
-            [points[1] for points in pairs],
-            [self.contour_underlay_stitch_length],
-            self.contour_underlay_stitch_tolerance
-        )
-        if self.satin_method == 'zigzag':
-            top_layer_stitches = top_layer.stitches
-
-            end_first = self._get_peak(top_layer_stitches[::-1], "peak_a")
-            first_side = self._shorten_contour_underlay_for_zigzag(first_side, end_first, True)
-
-            end_second = self._get_peak(top_layer_stitches[::-1], "peak_b")
-            second_side = self._shorten_contour_underlay_for_zigzag(second_side, end_second, True)
-
-            start_second = self._get_peak(top_layer_stitches, "peak_b")
-            second_side = self._shorten_contour_underlay_for_zigzag(second_side, start_second)
-
-        first_side = self._apply_push_comp_on_point_list(first_side, self.contour_underlay_inset_px[0], self.contour_underlay_inset_px[1])
-        second_side = self._apply_push_comp_on_point_list(second_side, self.contour_underlay_inset_px[0], self.contour_underlay_inset_px[1])
-
-        if self.center_walk_is_odd():
-            first_side.reverse()
-        else:
-            second_side.reverse()
-
-        if end_point:
-            stitch_groups: list[StitchGroup] = []
-            tags = ("satin_column", "satin_column_underlay", "satin_contour_underlay")
-            first_linestring = shgeo.LineString(first_side)
-            first_start, first_end = self._split_linestring_at_end_point(first_linestring, end_point)
-            second_linestring = shgeo.LineString(second_side)
-            second_end, second_start = self._split_linestring_at_end_point(second_linestring, end_point)
-            stitch_groups.append(self._to_stitch_group(first_start, tags))
-            stitch_groups.append(self._to_stitch_group(second_end, tags))
-            stitch_groups.append(self._to_stitch_group(second_start, tags))
-            stitch_groups.append(self._to_stitch_group(first_end, tags))
-            return stitch_groups
-
-        stitch_group = StitchGroup(
-            color=self.color,
-            tags=("satin_column", "satin_column_underlay", "satin_contour_underlay"),
-            stitches=first_side
-        )
-
-        self.add_running_stitches(first_side[-1], second_side[0], stitch_group)
-        stitch_group.stitches += second_side
-        return [stitch_group]
-
-    def _get_peak(self, stitches: list[Stitch], peak: str) -> Stitch | None:
-        for stitch in stitches:
-            if peak in stitch.tags:
-                return stitch
-        return None
-
-    def _shorten_contour_underlay_for_zigzag(self, rail, end_point, cut_end=False) -> list[Point]:
-        if not end_point:
-            return rail
-        line = shgeo.LineString(rail)
-        if cut_end:
-            end = line.reverse().project(shgeo.Point(end_point))
-            shortened_line = self._apply_push_comp(line, 0, end)
-        else:
-            start = line.project(shgeo.Point(end_point))
-            shortened_line = self._apply_push_comp(line, start, 0)
-        return [Point(*point) for point in shortened_line.coords]
-
-    def do_center_walk(self, end_point: Optional[Point]):
-        # Center walk underlay is just a running stitch down and back on the
-        # center line between the bezier curves.
-        repeats = self.center_walk_underlay_repeats
-
-        stitch_groups = []
-        stitches = self._get_center_line_stitches(self.center_walk_underlay_position, self.center_walk_underlay_stitch_length)
-        if end_point:
-            tags = ("satin_column", "satin_column_underlay", "satin_center_walk")
-            stitches = shgeo.LineString(stitches)
-            start, end = self._split_linestring_at_end_point(stitches, end_point)
-            if self.center_walk_is_odd():
-                end, start = start, end
-            stitch_groups.append(self._to_stitch_group(start, tags))
-            stitch_groups.append(self._to_stitch_group(end, tags, True))
-        else:
-            stitch_group = StitchGroup(
-                color=self.color,
-                tags=("satin_column", "satin_column_underlay", "satin_center_walk"),
-                stitches=stitches
-            )
-            stitch_groups.append(stitch_group)
-
-        for stitch_group in stitch_groups:
-            stitch_count = len(stitch_group.stitches)
-            for i in range(repeats - 1):
-                if i % 2 == 0:
-                    stitch_group.stitches += reversed(stitch_group.stitches[:stitch_count])
-                else:
-                    stitch_group.stitches += stitch_group.stitches[:stitch_count]
-        return stitch_groups
-
-    def do_zigzag_underlay(self, end_point: Optional[Point]):
-        # zigzag underlay, usually done at a much lower density than the
-        # satin itself.  It looks like this:
-        #
-        # \/\/\/\/\/\/\/\/\/\/|
-        # /\/\/\/\/\/\/\/\/\/\|
-        #
-        # In combination with the "contour walk" underlay, this is the
-        # "German underlay" described here:
-        #   http://www.mrxstitch.com/underlay-what-lies-beneath-machine-embroidery/
-
-        stitch_groups = []
-
-        pairs = self.plot_points_on_rails(
-            self.zigzag_underlay_spacing / 2.0,
-            -self.zigzag_underlay_inset_px,
-            -self.zigzag_underlay_inset_percent/100)
-
-        if self.center_walk_is_odd():
-            pairs = list(reversed(pairs))
-
-        # This organizes the points in each side in the order that they'll be visited.
-        # take a point, from each side in turn, then go backed over the other points
-        point_groups = [p[i % 2] for i, p in enumerate(pairs)], list(reversed([p[i % 2] for i, p in enumerate(pairs, 1)]))
-
-        start_groups = []
-        end_groups = []
-        for points in point_groups:
-            if not end_point:
-                stitch_groups.append(self._generate_zigzag_stitch_group(points))
-                continue
-            if len(points) == 1:
-                points.append(points[0])
-            zigzag_line = shgeo.LineString(points)
-            start, end = self._split_linestring_at_end_point(zigzag_line, end_point)
-            start_groups.append(self._generate_zigzag_stitch_group([Stitch(*point) for point in start.coords]))
-            end_groups.append(self._generate_zigzag_stitch_group([Stitch(*point) for point in end.coords]))
-        if start_groups:
-            stitch_groups.append(self.connect_and_add(start_groups[0], end_groups[-1]))
-            stitch_groups.append(self.connect_and_add(start_groups[-1], end_groups[0]))
-
-        return stitch_groups
-
-    def _generate_zigzag_stitch_group(self, points):
-        max_len = self.zigzag_underlay_max_stitch_length
-        last_point = None
-        stitch_group = StitchGroup(color=self.color)
-        for point in points:
-            if last_point and max_len:
-                if last_point.distance(point) > max_len:
-                    split_points = running_stitch.split_segment_even_dist(last_point, point, max_len)
-                    for p in split_points:
-                        stitch_group.add_stitch(p, ("split_stitch",))
-            last_point = point
-            stitch_group.add_stitch(point, ("edge",))
-        stitch_group.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
-        return stitch_group
-
-    def _split_linestring_at_end_point(self, linestring: LineString, end_point: Point):
+    def split_linestring_at_end_point(self, linestring: LineString, end_point: Point):
         split_line = set_precision(shgeo.LineString(self.find_cut_points(end_point)), 0.00001)
         if not split_line:
             start = shgeo.Point(linestring.coords[0])
@@ -1313,7 +1081,7 @@ class SatinColumn(EmbroideryElement):
 
     def _split_top_layer(self, stitch_group: StitchGroup, end_point: Point):
         top_layer = shgeo.LineString(stitch_group.stitches)
-        start, end = self._split_linestring_at_end_point(top_layer, end_point)
+        start, end = self.split_linestring_at_end_point(top_layer, end_point)
         stitch_group2 = deepcopy(stitch_group)
         stitch_group2.stitches = [Stitch(*point) for point in end.reverse().coords]
         stitch_group1 = stitch_group
@@ -1454,7 +1222,7 @@ class SatinColumn(EmbroideryElement):
         top_layer_group = do_top_layer_stitch_group(self)
 
         # underlays
-        stitch_groups.extend(self._do_underlay_stitch_groups(top_layer_group, end_point))
+        stitch_groups.extend(do_underlay_stitch_groups(self, top_layer_group, end_point))
 
         if end_point:
             stitch_groups.extend(self._split_top_layer(top_layer_group, end_point))

--- a/lib/elements/satin_column/split_points.py
+++ b/lib/elements/satin_column/split_points.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
 def get_split_points(satin: 'SatinColumn', a, b, a_short, b_short, length, count=None, length_sigma=0.0,
                      random_phase=False, min_split_length=None, seed=None, row_num=0, from_end=False):
     if satin.split_method == "default":
-        return _get_split_points_default(satin,
+        return _get_split_points_default(
+            satin,
             a, b, a_short, b_short, length, count, length_sigma,
             random_phase, min_split_length, seed)
     elif satin.split_method == "simple":

--- a/lib/elements/satin_column/split_points.py
+++ b/lib/elements/satin_column/split_points.py
@@ -1,0 +1,78 @@
+from typing import TYPE_CHECKING
+
+from shapely import geometry as shgeo
+
+from ...stitches import running_stitch
+
+if TYPE_CHECKING:
+    from .satin_column import SatinColumn
+
+
+def get_split_points(satin: 'SatinColumn', a, b, a_short, b_short, length, count=None, length_sigma=0.0,
+                     random_phase=False, min_split_length=None, seed=None, row_num=0, from_end=False):
+    if satin.split_method == "default":
+        return _get_split_points_default(satin,
+            a, b, a_short, b_short, length, count, length_sigma,
+            random_phase, min_split_length, seed)
+    elif satin.split_method == "simple":
+        return _get_split_points_simple(satin, a, b, a_short, b_short, length, row_num, from_end), None
+    elif satin.split_method == "staggered":
+        return _get_split_points_staggered(satin, a, b, a_short, b_short, length, row_num, from_end), None
+    raise ValueError(f'Unexpected split method: {satin.split_method}')
+
+
+def _get_split_points_default(satin: 'SatinColumn', a, b, a_short, b_short, length, count=None, length_sigma=0.0, random_phase=False,
+                              min_split_length=None,
+                              seed=None):
+    if not length:
+        return ([], None)
+    if min_split_length is None:
+        min_split_length = length
+    distance = a.distance(b)
+    if distance <= min_split_length:
+        return ([], 1)
+    if random_phase:
+        points = running_stitch.split_segment_random_phase(a_short, b_short, length, length_sigma, seed)
+        # avoid hard stitches: do not insert split stitches near the end points
+        if len(points) > 1 and points[0].distance(shgeo.Point(a)) <= satin.min_stitch_len:
+            del points[0]
+        if len(points) > 1 and points[-1].distance(shgeo.Point(b)) <= satin.min_stitch_len:
+            del points[-1]
+        return (points, None)
+    elif count is not None:
+        points = running_stitch.split_segment_even_n(a, b, count, length_sigma, seed)
+        return (points, count)
+    else:
+        points = running_stitch.split_segment_even_dist(a, b, length, length_sigma, seed)
+        return (points, len(points) + 1)
+
+
+def _get_split_points_simple(satin: 'SatinColumn', a, b, a_short, b_short, length, row_num=0, from_end=False):
+    return _get_split_points_staggered(satin, a, b, a_short, b_short, length, row_num, from_end, 1)
+
+
+def _get_split_points_staggered(satin: 'SatinColumn', a, b, a_short, b_short, length, row_num=0, from_end=False, staggers=None):
+    if not length or a.distance(b) <= length:
+        return []
+
+    if staggers is None:
+        # This is only here to allow _get_split_points_simple to override
+        staggers = satin.split_staggers
+
+    if from_end:
+        a, b = b, a
+        a_short, b_short = b_short, a_short
+
+    line = shgeo.LineString((a, b))
+    a_short_projection = line.project(shgeo.Point(a_short))
+    b_short_projection = line.project(shgeo.Point(b_short))
+    split_points = running_stitch.split_segment_stagger_phase(
+        a, b, length,
+        staggers, row_num,
+        min_val=a_short_projection,
+        max_val=b_short_projection)
+
+    if from_end:
+        split_points = list(reversed(split_points))
+
+    return split_points

--- a/lib/elements/satin_column/stitches.py
+++ b/lib/elements/satin_column/stitches.py
@@ -1,6 +1,7 @@
 import itertools
 from typing import TYPE_CHECKING
 
+from .split_points import get_split_points
 from .rails import plot_points_on_rails
 from ...stitch_plan import StitchGroup
 from ...utils import prng
@@ -37,14 +38,14 @@ def _do_e_stitch(satin: 'SatinColumn'):
     # a point from the first and second rail respectively
     for i, (left, right), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
         check_stop_flag()
-        split_points, _ = satin.get_split_points(
-            left, right, a_short, b_short, max_stitch_length,
+        split_points, _ = get_split_points(
+            satin, left, right, a_short, b_short, max_stitch_length,
             None, length_sigma, random_phase, min_split_length,
             prng.join_args(seed, 'satin-split', 2 * i + 1), 2 * i + 1)
 
         # zigzag spacing is wider than stitch length, subdivide
         if last_point is not None and max_stitch_length is not None and satin.zigzag_spacing > max_stitch_length:
-            points, _ = satin.get_split_points(last_point, left, last_point, left, max_stitch_length)
+            points, _ = get_split_points(satin, last_point, left, last_point, left, max_stitch_length)
             stitch_group.add_stitches(points)
 
         stitch_group.add_stitch(a_short, ("edge", "left"))
@@ -88,8 +89,8 @@ def _do_s_stitch(satin: 'SatinColumn'):
     for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
         check_stop_flag()
         points = [a_short]
-        split_points, _ = satin.get_split_points(
-            a, b, a_short, b_short, max_stitch_length,
+        split_points, _ = get_split_points(
+            satin, a, b, a_short, b_short, max_stitch_length,
             None, length_sigma, random_phase, min_split_length,
             prng.join_args(seed, 'satin-split', i), i)
         points.extend(split_points)
@@ -100,7 +101,7 @@ def _do_s_stitch(satin: 'SatinColumn'):
 
         # zigzag spacing is wider than stitch length, subdivide
         if last_point is not None and max_stitch_length is not None and satin.zigzag_spacing > max_stitch_length:
-            initial_points, _ = satin.get_split_points(last_point, points[0], last_point, points[0], max_stitch_length)
+            initial_points, _ = get_split_points(satin, last_point, points[0], last_point, points[0], max_stitch_length)
 
         stitch_group.add_stitches(points)
         last_point = points[-1]
@@ -145,16 +146,16 @@ def _do_zigzag(satin: 'SatinColumn'):
     last_point_short = None
     for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
         if last_point:
-            split_points, _ = satin.get_split_points(
-                last_point, a, last_point_short, a_short, max_stitch_length, None,
+            split_points, _ = get_split_points(
+                satin, last_point, a, last_point_short, a_short, max_stitch_length, None,
                 length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i,
                 from_end=True)
             stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
 
         stitch_group.add_stitch(a_short, ("satin_column", "peak_a", "peak_stitch"))
 
-        split_points, _ = satin.get_split_points(
-            a, b, a_short, b_short, max_stitch_length, None,
+        split_points, _ = get_split_points(
+            satin, a, b, a_short, b_short, max_stitch_length, None,
             length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1),
             row_num=2 * i + 1)
         stitch_group.add_stitches(split_points, ("satin_column", "zigzag_split_stitch"))
@@ -203,16 +204,16 @@ def _do_satin(satin: 'SatinColumn'):
     last_count = None
     for i, (a, b), (a_short, b_short) in zip(itertools.count(0), pairs, short_pairs):
         if last_point is not None:
-            split_points, _ = satin.get_split_points(
-                last_point, a, last_short_point, a_short, max_stitch_length, last_count,
+            split_points, _ = get_split_points(
+                satin, last_point, a, last_short_point, a_short, max_stitch_length, last_count,
                 length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i), row_num=2 * i, from_end=True)
             stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
 
         stitch_group.add_stitch(a_short)
         stitch_group.stitches[-1].add_tags(("satin_column", "satin_column_edge"))
 
-        split_points, last_count = satin.get_split_points(
-            a, b, a_short, b_short, max_stitch_length, None,
+        split_points, last_count = get_split_points(
+            satin, a, b, a_short, b_short, max_stitch_length, None,
             length_sigma, random_phase, min_split_length, prng.join_args(seed, 'satin-split', 2 * i + 1), row_num=2 * i + 1)
         stitch_group.add_stitches(split_points, ("satin_column", "satin_split_stitch"))
 

--- a/lib/elements/satin_column/underlay.py
+++ b/lib/elements/satin_column/underlay.py
@@ -12,6 +12,7 @@ from .rails import plot_points_on_rails
 if TYPE_CHECKING:
     from .satin_column import SatinColumn
 
+
 def do_underlay_stitch_groups(satin: 'SatinColumn', top_layer: StitchGroup, end_point: Optional[Point]) -> list[StitchGroup]:
     stitch_groups: list[StitchGroup] = []
     if satin.center_walk_underlay:
@@ -25,6 +26,7 @@ def do_underlay_stitch_groups(satin: 'SatinColumn', top_layer: StitchGroup, end_
 
     return stitch_groups
 
+
 def _to_stitch_group(satin: 'SatinColumn', linestring: LineString, tags, reverse: bool = False) -> StitchGroup:
     if reverse:
         linestring = linestring.reverse()
@@ -33,6 +35,7 @@ def _to_stitch_group(satin: 'SatinColumn', linestring: LineString, tags, reverse
         tags=tags,
         stitches=[Stitch.from_coordinates(coord) for coord in linestring.coords]
     )
+
 
 def _do_contour_underlay(satin: 'SatinColumn', top_layer: StitchGroup, end_point: Optional[Point]):
     # "contour walk" underlay: do stitches up one side and down the
@@ -100,11 +103,13 @@ def _do_contour_underlay(satin: 'SatinColumn', top_layer: StitchGroup, end_point
     stitch_group.stitches += second_side
     return [stitch_group]
 
+
 def _get_peak(stitches: list[Stitch], peak: str) -> Stitch | None:
     for stitch in stitches:
         if peak in stitch.tags:
             return stitch
     return None
+
 
 def _shorten_contour_underlay_for_zigzag(rail: list[Point], end_point: Optional[Point], cut_end: bool = False) -> list[Point]:
     if not end_point:
@@ -117,6 +122,7 @@ def _shorten_contour_underlay_for_zigzag(rail: list[Point], end_point: Optional[
         start = line.project(shgeo.Point(end_point))
         shortened_line = apply_push_comp(line, start, 0)
     return [Point(*point) for point in shortened_line.coords]
+
 
 def _do_center_walk(satin: 'SatinColumn', end_point: Optional[Point]):
     # Center walk underlay is just a running stitch down and back on the
@@ -150,6 +156,7 @@ def _do_center_walk(satin: 'SatinColumn', end_point: Optional[Point]):
                 stitch_group.stitches += stitch_group.stitches[:stitch_count]
     return stitch_groups
 
+
 def _do_zigzag_underlay(satin: 'SatinColumn', end_point: Optional[Point]):
     # zigzag underlay, usually done at a much lower density than the
     # satin itself.  It looks like this:
@@ -174,7 +181,10 @@ def _do_zigzag_underlay(satin: 'SatinColumn', end_point: Optional[Point]):
 
     # This organizes the points in each side in the order that they'll be visited.
     # take a point, from each side in turn, then go backed over the other points
-    point_groups: tuple[list[Point], list[Point]] = [pair[i % 2] for i, pair in enumerate(pairs)], list(reversed([pair[i % 2] for i, pair in enumerate(pairs, 1)]))
+    point_groups: tuple[list[Point], list[Point]] = (
+        [pair[i % 2] for i, pair in enumerate(pairs)],
+        list(reversed([pair[i % 2] for i, pair in enumerate(pairs, 1)])),
+    )
 
     start_groups = []
     end_groups = []
@@ -193,6 +203,7 @@ def _do_zigzag_underlay(satin: 'SatinColumn', end_point: Optional[Point]):
         stitch_groups.append(satin.connect_and_add(start_groups[-1], end_groups[0]))
 
     return stitch_groups
+
 
 def _generate_zigzag_stitch_group(satin: 'SatinColumn', points: list[Point] | list[Stitch]) -> StitchGroup:
     max_len = satin.zigzag_underlay_max_stitch_length

--- a/lib/elements/satin_column/underlay.py
+++ b/lib/elements/satin_column/underlay.py
@@ -1,0 +1,210 @@
+from typing import Optional, TYPE_CHECKING
+
+from shapely import LineString
+from shapely import geometry as shgeo
+
+from ...stitch_plan import Stitch, StitchGroup
+from ...stitches import running_stitch
+from ...utils import Point
+from .compensation import apply_push_comp, apply_push_comp_on_point_list
+from .rails import plot_points_on_rails
+
+if TYPE_CHECKING:
+    from .satin_column import SatinColumn
+
+def do_underlay_stitch_groups(satin: 'SatinColumn', top_layer: StitchGroup, end_point: Optional[Point]) -> list[StitchGroup]:
+    stitch_groups: list[StitchGroup] = []
+    if satin.center_walk_underlay:
+        stitch_groups.extend(_do_center_walk(satin, end_point))
+
+    if satin.contour_underlay:
+        stitch_groups.extend(_do_contour_underlay(satin, top_layer, end_point))
+
+    if satin.zigzag_underlay:
+        stitch_groups.extend(_do_zigzag_underlay(satin, end_point))
+
+    return stitch_groups
+
+def _to_stitch_group(satin: 'SatinColumn', linestring: LineString, tags, reverse: bool = False) -> StitchGroup:
+    if reverse:
+        linestring = linestring.reverse()
+    return StitchGroup(
+        color=satin.color,
+        tags=tags,
+        stitches=[Stitch.from_coordinates(coord) for coord in linestring.coords]
+    )
+
+def _do_contour_underlay(satin: 'SatinColumn', top_layer: StitchGroup, end_point: Optional[Point]):
+    # "contour walk" underlay: do stitches up one side and down the
+    # other. if the two sides are far away, adding a running stitch to travel
+    # in between avoids a long jump or a trim.
+
+    pairs = plot_points_on_rails(
+        satin,
+        satin.contour_underlay_stitch_tolerance,
+        -satin.contour_underlay_inset_px, -satin.contour_underlay_inset_percent/100)
+
+    if not pairs:
+        return []
+
+    first_side = running_stitch.even_running_stitch(
+        [points[0] for points in pairs],
+        [satin.contour_underlay_stitch_length],
+        satin.contour_underlay_stitch_tolerance
+    )
+    second_side = running_stitch.even_running_stitch(
+        [points[1] for points in pairs],
+        [satin.contour_underlay_stitch_length],
+        satin.contour_underlay_stitch_tolerance
+    )
+    if satin.satin_method == 'zigzag':
+        top_layer_stitches = top_layer.stitches
+
+        end_first = _get_peak(top_layer_stitches[::-1], "peak_a")
+        first_side = _shorten_contour_underlay_for_zigzag(first_side, end_first, cut_end=True)
+
+        end_second = _get_peak(top_layer_stitches[::-1], "peak_b")
+        second_side = _shorten_contour_underlay_for_zigzag(second_side, end_second, cut_end=True)
+
+        start_second = _get_peak(top_layer_stitches, "peak_b")
+        second_side = _shorten_contour_underlay_for_zigzag(second_side, start_second)
+
+    first_side = apply_push_comp_on_point_list(first_side, satin.contour_underlay_inset_px[0], satin.contour_underlay_inset_px[1])
+    second_side = apply_push_comp_on_point_list(second_side, satin.contour_underlay_inset_px[0], satin.contour_underlay_inset_px[1])
+
+    if satin.center_walk_is_odd():
+        first_side.reverse()
+    else:
+        second_side.reverse()
+
+    if end_point:
+        stitch_groups: list[StitchGroup] = []
+        tags = ("satin_column", "satin_column_underlay", "satin_contour_underlay")
+        first_linestring = shgeo.LineString(first_side)
+        first_start, first_end = satin.split_linestring_at_end_point(first_linestring, end_point)
+        second_linestring = shgeo.LineString(second_side)
+        second_end, second_start = satin.split_linestring_at_end_point(second_linestring, end_point)
+        stitch_groups.append(_to_stitch_group(satin, first_start, tags))
+        stitch_groups.append(_to_stitch_group(satin, second_end, tags))
+        stitch_groups.append(_to_stitch_group(satin, second_start, tags))
+        stitch_groups.append(_to_stitch_group(satin, first_end, tags))
+        return stitch_groups
+
+    stitch_group = StitchGroup(
+        color=satin.color,
+        tags=("satin_column", "satin_column_underlay", "satin_contour_underlay"),
+        stitches=first_side
+    )
+
+    satin.add_running_stitches(first_side[-1], second_side[0], stitch_group)
+    stitch_group.stitches += second_side
+    return [stitch_group]
+
+def _get_peak(stitches: list[Stitch], peak: str) -> Stitch | None:
+    for stitch in stitches:
+        if peak in stitch.tags:
+            return stitch
+    return None
+
+def _shorten_contour_underlay_for_zigzag(rail: list[Point], end_point: Optional[Point], cut_end: bool = False) -> list[Point]:
+    if not end_point:
+        return rail
+    line = shgeo.LineString(rail)
+    if cut_end:
+        end = line.reverse().project(shgeo.Point(end_point))
+        shortened_line = apply_push_comp(line, 0, end)
+    else:
+        start = line.project(shgeo.Point(end_point))
+        shortened_line = apply_push_comp(line, start, 0)
+    return [Point(*point) for point in shortened_line.coords]
+
+def _do_center_walk(satin: 'SatinColumn', end_point: Optional[Point]):
+    # Center walk underlay is just a running stitch down and back on the
+    # center line between the bezier curves.
+    repeats = satin.center_walk_underlay_repeats
+
+    stitch_groups = []
+    stitches = satin.get_center_line_stitches(satin.center_walk_underlay_position, satin.center_walk_underlay_stitch_length)
+    if end_point:
+        tags = ("satin_column", "satin_column_underlay", "satin_center_walk")
+        stitches = shgeo.LineString(stitches)
+        start, end = satin.split_linestring_at_end_point(stitches, end_point)
+        if satin.center_walk_is_odd():
+            end, start = start, end
+        stitch_groups.append(_to_stitch_group(satin, start, tags))
+        stitch_groups.append(_to_stitch_group(satin, end, tags, True))
+    else:
+        stitch_group = StitchGroup(
+            color=satin.color,
+            tags=("satin_column", "satin_column_underlay", "satin_center_walk"),
+            stitches=stitches
+        )
+        stitch_groups.append(stitch_group)
+
+    for stitch_group in stitch_groups:
+        stitch_count = len(stitch_group.stitches)
+        for i in range(repeats - 1):
+            if i % 2 == 0:
+                stitch_group.stitches += reversed(stitch_group.stitches[:stitch_count])
+            else:
+                stitch_group.stitches += stitch_group.stitches[:stitch_count]
+    return stitch_groups
+
+def _do_zigzag_underlay(satin: 'SatinColumn', end_point: Optional[Point]):
+    # zigzag underlay, usually done at a much lower density than the
+    # satin itself.  It looks like this:
+    #
+    # \/\/\/\/\/\/\/\/\/\/|
+    # /\/\/\/\/\/\/\/\/\/\|
+    #
+    # In combination with the "contour walk" underlay, this is the
+    # "German underlay" described here:
+    #   http://www.mrxstitch.com/underlay-what-lies-beneath-machine-embroidery/
+
+    stitch_groups = []
+
+    pairs = plot_points_on_rails(
+        satin,
+        satin.zigzag_underlay_spacing / 2.0,
+        -satin.zigzag_underlay_inset_px,
+        -satin.zigzag_underlay_inset_percent/100)
+
+    if satin.center_walk_is_odd():
+        pairs = list(reversed(pairs))
+
+    # This organizes the points in each side in the order that they'll be visited.
+    # take a point, from each side in turn, then go backed over the other points
+    point_groups: tuple[list[Point], list[Point]] = [pair[i % 2] for i, pair in enumerate(pairs)], list(reversed([pair[i % 2] for i, pair in enumerate(pairs, 1)]))
+
+    start_groups = []
+    end_groups = []
+    for points in point_groups:
+        if not end_point:
+            stitch_groups.append(_generate_zigzag_stitch_group(satin, points))
+            continue
+        if len(points) == 1:
+            points.append(points[0])
+        zigzag_line = shgeo.LineString(points)
+        start, end = satin.split_linestring_at_end_point(zigzag_line, end_point)
+        start_groups.append(_generate_zigzag_stitch_group(satin, [Stitch(*point) for point in start.coords]))
+        end_groups.append(_generate_zigzag_stitch_group(satin, [Stitch(*point) for point in end.coords]))
+    if start_groups:
+        stitch_groups.append(satin.connect_and_add(start_groups[0], end_groups[-1]))
+        stitch_groups.append(satin.connect_and_add(start_groups[-1], end_groups[0]))
+
+    return stitch_groups
+
+def _generate_zigzag_stitch_group(satin: 'SatinColumn', points: list[Point] | list[Stitch]) -> StitchGroup:
+    max_len = satin.zigzag_underlay_max_stitch_length
+    last_point = None
+    stitch_group = StitchGroup(color=satin.color)
+    for point in points:
+        if last_point and max_len:
+            if last_point.distance(point) > max_len:
+                split_points = running_stitch.split_segment_even_dist(last_point, point, max_len)
+                for p in split_points:
+                    stitch_group.add_stitch(p, ("split_stitch",))
+        last_point = point
+        stitch_group.add_stitch(point, ("edge",))
+    stitch_group.add_tags(("satin_column", "satin_column_underlay", "satin_zigzag_underlay"))
+    return stitch_group


### PR DESCRIPTION
Continuation of #4544.

This split is for underlay generation, finding split points, and push compensation. 

As before, I have changed none of the underlying logic and it was essentially just a cut + paste. I added typings to stuff where I noticed them missing and it wouldn't blow up the PR - one clear benefit of this responsibility split is that it's now much easier to trace callers and so typings are much easier to add.

Had to make two methods public for now to avoid blowing up the scope of this PR. This is not the last responsibility split PR, but at this point SatinColumn is _mostly_ params and cached properties which is cool. The next PR might also include some typings on running_stitch.py which is currently blocking finishing some typings in this PR.